### PR TITLE
Fix blank page and double-login when app is opened without trailing slash

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
             // Canonicalise to trailing-slash form before any relative resource is fetched,
             // so ./config.js and ./assets/* resolve against the correct base regardless of
             // whether the user entered the app with or without a trailing slash.
-            // Skip when the last path segment has an extension so direct hits to
-            // /index.html or similar file URLs aren't redirected to a 404.
-            if (!location.pathname.endsWith('/') && !/\.[^/]+$/.test(location.pathname)) {
+            // Skip when the last path segment looks like a file (contains a dot) so
+            // direct hits to /index.html or similar file URLs aren't redirected to a 404.
+            if (!location.pathname.endsWith('/') && !location.pathname.split('/').pop().includes('.')) {
                 location.replace(location.pathname + '/' + location.search + location.hash);
             }
         </script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
     <head>
+        <script>
+            // Canonicalise to trailing-slash form before any relative resource is fetched,
+            // so ./config.js and ./assets/* resolve against the correct base regardless of
+            // whether the user entered the app with or without a trailing slash.
+            if (!location.pathname.endsWith('/')) {
+                location.replace(location.pathname + '/' + location.search + location.hash);
+            }
+        </script>
         <script type="text/javascript" src="./config.js"></script>
         <meta charset="utf-8" />
         <link rel="icon" href="./ot-sign-color.svg" />

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
             // Canonicalise to trailing-slash form before any relative resource is fetched,
             // so ./config.js and ./assets/* resolve against the correct base regardless of
             // whether the user entered the app with or without a trailing slash.
-            if (!location.pathname.endsWith('/')) {
+            // Skip when the last path segment has an extension so direct hits to
+            // /index.html or similar file URLs aren't redirected to a 404.
+            if (!location.pathname.endsWith('/') && !/\.[^/]+$/.test(location.pathname)) {
                 location.replace(location.pathname + '/' + location.search + location.hash);
             }
         </script>

--- a/src/components/AppRedirect.tsx
+++ b/src/components/AppRedirect.tsx
@@ -22,7 +22,7 @@ export default function AppRedirect() {
         dispatch(actions.clearUnauthorized());
 
         const url = window.location.toString().substring(window.location.origin.length);
-        if (!url.includes('/#/login?redirect=')) {
+        if (!url.includes('#/login?redirect=')) {
             const redirect = encodeURIComponent(url);
             navigate(`/login?redirect=${redirect}`);
         }


### PR DESCRIPTION
## Summary
- Canonicalise the document URL to the trailing-slash form via a small inline script at the very top of `<head>` in `index.html`. This ensures relative asset URLs (`./config.js`, `./assets/*`) resolve against the correct base regardless of whether the user enters the app at `/<mount>` or `/<mount>/`. The script is path-agnostic — nothing about the mount path is hardcoded.
- Loosen the recursion guard in `AppRedirect.tsx` to match `#/login?redirect=` rather than `/#/login?redirect=`, so it triggers correctly whether or not a slash precedes the hash. Without this, entering the app at the bare-path form caused the post-OAuth flow to re-wrap the login URL into itself, surfacing as a double login.

## Why
Behind a reverse proxy that mounts the SPA at a path prefix (e.g. Kong forwarding `/administrator` to the FE container), Vite's relative-URL build output (`base: './'`) produces asset references that the browser resolves against the document's "directory". The bare-path form (`/administrator`) makes the browser treat the document as a *file*, sending all relative asset requests to `/`, which 404s. The trailing-slash form (`/administrator/`) makes it treat the document as a *directory*, and assets resolve correctly. Canonicalising at the very start of HTML parsing — before any relative `<script>` is fetched — gives consistent behaviour for both URL forms with no proxy-side customisation required.

The recursion-guard fix is defense-in-depth for any directly-crafted URL of the form `/<mount>#/login?redirect=...` that might still bypass the canonicalisation script (e.g. a bookmark, a manually edited URL).

## Test plan
- [ ] Hard-refresh `https://<host>/administrator` (no trailing slash) in an incognito window — URL bar snaps to `/administrator/`, app loads, single login completes successfully.
- [ ] Hard-refresh `https://<host>/administrator/` (with trailing slash) — app loads, single login completes successfully.
- [ ] Verify no nested `?redirect=...?redirect=...` chains in the URL bar after login in either flow.
- [ ] Verify no console errors in either flow.
- [ ] Bookmark a deep route `/administrator/#/dashboard` and confirm normal navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)