### PR TITLE
Drop empty resource picker stubs from cleared selections

### DIFF
--- a/src/utils/attributes/attributes.spec.ts
+++ b/src/utils/attributes/attributes.spec.ts
@@ -627,6 +627,127 @@ describe('attributes utils', () => {
             const result = collectFormAttributes('id1', descriptors, values);
             expect(result).toEqual([]);
         });
+
+        test('drops empty resource picker stubs so cleared selection serialises as empty content', () => {
+            // Regression: when the operator clears a previously-selected resource (e.g. removes
+            // the CA certificate on an authority), the picker leaves a stub entry in the form
+            // value array. Serialising it produces { data: "" } which fails polymorphic
+            // deserialisation on the backend with "missing type id property 'resource'".
+            // The stub must be dropped so the request carries content: [] instead.
+            const descriptors = [
+                {
+                    type: AttributeType.Data,
+                    name: 'caCertificates',
+                    uuid: 'u-resource',
+                    contentType: AttributeContentType.Resource,
+                    content: [],
+                    properties: { required: false, label: 'CA', readOnly: false, visible: true, list: true },
+                },
+            ] as any[];
+            // Every shape the picker is observed to leave behind when the operator clears a
+            // selection — primitives, react-select-style { value }, and content-style { data }.
+            const stubVariants: Array<unknown[]> = [
+                [''],
+                [null],
+                [undefined],
+                ['', null, undefined],
+                [{ data: '' }],
+                [{ data: null }],
+                [{ data: undefined }],
+                [{ data: '', reference: '' }],
+                [{ value: '' }],
+                [{ value: null }],
+                [{ value: undefined }],
+                [{ value: { data: '' } }],
+            ];
+            for (const value of stubVariants) {
+                const values = { __attributes__id1__: { caCertificates: value } };
+                const result = collectFormAttributes('id1', descriptors, values);
+                expect(result).toHaveLength(1);
+                expect(result[0].name).toBe('caCertificates');
+                expect(result[0].content).toEqual([]);
+            }
+        });
+
+        test('drops single-pick resource attribute when its form value is an empty stub', () => {
+            // Single-pick resource picker (multiSelect=false) holds a single object as the form
+            // value. When the operator clears the selection the value is { data: '' } (or null).
+            // The backend rejects { data: '' } with "missing type id property 'resource'" on
+            // polymorphic deserialisation, so the entire attribute must be dropped from the
+            // request rather than serialised as content: [{ data: '' }].
+            const descriptors = [
+                {
+                    type: AttributeType.Data,
+                    name: 'caCertificates',
+                    uuid: 'u-resource',
+                    contentType: AttributeContentType.Resource,
+                    content: [],
+                    properties: { required: false, label: 'CA', readOnly: false, visible: true, list: true, multiSelect: false },
+                },
+            ] as any[];
+            const stubVariants: unknown[] = [
+                '',
+                null,
+                undefined,
+                { data: '' },
+                { data: null },
+                { data: '', reference: '' },
+                { value: '' },
+                { value: null },
+            ];
+            for (const value of stubVariants) {
+                const values = { __attributes__id1__: { caCertificates: value } };
+                const result = collectFormAttributes('id1', descriptors, values);
+                expect(result).toEqual([]);
+            }
+        });
+
+        test('keeps valid resource picker selections', () => {
+            const descriptors = [
+                {
+                    type: AttributeType.Data,
+                    name: 'caCertificates',
+                    uuid: 'u-resource',
+                    contentType: AttributeContentType.Resource,
+                    content: [],
+                    properties: { required: false, label: 'CA', readOnly: false, visible: true, list: true },
+                },
+            ] as any[];
+            const selectedResource = {
+                data: { uuid: 'cert-uuid-1', name: 'AAA Certificate Services', resource: 'certificates' },
+                reference: 'AAA Certificate Services',
+            };
+            const values = { __attributes__id1__: { caCertificates: [selectedResource] } };
+
+            const result = collectFormAttributes('id1', descriptors, values);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].content).toHaveLength(1);
+            expect(result[0].content[0].data).toMatchObject({ uuid: 'cert-uuid-1', resource: 'certificates' });
+        });
+
+        test('does not drop empty entries for non-resource list attributes', () => {
+            // Defensive: the stub-filter is scoped to RESOURCE so primitive list types preserve
+            // whatever the form sends today (no behaviour change for STRING / TEXT / etc.).
+            const descriptors = [
+                {
+                    type: AttributeType.Data,
+                    name: 'tags',
+                    uuid: 'u-string-list',
+                    contentType: AttributeContentType.String,
+                    content: [],
+                    properties: { required: false, label: 'Tags', readOnly: false, visible: true, list: true },
+                },
+            ] as any[];
+            const values = { __attributes__id1__: { tags: ['', 'real-tag'] } };
+
+            const result = collectFormAttributes('id1', descriptors, values);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].content).toHaveLength(2);
+            expect(result[0].content[0].data).toBe('');
+            expect(result[0].content[1].data).toBe('real-tag');
+        });
     });
 
     describe('mapAttributeContentToOptionValue', () => {

--- a/src/utils/attributes/attributes.tsx
+++ b/src/utils/attributes/attributes.tsx
@@ -253,6 +253,25 @@ export function collectFormAttributes(
                 content = getAttributeFormValue(descriptor.contentType, descriptor.content, attributes[attribute]);
             }
 
+            if (descriptor.contentType === AttributeContentType.Resource) {
+                // The resource picker leaves a stub entry in the form value when the operator
+                // clears a previously-selected resource. Whatever shape the picker produces —
+                // primitive empty, object with empty data, single-pick scalar, react-select
+                // null — it normalises to a content shape whose `data` is empty, which fails
+                // polymorphic deserialisation on the backend with "missing type id property
+                // 'resource'". Strip the stub so a cleared selection serialises as either
+                // content: [] (list / multiSelect) or no attribute at all (single-pick).
+                if (Array.isArray(content)) {
+                    content = content.filter(
+                        (item: { data: unknown }) => item.data !== null && item.data !== undefined && item.data !== '',
+                    );
+                } else if (content?.data === null || content?.data === undefined || content?.data === '') {
+                    content = undefined;
+                }
+            }
+
+            if (content === undefined) continue;
+
             if (content.data !== undefined || Array.isArray(content)) {
                 const contentArray = Array.isArray(content) ? content : [content];
                 const existing = existingAttributes?.find((a) => a.name === attributeName);


### PR DESCRIPTION
## Summary

When the operator clears a previously-selected resource on a RESOURCE-typed attribute (single-pick or multi-pick), the picker leaves a stub in the form value. `collectFormAttributes` then serialises the stub into a content shape carrying `{ data: \"\" }`, and the backend rejects the request with HTTP 400 \`JSON parse error: Could not resolve subtype of [...] ResourceObjectContentData: missing type id property 'resource' (for POJO property 'data')\` — the polymorphic deserialisation requires an object with the `resource` discriminator and an empty string can never satisfy that.

Observed stub shapes:

| Picker mode | Form value when cleared |
|---|---|
| single-pick (`multiSelect=false`) | `''`, `null`, `{ data: '' }`, `{ data: null }`, `{ value: null }` |
| multi-pick / list | `[]` is fine, but the picker keeps `[{ data: '' }]` / `[null]` etc. |

## What changed

`src/utils/attributes/attributes.tsx` — after mapping form values to content for a RESOURCE-typed attribute, normalise the result:

- **Array content:** drop entries whose `data` is `null` / `undefined` / `''` so a cleared multi-pick serialises as `content: []`.
- **Single content:** if the value is `null` / has empty `data`, drop the whole attribute from the request.

The fix is gated by `descriptor.contentType === AttributeContentType.Resource`. Non-resource list / scalar attributes (STRING, INTEGER, BOOLEAN, FILE, ...) preserve their existing behaviour exactly.

## Test plan

- [x] Regression tests in `attributes.spec.ts` cover every observed stub shape (multi-pick array variants, single-pick primitive empties, single-pick object stubs, react-select-style `{ value }` stubs).
- [x] Valid resource picker selections survive unchanged.
- [x] Non-resource list types are not affected.
- [x] Full `vitest run`: 144 files / 2179 tests pass.
- [x] Verified live against a deployed core: edit authority → remove cert → save now succeeds (PUT carries no malformed content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)