### PR TITLE
Fix datetime object mapping when generating attribute form

### DIFF
--- a/src/components/Attributes/AttributeEditor/Attribute/index.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/index.tsx
@@ -101,9 +101,9 @@ export function Attribute({
       "FLOAT": "number",         // possibly list
       "STRING": "text",          // possibly list
       "TEXT": "textarea",        // not list
-      "DATE": "text",            // not list
-      "TIME": "text",            // not list
-      "DATETIME": "text",        // not list
+      "DATE": "date",            // not list
+      "TIME": "time",            // not list
+      "DATETIME": "datetime-local",        // not list
       "FILE": "file",            // not list
       "SECRET": "password",      // not list
       "CREDENTIAL": "text",      // list only

--- a/src/components/Forms/DiscoveryForm/index.tsx
+++ b/src/components/Forms/DiscoveryForm/index.tsx
@@ -220,29 +220,29 @@ export default function DiscoveryForm({
 
                      </Field>
 
-                     <Field name="storeKind" validate={validateRequired()}>
+                     {discoveryProvider ? <Field name="storeKind" validate={validateRequired()}>
 
-                        {({ input, meta }) => (
+                           {({ input, meta }) => (
 
-                           <FormGroup>
+                              <FormGroup>
 
-                              <Label for="storeKind">Kind</Label>
+                                 <Label for="storeKind">Kind</Label>
 
-                              <Select
-                                 {...input}
-                                 maxMenuHeight={140}
-                                 menuPlacement="auto"
-                                 options={optionsForKinds}
-                                 placeholder="Select Kind"
-                                 onChange={(event) => { onKindChange(event); input.onChange(event); }}
-                                 styles={{ control: (provided) => (meta.touched && meta.invalid ? { ...provided, border: "solid 1px red", "&:hover": { border: "solid 1px red" } } : { ...provided }) }}
-                              />
+                                 <Select
+                                    {...input}
+                                    maxMenuHeight={140}
+                                    menuPlacement="auto"
+                                    options={optionsForKinds}
+                                    placeholder="Select Kind"
+                                    onChange={(event) => { onKindChange(event); input.onChange(event); }}
+                                    styles={{ control: (provided) => (meta.touched && meta.invalid ? { ...provided, border: "solid 1px red", "&:hover": { border: "solid 1px red" } } : { ...provided }) }}
+                                 />
 
-                              <div className="invalid-feedback" style={meta.touched && meta.invalid ? { display: "block" } : {}}>Required Field</div>
+                                 <div className="invalid-feedback" style={meta.touched && meta.invalid ? { display: "block" } : {}}>Required Field</div>
 
-                           </FormGroup>
-                        )}
-                     </Field>
+                              </FormGroup>
+                           )}
+                        </Field> : undefined}
 
 
 

--- a/src/components/Forms/GroupForm/index.tsx
+++ b/src/components/Forms/GroupForm/index.tsx
@@ -72,7 +72,7 @@ function GroupForm({ title }: Props) {
     () => {
       history.goBack()
     },
-    [history, params.id, editMode]
+    [history]
 
   );
 

--- a/src/utils/attributes.ts
+++ b/src/utils/attributes.ts
@@ -10,22 +10,6 @@ export const attributeFieldNameTransform: { [name: string]: string } = {
 };
 
 
-export const attributeFieldTypeTransform: { [name: string]: string } = {
-   BOOLEAN: "checkbox",
-   INTEGER: "number",
-   FLOAT: "number",
-   STRING: "string",
-   TEXT: "textarea",
-   DATE: "date",
-   TIME: "time",
-   DATETIME: "datetime",
-   FILE: "file",
-   SECRET: "password",
-   CREDENTIAL: "select",
-   JSON: "select"
-};
-
-
 export function collectFormAttributes(id: string, descriptors: AttributeDescriptorModel[] | undefined, values: Record<string, any>): AttributeModel[] {
 
    if (!descriptors || !values[`__attributes__${id}__`]) return [];
@@ -112,7 +96,7 @@ export function collectFormAttributes(id: string, descriptors: AttributeDescript
          case "DATE":
 
             if (descriptor.list || descriptor.multiSelect) continue;
-            content = { value: attributes[attribute] };
+            content = { value: new Date(attributes[attribute]).toISOString() };
 
             break;
 
@@ -128,7 +112,7 @@ export function collectFormAttributes(id: string, descriptors: AttributeDescript
          case "DATETIME":
 
             if (descriptor.list || descriptor.multiSelect) continue;
-            content = { value: attributes[attribute] };
+            content = { value: new Date(attributes[attribute]).toISOString()};
 
             break;
 


### PR DESCRIPTION
This PR Contains the following changes
1. When the attribute form is generated, the mapping of the type of input is changed from text to time, date and datetime-local
2. Remove unused attribute mapping in the util
3. Update attribute collection for datetime object to send the datetime string
4. Remove compilation warning for unused dependency in the useEffect