### PR TITLE
Fix redirection of cancel button for create page

### DIFF
--- a/src/components/Forms/GroupForm/index.tsx
+++ b/src/components/Forms/GroupForm/index.tsx
@@ -70,11 +70,7 @@ function GroupForm({ title }: Props) {
   const onCancelClick = useCallback(
 
     () => {
-      if(editMode) {
-        history.push(`../detail/${params.id}`);
-      }else{
-        history.push(".");
-      }
+      history.goBack()
     },
     [history, params.id, editMode]
 

--- a/src/components/Forms/RaProfileForm/index.tsx
+++ b/src/components/Forms/RaProfileForm/index.tsx
@@ -112,9 +112,9 @@ export default function RaProfileForm({
    const onCancelClick = useCallback(
 
       () => {
-         history.push(`../detail/${params.id}`);
+         history.goBack()
       },
-      [history, params.id]
+      [history,]
 
    );
 


### PR DESCRIPTION
When the cancel button is clicked on RA Profile Page, it is not properly navigated to the previous page in history