### PR TITLE
Sanitize HTML to prevent potential XSS

### DIFF
--- a/src/components/Alerts/Alerts.spec.tsx
+++ b/src/components/Alerts/Alerts.spec.tsx
@@ -1,6 +1,5 @@
 import { test, expect } from 'playwright/ct-test';
-import AlertsWithStore from 'components/Alerts/AlertsWithStore';
-import { createAlertMessage } from 'components/Alerts/AlertsWithStore';
+import AlertsWithStore, { createAlertMessage } from 'components/Alerts/AlertsWithStore';
 import { alertsSlice } from 'ducks/alert-slice';
 
 test.describe('Alerts', () => {

--- a/src/components/Alerts/Alerts.spec.tsx
+++ b/src/components/Alerts/Alerts.spec.tsx
@@ -1,12 +1,13 @@
-import { test, expect } from '../../../playwright/ct-test';
-import AlertsWithStore, { createAlertMessage } from 'components/Alerts/AlertsWithStore';
+import { test, expect } from 'playwright/ct-test';
+import AlertsWithStore from 'components/Alerts/AlertsWithStore';
+import { createAlertMessage } from 'components/Alerts/AlertsWithStore';
 import { alertsSlice } from 'ducks/alert-slice';
 
 test.describe('Alerts', () => {
     test('should render alerts container when no messages', async ({ mount, page }) => {
         await mount(<AlertsWithStore />);
 
-        await expect(page.getByTestId('alerts-container')).toBeVisible();
+        await expect(page.getByTestId('alerts-container')).toBeAttached();
         await expect(page.getByRole('alert')).toHaveCount(0);
     });
 
@@ -26,6 +27,28 @@ test.describe('Alerts', () => {
 
         await expect(page.getByTestId('alert-2')).toBeVisible();
         await expect(page.getByTestId('alert-2')).toContainText('Something failed');
+    });
+
+    test('should strip onerror attribute from img XSS payload', async ({ mount, page }) => {
+        const xssMessage = '<img src=x onerror="window.__xss=true" alt="">Safe text';
+        const messages = [createAlertMessage({ id: 4, message: xssMessage, color: 'danger' })];
+        await mount(<AlertsWithStore preloadedState={{ [alertsSlice.name]: { messages, msgId: 5 } }} />);
+
+        const alert = page.getByTestId('alert-4');
+        await expect(alert).toBeVisible();
+        await expect(alert).toContainText('Safe text');
+        await expect(alert.locator('img')).not.toHaveAttribute('onerror');
+    });
+
+    test('should remove script tags from XSS payload', async ({ mount, page }) => {
+        const xssMessage = '<script>window.__xss=true</script>Visible text';
+        const messages = [createAlertMessage({ id: 5, message: xssMessage, color: 'danger' })];
+        await mount(<AlertsWithStore preloadedState={{ [alertsSlice.name]: { messages, msgId: 6 } }} />);
+
+        const alert = page.getByTestId('alert-5');
+        await expect(alert).toBeVisible();
+        await expect(alert).toContainText('Visible text');
+        await expect(alert.locator('script')).toHaveCount(0);
     });
 
     test('should remove alert when dismiss button clicked', async ({ mount, page }) => {

--- a/src/components/Alerts/Alerts.spec.tsx
+++ b/src/components/Alerts/Alerts.spec.tsx
@@ -1,6 +1,11 @@
 import { test, expect } from 'playwright/ct-test';
-import AlertsWithStore, { createAlertMessage } from 'components/Alerts/AlertsWithStore';
+import AlertsWithStore from 'components/Alerts/AlertsWithStore';
 import { alertsSlice } from 'ducks/alert-slice';
+import type { MessageModel } from 'types/alerts';
+
+function createAlertMessage(overrides: Partial<MessageModel> = {}): MessageModel {
+    return { id: 0, message: 'Test message', time: Date.now(), color: 'success', ...overrides };
+}
 
 test.describe('Alerts', () => {
     test('should render alerts container when no messages', async ({ mount, page }) => {

--- a/src/components/Alerts/AlertsWithStore.tsx
+++ b/src/components/Alerts/AlertsWithStore.tsx
@@ -2,11 +2,6 @@ import { Provider } from 'react-redux';
 import { createMockStore } from 'utils/test-helpers';
 import Alerts from './index';
 import { alertsSlice } from 'ducks/alert-slice';
-import type { MessageModel } from 'types/alerts';
-
-export function createAlertMessage(overrides: Partial<MessageModel> = {}): MessageModel {
-    return { id: 0, message: 'Test message', time: Date.now(), color: 'success', ...overrides };
-}
 
 export type AlertsWithStoreProps = {
     preloadedState?: Parameters<typeof createMockStore>[0];

--- a/src/components/Alerts/AlertsWithStore.tsx
+++ b/src/components/Alerts/AlertsWithStore.tsx
@@ -4,6 +4,10 @@ import Alerts from './index';
 import { alertsSlice } from 'ducks/alert-slice';
 import type { MessageModel } from 'types/alerts';
 
+export function createAlertMessage(overrides: Partial<MessageModel> = {}): MessageModel {
+    return { id: 0, message: 'Test message', time: Date.now(), color: 'success', ...overrides };
+}
+
 export type AlertsWithStoreProps = {
     preloadedState?: Parameters<typeof createMockStore>[0];
 };
@@ -24,13 +28,3 @@ function AlertsWithStore({ preloadedState }: AlertsWithStoreProps) {
     );
 }
 export default AlertsWithStore;
-
-export function createAlertMessage(overrides: Partial<MessageModel> = {}): MessageModel {
-    return {
-        id: 0,
-        message: 'Test message',
-        time: Date.now(),
-        color: 'success',
-        ...overrides,
-    };
-}

--- a/src/components/Alerts/index.tsx
+++ b/src/components/Alerts/index.tsx
@@ -27,13 +27,13 @@ function Alerts() {
                     })}
                     role="alert"
                     tabIndex={-1}
-                    aria-labelledby="hs-soft-color-warning-label"
+                    aria-labelledby={`hs-soft-color-warning-label-${alert.id}`}
                 >
                     <div className="absolute top-5 left-4 translate-y-[2px]">
                         {alert.color === 'success' ? <CircleCheck size={14} /> : <CircleX size={14} />}
                     </div>
                     <div
-                        id="hs-soft-color-warning-label"
+                        id={`hs-soft-color-warning-label-${alert.id}`}
                         className="text-lg font-semibold overflow-hidden"
                         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(alert.message) }}
                     />

--- a/src/components/Alerts/index.tsx
+++ b/src/components/Alerts/index.tsx
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import cn from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -34,7 +35,7 @@ function Alerts() {
                     <div
                         id="hs-soft-color-warning-label"
                         className="text-lg font-semibold overflow-hidden"
-                        dangerouslySetInnerHTML={{ __html: alert.message }}
+                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(alert.message) }}
                     />
                     <button
                         className="absolute top-2 right-2 translate-y-[3px] text-[var(--status-success-color)]"

--- a/src/ducks/test-reducers.ts
+++ b/src/ducks/test-reducers.ts
@@ -445,6 +445,29 @@ function tablePaginationTestReducer(
     return state;
 }
 
+export type AlertsTestState = {
+    messages: Array<{ id: number; message: string; time: number; color: 'success' | 'danger' | 'info'; isHiding?: boolean }>;
+    msgId: number;
+};
+
+const alertsTestInitialState: AlertsTestState = {
+    messages: [],
+    msgId: 0,
+};
+
+function alertsTestReducer(state: AlertsTestState = alertsTestInitialState, action: UnknownAction): AlertsTestState {
+    if (action.type === 'alerts/dismiss' && typeof action.payload === 'number') {
+        return { ...state, messages: state.messages.filter((m) => m.id !== action.payload) };
+    }
+    if (action.type === 'alerts/hide' && typeof action.payload === 'number') {
+        return {
+            ...state,
+            messages: state.messages.map((m) => (m.id === action.payload ? { ...m, isHiding: true } : m)),
+        };
+    }
+    return state;
+}
+
 export const testReducers = combineReducers({
     userInterface: userInterfaceTestReducer,
     enums: enumsTestReducer,
@@ -457,6 +480,7 @@ export const testReducers = combineReducers({
     secrets: secretsTestReducer,
     vaultProfiles: vaultProfilesTestReducer,
     tablePagination: tablePaginationTestReducer,
+    alerts: alertsTestReducer,
 });
 
 export const testInitialState = {
@@ -471,4 +495,5 @@ export const testInitialState = {
     secrets: secretsTestInitialState,
     vaultProfiles: vaultProfilesTestInitialState,
     tablePagination: tablePaginationTestInitialState,
+    alerts: alertsTestInitialState,
 };


### PR DESCRIPTION
Fixes #1434 

**Changes:**

  - Added DOMPurify.sanitize() around alert.message in src/components/Alerts/index.tsx
  - Fixed Alerts.spec.tsx — converted broken Playwright CT test to use AlertsWithStore wrapper (store must be created in-browser, not in Node.js). Added 2 new XSS sanitization tests (img onerror, script tags).
  - Added createAlertMessage helper to AlertsWithStore.tsx.
  - Added alerts reducer to test-reducers.ts so the mock store supports alerts state with dismiss/hide actions.

**Not changed:**

JsonViewer — its dangerouslySetInnerHTML usage is safe: all user-provided content passes through escapeHtml() before being composed into the HTML string, and the
only injected tags use hardcoded color values.