### PR TITLE
Make cancel button available at all time in Issue certificate page

### DIFF
--- a/src/components/Forms/CertificateIssueForm/index.tsx
+++ b/src/components/Forms/CertificateIssueForm/index.tsx
@@ -373,11 +373,10 @@ function CertificateForm({
                         <Button
                            color="default"
                            onClick={onCancel}
-                           disabled={submitting || !valid}
+                           disabled={submitting}
                         >
                            Cancel
                         </Button>
-
 
                      </ButtonGroup>
 


### PR DESCRIPTION
When a new certificate is to be issued, the cancel button is not available untill all the fields are entered.

This fix makes the button enabled except when isSubmitting flag is true