### PR TITLE
Sonar qube part five

### DIFF
--- a/src/components/Alerts/AlertsWithStore.tsx
+++ b/src/components/Alerts/AlertsWithStore.tsx
@@ -3,9 +3,9 @@ import { createMockStore } from 'utils/test-helpers';
 import Alerts from './index';
 import { alertsSlice } from 'ducks/alert-slice';
 
-export type AlertsWithStoreProps = Readonly<{
+export type AlertsWithStoreProps = {
     preloadedState?: Parameters<typeof createMockStore>[0];
-}>;
+};
 
 const defaultPreloadedState: Parameters<typeof createMockStore>[0] = {
     [alertsSlice.name]: {
@@ -14,7 +14,7 @@ const defaultPreloadedState: Parameters<typeof createMockStore>[0] = {
     },
 };
 
-function AlertsWithStore({ preloadedState }: AlertsWithStoreProps) {
+function AlertsWithStore({ preloadedState }: Readonly<AlertsWithStoreProps>) {
     const store = createMockStore(preloadedState ?? defaultPreloadedState);
     return (
         <Provider store={store}>

--- a/src/components/Attributes/AttributeDescriptorViewer/index.tsx
+++ b/src/components/Attributes/AttributeDescriptorViewer/index.tsx
@@ -7,11 +7,11 @@ import { useSelector } from 'react-redux';
 import { type AttributeDescriptorModel, isDataAttributeModel, isInfoAttributeModel } from 'types/attributes';
 import { AttributeConstraintType, PlatformEnum } from 'types/openapi';
 
-export type Props = Readonly<{
+export type Props = {
     attributeDescriptors: AttributeDescriptorModel[];
-}>;
+};
 
-export default function AttributeDescriptorViewer({ attributeDescriptors }: Props) {
+export default function AttributeDescriptorViewer({ attributeDescriptors }: Readonly<Props>) {
     const attributeTypeEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.AttributeType));
     const attributeContentTypeEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.AttributeContentType));
     const headers: TableHeader[] = useMemo(

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldFile.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldFile.tsx
@@ -6,14 +6,14 @@ import cn from 'classnames';
 import type { CustomAttributeModel, DataAttributeModel } from 'types/attributes';
 import { buildAttributeValidators } from './attributeHelpers';
 
-type AttributeFieldFileProps = Readonly<{
+type AttributeFieldFileProps = {
     name: string;
     descriptor: DataAttributeModel | CustomAttributeModel;
     deleteButton?: React.ReactNode;
     onFileDrop: (e: React.DragEvent<HTMLInputElement>) => void;
     onFileDragOver: (e: React.DragEvent<HTMLInputElement>) => void;
     onFileChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
-}>;
+};
 
 export function AttributeFieldFile({
     name,
@@ -22,7 +22,7 @@ export function AttributeFieldFile({
     onFileDrop,
     onFileDragOver,
     onFileChanged,
-}: AttributeFieldFileProps): React.ReactNode {
+}: Readonly<AttributeFieldFileProps>): React.ReactNode {
     const { control } = useFormContext<Record<string, any>>();
 
     return (

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldFileTestWrapper.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldFileTestWrapper.tsx
@@ -3,14 +3,14 @@ import * as ReactHookForm from 'react-hook-form';
 import { AttributeFieldFile } from './AttributeFieldFile';
 import type { DataAttributeModel } from 'types/attributes';
 
-export type AttributeFieldFileTestWrapperProps = Readonly<{
+export type AttributeFieldFileTestWrapperProps = {
     name: string;
     descriptor: DataAttributeModel;
     deleteButton?: React.ReactNode;
     onFileDrop: (e: React.DragEvent<HTMLInputElement>) => void;
     onFileDragOver: (e: React.DragEvent<HTMLInputElement>) => void;
     onFileChanged: (e: React.ChangeEvent<HTMLInputElement>) => void;
-}>;
+};
 
 export function AttributeFieldFileTestWrapper({
     name,
@@ -19,7 +19,7 @@ export function AttributeFieldFileTestWrapper({
     onFileDrop,
     onFileDragOver,
     onFileChanged,
-}: AttributeFieldFileTestWrapperProps) {
+}: Readonly<AttributeFieldFileTestWrapperProps>) {
     const methods = ReactHookForm.useForm({
         defaultValues: {
             [name]: { content: '', fileName: '', mimeType: '' },

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.tsx
@@ -29,12 +29,22 @@ interface FieldStateError {
     error?: { message?: string } | string;
 }
 
-type AttributeFieldInputProps = Readonly<{
+type AttributeFieldInputProps = {
     name: string;
     descriptor: DataAttributeModel | CustomAttributeModel;
     busy: boolean;
     deleteButton?: React.ReactNode;
-}>;
+};
+
+type StandardInputControlProps = {
+    name: string;
+    descriptor: DataAttributeModel | CustomAttributeModel;
+    busy: boolean;
+    deleteButton?: React.ReactNode;
+    field: FieldStateLike;
+    fieldState: FieldStateError;
+    submitCount: number;
+};
 
 function StandardInputControl({
     name,
@@ -44,15 +54,7 @@ function StandardInputControl({
     field,
     fieldState,
     submitCount,
-}: Readonly<{
-    name: string;
-    descriptor: DataAttributeModel | CustomAttributeModel;
-    busy: boolean;
-    deleteButton?: React.ReactNode;
-    field: FieldStateLike;
-    fieldState: FieldStateError;
-    submitCount: number;
-}>): React.ReactNode {
+}: Readonly<StandardInputControlProps>): React.ReactNode {
     const transformed = transformInputValueForDescriptor(field.value, descriptor);
     const validationVisible = fieldState.isTouched || submitCount > 0;
     const inputClassName = cn(
@@ -141,7 +143,7 @@ function StandardInputControl({
     );
 }
 
-export function AttributeFieldInput({ name, descriptor, busy, deleteButton }: AttributeFieldInputProps): React.ReactNode {
+export function AttributeFieldInput({ name, descriptor, busy, deleteButton }: Readonly<AttributeFieldInputProps>): React.ReactNode {
     const { setValue, control, watch } = useFormContext<Record<string, any>>();
     const { submitCount } = useFormState({ control });
     const formValues = watch();

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInputTestWrapper.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInputTestWrapper.tsx
@@ -3,13 +3,13 @@ import * as ReactHookForm from 'react-hook-form';
 import { AttributeFieldInput } from './AttributeFieldInput';
 import type { DataAttributeModel } from 'types/attributes';
 
-export type AttributeFieldInputTestWrapperProps = Readonly<{
+export type AttributeFieldInputTestWrapperProps = {
     name: string;
     descriptor: DataAttributeModel;
     busy?: boolean;
     deleteButton?: React.ReactNode;
     defaultValues?: Record<string, unknown>;
-}>;
+};
 
 export function AttributeFieldInputTestWrapper({
     name,
@@ -17,7 +17,7 @@ export function AttributeFieldInputTestWrapper({
     busy = false,
     deleteButton,
     defaultValues = {},
-}: AttributeFieldInputTestWrapperProps) {
+}: Readonly<AttributeFieldInputTestWrapperProps>) {
     const methods = ReactHookForm.useForm({
         defaultValues: {
             [name]: undefined,

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldSelect.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldSelect.tsx
@@ -9,7 +9,7 @@ import { Plus } from 'lucide-react';
 import type { CustomAttributeModel, DataAttributeModel } from 'types/attributes';
 import { getSelectValueFromField, buildAttributeValidators, parseListValueByContentType } from './attributeHelpers';
 
-type AttributeFieldSelectProps = Readonly<{
+type AttributeFieldSelectProps = {
     name: string;
     descriptor: DataAttributeModel | CustomAttributeModel;
     options?: { label: string; value: any }[];
@@ -18,7 +18,7 @@ type AttributeFieldSelectProps = Readonly<{
     addNewAttributeValue?: { label: string; value: string; disabled?: boolean };
     onSelectChangeMulti: (fieldOnChange: (v: any) => void) => (newValue: any) => void;
     onSelectChangeSingle: (fieldOnChange: (v: any) => void) => (newValue: any) => void;
-}>;
+};
 
 export function AttributeFieldSelect({
     name,
@@ -29,7 +29,7 @@ export function AttributeFieldSelect({
     addNewAttributeValue,
     onSelectChangeMulti,
     onSelectChangeSingle,
-}: AttributeFieldSelectProps): React.ReactNode {
+}: Readonly<AttributeFieldSelectProps>): React.ReactNode {
     const { control } = useFormContext<Record<string, any>>();
     const [showAddCustom, setShowAddCustom] = useState(false);
     const [singleSelectKey, setSingleSelectKey] = useState(0);

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldSelectTestWrapper.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldSelectTestWrapper.tsx
@@ -3,7 +3,7 @@ import * as ReactHookForm from 'react-hook-form';
 import { AttributeFieldSelect } from './AttributeFieldSelect';
 import type { DataAttributeModel } from 'types/attributes';
 
-export type AttributeFieldSelectTestWrapperProps = Readonly<{
+export type AttributeFieldSelectTestWrapperProps = {
     name: string;
     descriptor: DataAttributeModel;
     options?: { label: string; value: string | number }[];
@@ -11,7 +11,7 @@ export type AttributeFieldSelectTestWrapperProps = Readonly<{
     deleteButton?: React.ReactNode;
     addNewAttributeValue?: { label: string; value: string; disabled?: boolean };
     defaultValues?: Record<string, unknown>;
-}>;
+};
 
 export function AttributeFieldSelectTestWrapper({
     name,
@@ -21,7 +21,7 @@ export function AttributeFieldSelectTestWrapper({
     deleteButton,
     addNewAttributeValue,
     defaultValues = {},
-}: AttributeFieldSelectTestWrapperProps) {
+}: Readonly<AttributeFieldSelectTestWrapperProps>) {
     const methods = ReactHookForm.useForm({
         defaultValues: {
             [name]: undefined,

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeInfo.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeInfo.tsx
@@ -3,13 +3,13 @@ import parse from 'html-react-parser';
 import { marked } from 'marked';
 import type React from 'react';
 
-type AttributeInfoProps = Readonly<{
+type AttributeInfoProps = {
     name: string;
     label: string;
     content: string | React.ReactNode;
-}>;
+};
 
-export function AttributeInfo({ name, label, content }: AttributeInfoProps): React.ReactNode {
+export function AttributeInfo({ name, label, content }: Readonly<AttributeInfoProps>): React.ReactNode {
     const renderedContent = typeof content === 'string' ? parse(DOMPurify.sanitize(marked.parse(content) as string)) : content;
 
     return (

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeTestWrapper.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeTestWrapper.tsx
@@ -6,7 +6,7 @@ import GlobalModal from 'components/GlobalModal';
 import { Attribute } from './index';
 import type { DataAttributeModel, InfoAttributeModel, CustomAttributeModel } from 'types/attributes';
 
-export type AttributeTestWrapperProps = Readonly<{
+export type AttributeTestWrapperProps = {
     name: string;
     descriptor: DataAttributeModel | InfoAttributeModel | CustomAttributeModel | undefined;
     options?: { label: string; value: any }[];
@@ -16,7 +16,7 @@ export type AttributeTestWrapperProps = Readonly<{
     defaultValues?: Record<string, unknown>;
     /** Preloaded store state (e.g. userInterface.initiateAttributeCallback) */
     preloadedState?: Record<string, unknown>;
-}>;
+};
 
 export function AttributeTestWrapper({
     name,
@@ -27,7 +27,7 @@ export function AttributeTestWrapper({
     deleteButton,
     defaultValues = {},
     preloadedState,
-}: AttributeTestWrapperProps) {
+}: Readonly<AttributeTestWrapperProps>) {
     const store = createMockStore(preloadedState);
     const methods = ReactHookForm.useForm({
         defaultValues: {

--- a/src/components/Attributes/AttributeEditor/Attribute/index.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/index.tsx
@@ -18,14 +18,14 @@ import { AttributeFieldSelect } from './AttributeFieldSelect';
 import { AttributeFieldFile } from './AttributeFieldFile';
 import { AttributeFieldInput } from './AttributeFieldInput';
 
-type Props = Readonly<{
+type Props = {
     name: string;
     descriptor: DataAttributeModel | InfoAttributeModel | CustomAttributeModel | undefined;
     options?: { label: string; value: any }[];
     busy?: boolean;
     userInteractedRef?: React.RefObject<boolean>;
     deleteButton?: React.ReactNode;
-}>;
+};
 
 export function Attribute({
     name,
@@ -34,7 +34,7 @@ export function Attribute({
     busy = false,
     userInteractedRef: userInteractionRef,
     deleteButton,
-}: Props): React.ReactNode {
+}: Readonly<Props>): React.ReactNode {
     const { setValue } = useFormContext<Record<string, any>>();
     const [addNewAttributeValue, setAddNewAttributeValue] = useState<AddNewAttributeType | undefined>();
     const attributeCallbackValue = useSelector(userInterfaceSelectors.selectAttributeCallbackValue);

--- a/src/components/Attributes/AttributeEditor/AttributeEditorTestWrapper.tsx
+++ b/src/components/Attributes/AttributeEditor/AttributeEditorTestWrapper.tsx
@@ -7,7 +7,7 @@ import { createMockStore } from 'utils/test-helpers';
 import AttributeEditor from './index';
 import type { AttributeDescriptorModel, AttributeResponseModel } from 'types/attributes';
 
-export type AttributeEditorTestWrapperProps = Readonly<{
+export type AttributeEditorTestWrapperProps = {
     id: string;
     attributeDescriptors: AttributeDescriptorModel[];
     attributes?: AttributeResponseModel[];
@@ -18,7 +18,7 @@ export type AttributeEditorTestWrapperProps = Readonly<{
     kind?: string;
     withRemoveAction?: boolean;
     preloadedState?: Record<string, unknown>;
-}>;
+};
 
 /** Build form defaultValues so Data/Custom fields exist on first paint (before AttributeEditor effects run) */
 function buildAttributeDefaultValues(
@@ -48,7 +48,7 @@ export function AttributeEditorTestWrapper({
     kind,
     withRemoveAction = true,
     preloadedState,
-}: AttributeEditorTestWrapperProps) {
+}: Readonly<AttributeEditorTestWrapperProps>) {
     const store = useMemo(() => createMockStore(preloadedState), [preloadedState]);
     const defaultValues = useMemo(
         () => ({ ...buildAttributeDefaultValues(id, attributeDescriptors, attributes) }),

--- a/src/components/Attributes/AttributeEditor/CustomAttributeAddSelect/index.tsx
+++ b/src/components/Attributes/AttributeEditor/CustomAttributeAddSelect/index.tsx
@@ -3,12 +3,12 @@ import Select from 'components/Select';
 import { type AttributeDescriptorModel, type CustomAttributeModel, isCustomAttributeModel } from '../../../../types/attributes';
 import Label from 'components/Label';
 
-export type Props = Readonly<{
+export type Props = {
     attributeDescriptors: AttributeDescriptorModel[] | undefined;
     onAdd: (attribute: CustomAttributeModel) => void;
-}>;
+};
 
-export default function CustomAttributeAddSelect({ attributeDescriptors, onAdd }: Props) {
+export default function CustomAttributeAddSelect({ attributeDescriptors, onAdd }: Readonly<Props>) {
     const { options, uuidToAttributeMap } = useMemo(() => {
         const customAttributes = attributeDescriptors?.filter<CustomAttributeModel>((el) => isCustomAttributeModel(el)) || [];
 

--- a/src/components/Attributes/AttributeEditor/index.tsx
+++ b/src/components/Attributes/AttributeEditor/index.tsx
@@ -57,7 +57,7 @@ function cloneForCompare<T>(value: T): T {
 const emptyAttributes: AttributeResponseModel[] = [];
 const emptyGroupAttributesCallbackAttributes: AttributeDescriptorModel[] = [];
 
-export type Props = Readonly<{
+export type Props = {
     id: string;
     attributeDescriptors: AttributeDescriptorModel[];
     groupAttributesCallbackAttributes?: AttributeDescriptorModel[];
@@ -69,7 +69,7 @@ export type Props = Readonly<{
     callbackResource?: Resource;
     callbackParentUuid?: string;
     withRemoveAction?: boolean;
-}>;
+};
 
 function AttributeEditorInner({
     id,
@@ -83,7 +83,7 @@ function AttributeEditorInner({
     groupAttributesCallbackAttributes = emptyGroupAttributesCallbackAttributes,
     setGroupAttributesCallbackAttributes = () => emptyGroupAttributesCallbackAttributes,
     withRemoveAction = true,
-}: Props) {
+}: Readonly<Props>) {
     const dispatch = useDispatch();
 
     const { setValue, watch } = useFormContext<Record<string, any>>();

--- a/src/components/Attributes/AttributeViewer/AttributeViewerMountHarness.tsx
+++ b/src/components/Attributes/AttributeViewer/AttributeViewerMountHarness.tsx
@@ -31,7 +31,7 @@ export function createAttributeViewerStore() {
 
 type HarnessProps = Props;
 
-export default function AttributeViewerMountHarness(props: HarnessProps) {
+export default function AttributeViewerMountHarness(props: Readonly<HarnessProps>) {
     const store = createAttributeViewerStore();
     return (
         <Provider store={store}>

--- a/src/components/Attributes/AttributeViewer/index.tsx
+++ b/src/components/Attributes/AttributeViewer/index.tsx
@@ -28,17 +28,14 @@ export enum ATTRIBUTE_VIEWER_TYPE {
     ATTRIBUTE_EDIT,
 }
 
-function AttributeEditForm({
-    descriptor,
-    initialContent,
-    onSubmit,
-    onCancel,
-}: Readonly<{
+type AttributeEditFormProps = {
     descriptor: CustomAttributeModel;
     initialContent?: BaseAttributeContentModel[];
     onSubmit: (uuid: string, content: BaseAttributeContentModel[]) => void;
     onCancel: () => void;
-}>) {
+};
+
+function AttributeEditForm({ descriptor, initialContent, onSubmit, onCancel }: Readonly<AttributeEditFormProps>) {
     const methods = ReactHookForm.useForm<any>({
         defaultValues: {},
     });
@@ -58,7 +55,7 @@ function AttributeEditForm({
     );
 }
 
-export type Props = Readonly<{
+export type Props = {
     attributes?: AttributeResponseModel[];
     descriptors?: AttributeDescriptorModel[] | CustomAttributeModel[];
     metadata?: MetadataModel[];
@@ -66,7 +63,7 @@ export type Props = Readonly<{
     hasHeader?: boolean;
     onSubmit?: (attributeUuid: string, content: BaseAttributeContentModel[]) => void;
     onRemove?: (attributeUuid: string) => void;
-}>;
+};
 
 export default function AttributeViewer({
     attributes = [],
@@ -76,7 +73,7 @@ export default function AttributeViewer({
     viewerType = ATTRIBUTE_VIEWER_TYPE.ATTRIBUTE,
     onSubmit,
     onRemove,
-}: Props) {
+}: Readonly<Props>) {
     const getContent = getAttributeContent;
     const [editingAttributesNames, setEditingAttributesNames] = useState<string[]>([]);
     const contentTypeEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.AttributeContentType));

--- a/src/components/Attributes/CodeBlock/index.tsx
+++ b/src/components/Attributes/CodeBlock/index.tsx
@@ -10,9 +10,9 @@ import { base64ToUtf8 } from 'utils/common-utils';
 import type { CodeBlockAttributeContentModel } from '../../../types/attributes';
 import type { ProgrammingLanguageEnum } from '../../../types/openapi';
 
-type Props = Readonly<{
+type Props = {
     content: CodeBlockAttributeContentModel;
-}>;
+};
 
 export const getHighLightedCode = (code: string, language: ProgrammingLanguageEnum) => {
     try {
@@ -23,7 +23,7 @@ export const getHighLightedCode = (code: string, language: ProgrammingLanguageEn
     }
 };
 
-export default function CodeBlock({ content }: Props) {
+export default function CodeBlock({ content }: Readonly<Props>) {
     const dispatch = useDispatch();
 
     const handleOpenDialog = () => {

--- a/src/components/Attributes/ComplianceRuleAttributeViewer/index.tsx
+++ b/src/components/Attributes/ComplianceRuleAttributeViewer/index.tsx
@@ -3,13 +3,13 @@ import { useMemo } from 'react';
 import { type AttributeDescriptorModel, type AttributeResponseModel, isDataAttributeModel } from 'types/attributes';
 import { getAttributeContent } from 'utils/attributes/attributes';
 
-export type Props = Readonly<{
+export type Props = {
     attributes?: AttributeResponseModel[];
     descriptorAttributes?: AttributeDescriptorModel[];
     hasHeader?: boolean;
-}>;
+};
 
-export default function ComplianceRuleAttributeViewer({ attributes, descriptorAttributes, hasHeader = true }: Props) {
+export default function ComplianceRuleAttributeViewer({ attributes, descriptorAttributes, hasHeader = true }: Readonly<Props>) {
     const getContent = getAttributeContent;
 
     const tableHeaders: TableHeader[] = useMemo(

--- a/src/components/Attributes/CustomAttributeWidget/CustomAttributeWidgetMountHarness.tsx
+++ b/src/components/Attributes/CustomAttributeWidget/CustomAttributeWidgetMountHarness.tsx
@@ -24,13 +24,13 @@ function minimalDescriptor(overrides: Partial<CustomAttributeModel> = {}): Custo
     } as CustomAttributeModel;
 }
 
-type HarnessProps = Readonly<{
+type HarnessProps = {
     resource?: Resource;
     resourceUuid?: string;
     attributes?: any;
     className?: string;
     availableAttributes?: CustomAttributeModel[];
-}>;
+};
 
 /**
  * Creates store and renders CustomAttributeWidget in browser (for CT).
@@ -42,7 +42,7 @@ export default function CustomAttributeWidgetMountHarness({
     attributes,
     className,
     availableAttributes = [minimalDescriptor()],
-}: HarnessProps) {
+}: Readonly<HarnessProps>) {
     const store = createMockStore({
         customAttributes: {
             resourceCustomAttributes: availableAttributes,

--- a/src/components/Attributes/CustomAttributeWidget/index.tsx
+++ b/src/components/Attributes/CustomAttributeWidget/index.tsx
@@ -10,15 +10,15 @@ import ContentValueField from '../../Input/DynamicContent/ContentValueField';
 import Widget from '../../Widget';
 import AttributeViewer, { ATTRIBUTE_VIEWER_TYPE } from '../AttributeViewer';
 
-export type Props = Readonly<{
+export type Props = {
     resource: Resource;
     resourceUuid: string;
     attributes: AttributeResponseModel[] | undefined;
     className?: string;
     noBorder?: boolean;
-}>;
+};
 
-export default function CustomAttributeWidget({ resource, resourceUuid, attributes, className, noBorder }: Props) {
+export default function CustomAttributeWidget({ resource, resourceUuid, attributes, className, noBorder }: Readonly<Props>) {
     const dispatch = useDispatch();
     const [isAttributeContentLoaded, setIsAttributeContentLoaded] = useState<boolean>(false);
 

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames';
 
 export type BadgeColor = 'gray' | 'secondary' | 'success' | 'primary' | 'danger' | 'warning' | 'info' | 'transparent';
 
-type Props = Readonly<{
+type Props = {
     color?: BadgeColor;
     onClick?: () => void;
     onRemove?: () => void;
@@ -13,9 +13,20 @@ type Props = Readonly<{
     size?: 'small' | 'medium' | 'large';
     dataTestId?: string;
     id?: string;
-}>;
+};
 
-function Badge({ color = 'secondary', onClick, onRemove, children, style, className, title, size = 'small', dataTestId, id }: Props) {
+function Badge({
+    color = 'secondary',
+    onClick,
+    onRemove,
+    children,
+    style,
+    className,
+    title,
+    size = 'small',
+    dataTestId,
+    id,
+}: Readonly<Props>) {
     const colorClasses = {
         gray: 'bg-gray-800 text-white dark:bg-white dark:text-neutral-800',
         secondary: 'bg-gray-500 text-white',

--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -2,16 +2,16 @@ import cn from 'classnames';
 import { Link } from 'react-router';
 import type React from 'react';
 
-type Props = Readonly<{
+type Props = {
     items: {
         label: string;
         href?: string;
     }[];
     title?: string;
     rightContent?: React.ReactNode;
-}>;
+};
 
-function Breadcrumb({ items, title: titleProp, rightContent }: Props) {
+function Breadcrumb({ items, title: titleProp, rightContent }: Readonly<Props>) {
     const title = titleProp || items.at(-1)?.label || '';
     return (
         <div className="mb-4 md:mb-8">

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -4,7 +4,7 @@ import Tooltip from 'components/Tooltip';
 export type ButtonVariant = 'solid' | 'outline' | 'transparent';
 
 export type ButtonColor = 'primary' | 'danger' | 'secondary' | 'warning' | 'lightGray';
-export type Props = Readonly<{
+export type Props = {
     variant?: ButtonVariant;
     color?: ButtonColor;
     onClick?: (event: React.MouseEvent) => void;
@@ -16,7 +16,7 @@ export type Props = Readonly<{
     disabledTooltip?: string;
     type?: 'submit' | 'reset' | 'button';
     'data-testid'?: string;
-}>;
+};
 
 const baseButton =
     'inline-flex items-center gap-x-2 text-sm font-medium rounded-lg disabled:opacity-35 disabled:pointer-events-none focus:outline-hidden border';
@@ -70,7 +70,7 @@ function Button({
     disabledTooltip,
     type = 'button',
     'data-testid': dataTestId,
-}: Props) {
+}: Readonly<Props>) {
     const buttonElement = (
         <button
             type={type}

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,14 +1,14 @@
 import Spinner from 'components/Spinner';
 
-type Props = Readonly<{
+type Props = {
     children: React.ReactNode;
     isLoading?: boolean;
     title?: string;
     subtitle?: string;
     content?: string;
-}>;
+};
 
-function Card({ title, subtitle, content, children, isLoading }: Props) {
+function Card({ title, subtitle, content, children, isLoading }: Readonly<Props>) {
     if (isLoading) {
         return (
             <div className="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl p-4 md:p-5 dark:bg-neutral-900 dark:border-neutral-700 dark:shadow-neutral-700/70">

--- a/src/components/CertificateAssociationsFormWidget/CertificateAssociationsFormWidget.tsx
+++ b/src/components/CertificateAssociationsFormWidget/CertificateAssociationsFormWidget.tsx
@@ -7,13 +7,13 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { buildUserOption } from 'utils/widget';
 
-type Props = Readonly<{
+type Props = {
     userOptions: { value: string; label: string }[];
     groupOptions: { value: string; label: string }[];
     setUserOptions: (options: { value: string; label: string }[]) => void;
     setGroupOptions: (options: { value: string; label: string }[]) => void;
     renderCustomAttributes: React.ReactNode;
-}>;
+};
 
 export default function CertificateAssociationsFormWidget({
     renderCustomAttributes,
@@ -21,7 +21,7 @@ export default function CertificateAssociationsFormWidget({
     groupOptions,
     setUserOptions,
     setGroupOptions,
-}: Props) {
+}: Readonly<Props>) {
     const dispatch = useDispatch();
     const users = useSelector(userSelectors.users);
     const groups = useSelector(groupsSelectors.certificateGroups);

--- a/src/components/CertificateAssociationsFormWidget/CertificateAssociationsFormWidgetTestWrapper.tsx
+++ b/src/components/CertificateAssociationsFormWidget/CertificateAssociationsFormWidgetTestWrapper.tsx
@@ -8,13 +8,13 @@ import CertificateAssociationsFormWidget from './CertificateAssociationsFormWidg
 
 type Option = { value: string; label: string };
 
-type WrapperProps = Readonly<{
+type WrapperProps = {
     users?: Array<{ uuid: string; username: string; firstName?: string; lastName?: string }>;
     groups?: Array<{ uuid: string; name: string }>;
     initialUserOptions?: Option[];
     initialGroupOptions?: Option[];
     renderCustomAttributes?: React.ReactNode;
-}>;
+};
 
 type FormData = {
     owner: string;
@@ -45,7 +45,7 @@ export default function CertificateAssociationsFormWidgetTestWrapper({
     initialUserOptions = [],
     initialGroupOptions = [],
     renderCustomAttributes = <div data-testid="custom-attributes-content">Custom attributes content</div>,
-}: WrapperProps) {
+}: Readonly<WrapperProps>) {
     const store = useMemo(() => createCertificateAssociationsStore({ users, groups }), [users, groups]);
     const methods = useForm<FormData>({
         defaultValues: {

--- a/src/components/CertificateAttributes/index.tsx
+++ b/src/components/CertificateAttributes/index.tsx
@@ -3,13 +3,13 @@ import { useMemo } from 'react';
 import type { CertificateDetailResponseModel } from 'types/certificate';
 import { dateFormatter } from 'utils/dateUtil';
 
-type Props = Readonly<{
+type Props = {
     certificate?: CertificateDetailResponseModel;
     csr?: boolean;
     isLoading?: boolean;
-}>;
+};
 
-function CertificateAttributes({ certificate, csr = false, isLoading = false }: Props) {
+function CertificateAttributes({ certificate, csr = false, isLoading = false }: Readonly<Props>) {
     const detailHeaders: TableHeader[] = useMemo(
         () => [
             {

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames';
 import Label from 'components/Label';
 
-type Props = Readonly<{
+type Props = {
     checked: boolean;
     onChange: (checked: boolean) => void;
     placeholder?: string;
@@ -9,9 +9,9 @@ type Props = Readonly<{
     label?: string;
     disabled?: boolean;
     dataTestId?: string;
-}>;
+};
 
-function Checkbox({ checked, onChange, id, label, disabled = false, dataTestId }: Props) {
+function Checkbox({ checked, onChange, id, label, disabled = false, dataTestId }: Readonly<Props>) {
     return (
         <div className="flex items-center h-5" data-testid={dataTestId ? `${dataTestId}-wrapper` : undefined}>
             <input

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -1,14 +1,14 @@
 import cn from 'classnames';
 
-type Props = Readonly<{
+type Props = {
     children: React.ReactNode;
     className?: string;
     marginTop?: boolean;
     gap?: number;
     'data-testid'?: string;
-}>;
+};
 
-function Container({ children, className, marginTop, gap, 'data-testid': dataTestId }: Props) {
+function Container({ children, className, marginTop, gap, 'data-testid': dataTestId }: Readonly<Props>) {
     const gapClass = gap ? `gap-${gap}` : 'gap-4 md:gap-8';
     return (
         <div className={cn('flex flex-col', className, gapClass, { 'mt-4 md:mt-8': marginTop })} data-testid={dataTestId}>

--- a/src/components/CronBuilder/index.tsx
+++ b/src/components/CronBuilder/index.tsx
@@ -31,12 +31,12 @@ function StartTimePicker({
     );
 }
 
-type Props = Readonly<{
+type Props = {
     value: string;
     onChange: (value: string) => void;
-}>;
+};
 
-export default function CronBuilder({ value, onChange }: Props) {
+export default function CronBuilder({ value, onChange }: Readonly<Props>) {
     const [state, setState] = useState<CronState>(() => parseCron(value));
     const lastEmittedRef = useRef<string>(value);
 

--- a/src/components/CustomTable/PagedCustomTable.tsx
+++ b/src/components/CustomTable/PagedCustomTable.tsx
@@ -4,16 +4,16 @@ import { useLocation } from 'react-router';
 import { useDispatch, useSelector } from 'react-redux';
 import { actions as tablePaginationActions, selectors as tablePaginationSelectors } from 'ducks/table-pagination';
 
-type Props = Readonly<{
+type Props = {
     headers: TableHeader[];
     data: TableDataRow[];
     totalItems?: number;
     onReloadData: (pageSize: number, pageNumber: number) => void;
     stateKey?: string;
     tableStateKey?: string;
-}>;
+};
 
-export default function PagedCustomTable({ headers, data, totalItems, onReloadData, stateKey, tableStateKey }: Props) {
+export default function PagedCustomTable({ headers, data, totalItems, onReloadData, stateKey, tableStateKey }: Readonly<Props>) {
     const dispatch = useDispatch();
     const location = useLocation();
     const [pageSize, setPageSize] = useState(10);

--- a/src/components/CustomTable/TableRowCell.tsx
+++ b/src/components/CustomTable/TableRowCell.tsx
@@ -3,16 +3,16 @@ import cn from 'classnames';
 import Button from 'components/Button';
 import type { TableDataRow, TableHeader } from './types';
 
-export type TableRowCellProps = Readonly<{
+export type TableRowCellProps = {
     column: string | React.ReactNode | React.ReactNode[];
     index: number;
     row: TableDataRow;
     tblHeaders: TableHeader[] | undefined;
     hasDetails?: boolean;
     onDetailClick: (rowId: number | string) => void;
-}>;
+};
 
-export function TableRowCell({ column, index, row, tblHeaders, hasDetails = false, onDetailClick }: TableRowCellProps) {
+export function TableRowCell({ column, index, row, tblHeaders, hasDetails = false, onDetailClick }: Readonly<TableRowCellProps>) {
     const isFirstColumn = index === 0;
     const shouldShowButton = hasDetails && isFirstColumn && row.detailColumns && row.detailColumns.length > 0;
     const align = tblHeaders?.[index]?.align;

--- a/src/components/CustomTable/TableSkeleton.tsx
+++ b/src/components/CustomTable/TableSkeleton.tsx
@@ -8,15 +8,21 @@ function getCellWidth(row: number, col: number): number {
 
 const headerWidths = [96, 64, 80, 56];
 
-type Props = Readonly<{
+type Props = {
     columnsCount?: number;
     hasCheckboxes?: boolean;
     hasPagination?: boolean;
     canSearch?: boolean;
     rowCount?: number;
-}>;
+};
 
-function TableSkeleton({ columnsCount = 4, hasCheckboxes = true, hasPagination = true, canSearch = false, rowCount = 10 }: Props) {
+function TableSkeleton({
+    columnsCount = 4,
+    hasCheckboxes = true,
+    hasPagination = true,
+    canSearch = false,
+    rowCount = 10,
+}: Readonly<Props>) {
     const columns = Array.from({ length: columnsCount }, (_, i) => i);
     const rows = Array.from({ length: rowCount }, (_, i) => i);
 

--- a/src/components/CustomTable/index.tsx
+++ b/src/components/CustomTable/index.tsx
@@ -19,7 +19,7 @@ import TableSkeleton from './TableSkeleton';
 
 export type { TableDataRow, TableHeader } from './types';
 
-type Props = Readonly<{
+type Props = {
     headers: TableHeader[];
     data: TableDataRow[];
     canSearch?: boolean;
@@ -50,7 +50,7 @@ type Props = Readonly<{
     disableSelectionControls?: boolean;
     disableSearchControls?: boolean;
     isLoading?: boolean;
-}>;
+};
 
 const emptyCheckedRows: (string | number)[] = [];
 
@@ -78,7 +78,7 @@ function CustomTable({
     disableSelectionControls = false,
     disableSearchControls = false,
     isLoading = false,
-}: Props) {
+}: Readonly<Props>) {
     const location = useLocation();
     const [tblHeaders, setTblHeaders] = useState<TableHeader[]>();
     const [tblData, setTblData] = useState<TableDataRow[]>(data);

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -6,7 +6,7 @@ import { inputBaseClassName } from 'components/TextInput/inputStyles';
 import Button from 'components/Button';
 import Container from 'components/Container';
 
-type Props = Readonly<{
+type Props = {
     value?: string;
     onChange: (value: string) => void;
     onBlur?: () => void;
@@ -17,12 +17,12 @@ type Props = Readonly<{
     className?: string;
     required?: boolean;
     timePicker?: boolean;
-}>;
+};
 
 const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 const WEEKDAYS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
 
-function DatePicker({ value, onChange, onBlur, disabled, id, invalid, error, className, required, timePicker = false }: Props) {
+function DatePicker({ value, onChange, onBlur, disabled, id, invalid, error, className, required, timePicker = false }: Readonly<Props>) {
     const [isOpen, setIsOpen] = useState(false);
     const [selectedDate, setSelectedDate] = useState<Date | null>(value ? new Date(value) : null);
     const [selectedTime, setSelectedTime] = useState<{ hours: number; minutes: number; seconds: number }>(() => {

--- a/src/components/DetailPageSkeleton/index.tsx
+++ b/src/components/DetailPageSkeleton/index.tsx
@@ -7,14 +7,14 @@ const cardClass =
 
 type SkeletonLayout = 'simple' | 'tabs' | 'split';
 
-type Props = Readonly<{
+type Props = {
     layout?: SkeletonLayout;
     tabCount?: number;
     rowCount?: number;
     buttonsCount?: number;
     tabWidgetButtonsCount?: number;
     showBreadcrumb?: boolean;
-}>;
+};
 
 function BreadcrumbSkeleton() {
     return (
@@ -53,7 +53,7 @@ export default function DetailPageSkeleton({
     buttonsCount = 2,
     tabWidgetButtonsCount = 0,
     showBreadcrumb = true,
-}: Props) {
+}: Readonly<Props>) {
     if (layout === 'simple') {
         return (
             <div data-testid="detail-page-skeleton">

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -48,7 +48,7 @@ export interface DialogButton {
     variant?: ButtonVariant;
 }
 
-type Props = Readonly<{
+type Props = {
     isOpen: boolean;
     toggle?: () => void;
     caption?: string | React.ReactNode;
@@ -58,9 +58,19 @@ type Props = Readonly<{
     dataTestId?: string;
     icon?: ModalIcon;
     noBorder?: boolean;
-}>;
+};
 
-export default function Dialog({ isOpen, toggle, caption, body, buttons, size = 'sm', dataTestId, icon, noBorder = false }: Props) {
+export default function Dialog({
+    isOpen,
+    toggle,
+    caption,
+    body,
+    buttons,
+    size = 'sm',
+    dataTestId,
+    icon,
+    noBorder = false,
+}: Readonly<Props>) {
     const sizeClasses = {
         sm: 'sm:max-w-sm',
         md: 'sm:max-w-lg',

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -9,7 +9,7 @@ export interface DropdownItem {
     color?: ButtonColor;
 }
 
-type Props = Readonly<{
+type Props = {
     title: React.ReactNode;
     items?: DropdownItem[];
     disabled?: boolean;
@@ -19,9 +19,19 @@ type Props = Readonly<{
     hideArrow?: boolean;
     menu?: React.ReactNode;
     buttonRef?: React.RefObject<HTMLButtonElement | null>;
-}>;
+};
 
-function Dropdown({ title, items, disabled = false, btnStyle, className, menuClassName, hideArrow = false, menu, buttonRef }: Props) {
+function Dropdown({
+    title,
+    items,
+    disabled = false,
+    btnStyle,
+    className,
+    menuClassName,
+    hideArrow = false,
+    menu,
+    buttonRef,
+}: Readonly<Props>) {
     useEffect(() => {
         const hsMethods = (globalThis as any).HSStaticMethods;
         if (hsMethods) hsMethods.autoInit();

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -3,11 +3,11 @@ import { useLocation } from 'react-router';
 import Button from 'components/Button';
 import Container from 'components/Container';
 
-type Props = Readonly<{
+type Props = {
     children: ReactNode;
     fallback?: ReactNode;
     resetKey?: string | number;
-}>;
+};
 
 interface State {
     hasError: boolean;
@@ -16,7 +16,7 @@ interface State {
 }
 
 class ErrorBoundary extends Component<Props, State> {
-    constructor(props: Props) {
+    constructor(props: Readonly<Props>) {
         super(props);
         this.state = {
             hasError: false,
@@ -41,7 +41,7 @@ class ErrorBoundary extends Component<Props, State> {
         });
     }
 
-    componentDidUpdate(prevProps: Props) {
+    componentDidUpdate(prevProps: Readonly<Props>) {
         // Reset error state when resetKey changes (e.g., on navigation)
         if (this.props.resetKey !== prevProps.resetKey && this.state.hasError) {
             this.setState({

--- a/src/components/FilterWidget/FilterWidgetTestWrapper.tsx
+++ b/src/components/FilterWidget/FilterWidgetTestWrapper.tsx
@@ -94,7 +94,7 @@ export const defaultAvailableFilters: SearchFieldListModel[] = [
     },
 ];
 
-export type FilterWidgetTestWrapperProps = Readonly<{
+export type FilterWidgetTestWrapperProps = {
     title?: string;
     entity?: EntityType;
     availableFilters?: SearchFieldListModel[];
@@ -104,7 +104,7 @@ export type FilterWidgetTestWrapperProps = Readonly<{
     busyBadges?: boolean;
     extraFilterComponent?: React.ReactNode;
     filterGridCols?: 2 | 4;
-}>;
+};
 
 export default function FilterWidgetTestWrapper({
     title = 'Filters',
@@ -116,7 +116,7 @@ export default function FilterWidgetTestWrapper({
     busyBadges,
     extraFilterComponent,
     filterGridCols = 4,
-}: FilterWidgetTestWrapperProps) {
+}: Readonly<FilterWidgetTestWrapperProps>) {
     const getAvailableFiltersApi = useMemo(() => () => of(availableFilters), [availableFilters]);
 
     const preloadedState = useMemo(

--- a/src/components/FilterWidget/index.tsx
+++ b/src/components/FilterWidget/index.tsx
@@ -81,7 +81,7 @@ interface ObjectValueOptions {
     value: any;
 }
 
-type Props = Readonly<{
+type Props = {
     title: string;
     entity: EntityType;
     getAvailableFiltersApi: (apiClients: ApiClients) => Observable<Array<SearchFieldListModel>>;
@@ -90,7 +90,7 @@ type Props = Readonly<{
     busyBadges?: boolean;
     extraFilterComponent?: React.ReactNode;
     filterGridCols?: 2 | 4;
-}>;
+};
 
 export function FilterWidgetSkeleton({
     title = '',
@@ -141,7 +141,7 @@ export default function FilterWidget({
     busyBadges,
     extraFilterComponent,
     filterGridCols = 4,
-}: Props) {
+}: Readonly<Props>) {
     const dispatch = useDispatch();
 
     const searchGroupEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.FilterFieldSource));

--- a/src/components/FilterWidgetRuleAction/FilterWidgetRuleActionTestWrapper.tsx
+++ b/src/components/FilterWidgetRuleAction/FilterWidgetRuleActionTestWrapper.tsx
@@ -26,7 +26,7 @@ const defaultEnumsPreload = {
     },
 };
 
-export type FilterWidgetRuleActionTestWrapperProps = Readonly<{
+export type FilterWidgetRuleActionTestWrapperProps = {
     title?: string;
     entity?: EntityType;
     availableFilters?: SearchFieldListModel[];
@@ -35,7 +35,7 @@ export type FilterWidgetRuleActionTestWrapperProps = Readonly<{
     disableBadgeRemove?: boolean;
     busyBadges?: boolean;
     platformEnumsOverride?: Record<string, Record<string, { label: string }>>;
-}>;
+};
 
 export function FilterWidgetRuleActionTestWrapper({
     title = 'Filter rule actions',
@@ -46,7 +46,7 @@ export function FilterWidgetRuleActionTestWrapper({
     disableBadgeRemove,
     busyBadges,
     platformEnumsOverride,
-}: FilterWidgetRuleActionTestWrapperProps) {
+}: Readonly<FilterWidgetRuleActionTestWrapperProps>) {
     const getAvailableFiltersApi = useMemo(() => () => of(availableFilters), [availableFilters]);
 
     const preloadedState = useMemo(

--- a/src/components/FilterWidgetRuleAction/index.tsx
+++ b/src/components/FilterWidgetRuleAction/index.tsx
@@ -112,7 +112,7 @@ function mapActionToExecutionItem(a: ExecutionItemRequestModel, availableFilters
     return { fieldSource: a.fieldSource, fieldIdentifier: a.fieldIdentifier, data };
 }
 
-type Props = Readonly<{
+type Props = {
     title: string;
     entity: EntityType;
     getAvailableFiltersApi: (apiClients: ApiClients) => Observable<Array<SearchFieldListModel>>;
@@ -120,7 +120,7 @@ type Props = Readonly<{
     ExecutionsList?: ExecutionItemModel[];
     disableBadgeRemove?: boolean;
     busyBadges?: boolean;
-}>;
+};
 
 export default function FilterWidgetRuleAction({
     ExecutionsList,
@@ -130,7 +130,7 @@ export default function FilterWidgetRuleAction({
     getAvailableFiltersApi,
     disableBadgeRemove,
     busyBadges,
-}: Props) {
+}: Readonly<Props>) {
     const dispatch = useDispatch();
 
     const searchGroupEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.FilterFieldSource));

--- a/src/components/FlowChart/CustomEdge/index.tsx
+++ b/src/components/FlowChart/CustomEdge/index.tsx
@@ -3,15 +3,15 @@ import { getBezierPath, useStore } from 'reactflow';
 
 import { getEdgeParams } from './edgeUtils';
 
-type FloatingEdgeProps = Readonly<{
+type FloatingEdgeProps = {
     id: string;
     source: string;
     target: string;
     markerEnd?: string;
     style?: React.CSSProperties;
-}>;
+};
 
-function FloatingEdge({ id, source, target, markerEnd, style }: FloatingEdgeProps) {
+function FloatingEdge({ id, source, target, markerEnd, style }: Readonly<FloatingEdgeProps>) {
     const sourceNode = useStore(useCallback((store) => store.nodeInternals.get(source), [source]));
     const targetNode = useStore(useCallback((store) => store.nodeInternals.get(target), [target]));
 

--- a/src/components/FlowChart/CustomFlowNode/CustomFlowNodeMountWrapper.tsx
+++ b/src/components/FlowChart/CustomFlowNode/CustomFlowNodeMountWrapper.tsx
@@ -9,13 +9,13 @@ import { testInitialState } from 'ducks/test-reducers';
 
 type StoreType = ReturnType<typeof createMockStore>;
 
-type Props = Readonly<{
+type Props = {
     nodeProps: EntityNodeProps;
     /** Serializable initial state so store is created in browser (CT cannot pass store from Node). */
     initialStoreState?: typeof testInitialState;
     /** Called with store instance after mount (for tests that need to assert on state). */
     onStoreReady?: (store: StoreType) => void;
-}>;
+};
 
 class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { error: Error | null }> {
     state = { error: null as Error | null };
@@ -34,7 +34,7 @@ class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { err
  * Wrapper for Playwright CT: creates store in browser and renders CustomFlowNode with providers.
  * Must live outside the spec file so CT can mount it.
  */
-export default function CustomFlowNodeMountWrapper({ nodeProps, initialStoreState, onStoreReady }: Props) {
+export default function CustomFlowNodeMountWrapper({ nodeProps, initialStoreState, onStoreReady }: Readonly<Props>) {
     const store = React.useMemo(() => createMockStore((initialStoreState ?? testInitialState) as any), [initialStoreState]);
     React.useEffect(() => {
         onStoreReady?.(store);

--- a/src/components/FlowChart/FlowChartMountWrapper.tsx
+++ b/src/components/FlowChart/FlowChartMountWrapper.tsx
@@ -7,13 +7,13 @@ import { testInitialState } from 'ducks/test-reducers';
 
 type StoreType = ReturnType<typeof createMockStore>;
 
-type Props = Readonly<{
+type Props = {
     flowChartProps: FlowChartProps;
     initialStoreState?: typeof testInitialState;
     onStoreReady?: (store: StoreType) => void;
-}>;
+};
 
-export default function FlowChartMountWrapper({ flowChartProps, initialStoreState, onStoreReady }: Props) {
+export default function FlowChartMountWrapper({ flowChartProps, initialStoreState, onStoreReady }: Readonly<Props>) {
     const store = React.useMemo(() => createMockStore((initialStoreState ?? testInitialState) as any), [initialStoreState]);
 
     React.useEffect(() => {

--- a/src/components/ForceDeleteErrorTable.tsx
+++ b/src/components/ForceDeleteErrorTable.tsx
@@ -8,14 +8,19 @@ export interface ForceDeleteErrorItem {
     message: string;
 }
 
-type ForceDeleteErrorTableProps = Readonly<{
+type ForceDeleteErrorTableProps = {
     items?: ForceDeleteErrorItem[];
     entityNameSingular: string;
     entityNamePlural: string;
     itemsCount: number;
-}>;
+};
 
-export default function ForceDeleteErrorTable({ items, entityNameSingular, entityNamePlural, itemsCount }: ForceDeleteErrorTableProps) {
+export default function ForceDeleteErrorTable({
+    items,
+    entityNameSingular,
+    entityNamePlural,
+    itemsCount,
+}: Readonly<ForceDeleteErrorTableProps>) {
     const headers: TableHeader[] = useMemo(
         () => [
             {

--- a/src/components/Input/DynamicContent/AddCustomValueInput.tsx
+++ b/src/components/Input/DynamicContent/AddCustomValueInput.tsx
@@ -7,7 +7,7 @@ import { AttributeContentType } from 'types/openapi';
 const defaultInputClassName =
     'py-2.5 px-4 block w-full border border-gray-200 rounded-lg text-sm dark:bg-neutral-900 dark:border-neutral-700';
 
-type Props = Readonly<{
+type Props = {
     id: string;
     inputType: string;
     contentType: AttributeContentType;
@@ -16,7 +16,7 @@ type Props = Readonly<{
     onChange: (v: string | number | boolean) => void;
     readOnly: boolean;
     inputClassName?: string;
-}>;
+};
 
 export function AddCustomValueInput({
     id,
@@ -27,7 +27,7 @@ export function AddCustomValueInput({
     onChange,
     readOnly,
     inputClassName = defaultInputClassName,
-}: Props): React.ReactNode {
+}: Readonly<Props>): React.ReactNode {
     if (inputType === 'datetime-local') {
         let dateVal = typeof value === 'string' && value ? value : undefined;
         if (dateVal && !dateVal.includes('T')) dateVal = dateVal.replace(' ', 'T');

--- a/src/components/Input/DynamicContent/AddCustomValuePanel.tsx
+++ b/src/components/Input/DynamicContent/AddCustomValuePanel.tsx
@@ -7,7 +7,7 @@ import { ContentFieldConfiguration } from './contentFieldConfiguration';
 import { AddCustomValueInput } from './AddCustomValueInput';
 import { Check, X } from 'lucide-react';
 
-type Props = Readonly<{
+type Props = {
     open: boolean;
     onClose: () => void;
     idPrefix: string;
@@ -18,7 +18,7 @@ type Props = Readonly<{
     onFieldChange: (value: any) => void;
     parseValue?: (raw: string | number | boolean) => any;
     inputClassName?: string;
-}>;
+};
 
 export function AddCustomValuePanel({
     open,
@@ -31,7 +31,7 @@ export function AddCustomValuePanel({
     onFieldChange,
     parseValue = (x) => x,
     inputClassName,
-}: Props): React.ReactNode {
+}: Readonly<Props>): React.ReactNode {
     const [customValue, setCustomValue] = useState<string | number | boolean>('');
 
     if (!open) return null;

--- a/src/components/Input/DynamicContent/ContentDescriptorField/ContentDescriptorFieldTestWrapper.tsx
+++ b/src/components/Input/DynamicContent/ContentDescriptorField/ContentDescriptorFieldTestWrapper.tsx
@@ -2,13 +2,13 @@ import * as ReactHookForm from 'react-hook-form';
 import ContentDescriptorField from './index';
 import type { AttributeContentType } from 'types/openapi';
 
-export type ContentDescriptorFieldTestWrapperProps = Readonly<{
+export type ContentDescriptorFieldTestWrapperProps = {
     isList: boolean;
     contentType: AttributeContentType;
     defaultContent?: unknown[];
     readOnly?: boolean;
     showSubmitButton?: boolean;
-}>;
+};
 
 export function ContentDescriptorFieldTestWrapper({
     isList,
@@ -16,7 +16,7 @@ export function ContentDescriptorFieldTestWrapper({
     defaultContent = [{ data: '' }],
     readOnly = false,
     showSubmitButton = false,
-}: ContentDescriptorFieldTestWrapperProps) {
+}: Readonly<ContentDescriptorFieldTestWrapperProps>) {
     const methods = ReactHookForm.useForm({
         defaultValues: {
             content: defaultContent,

--- a/src/components/Input/DynamicContent/ContentDescriptorField/index.tsx
+++ b/src/components/Input/DynamicContent/ContentDescriptorField/index.tsx
@@ -87,12 +87,12 @@ function DescriptorInputControl({
     );
 }
 
-type Props = Readonly<{
+type Props = {
     isList: boolean;
     contentType: AttributeContentType;
-}>;
+};
 
-export default function ContentDescriptorField({ isList, contentType }: Props) {
+export default function ContentDescriptorField({ isList, contentType }: Readonly<Props>) {
     const { control, setValue, watch } = useFormContext();
     const contentValues = watch('content');
     const readOnly = watch('readOnly');

--- a/src/components/Input/DynamicContent/ContentValueField/ContentValueFieldTestWrapper.tsx
+++ b/src/components/Input/DynamicContent/ContentValueField/ContentValueFieldTestWrapper.tsx
@@ -2,14 +2,19 @@ import * as ReactHookForm from 'react-hook-form';
 import ContentValueField from './index';
 import type { BaseAttributeContentModel, CustomAttributeModel } from 'types/attributes';
 
-export type ContentValueFieldTestWrapperProps = Readonly<{
+export type ContentValueFieldTestWrapperProps = {
     id?: string;
     descriptor: CustomAttributeModel;
     initialContent?: BaseAttributeContentModel[];
     onSubmit?: (attributeUuid: string, content: BaseAttributeContentModel[]) => void;
-}>;
+};
 
-function ContentValueFieldTestWrapper({ id, descriptor, initialContent, onSubmit = () => {} }: ContentValueFieldTestWrapperProps) {
+function ContentValueFieldTestWrapper({
+    id,
+    descriptor,
+    initialContent,
+    onSubmit = () => {},
+}: Readonly<ContentValueFieldTestWrapperProps>) {
     const methods = ReactHookForm.useForm({
         defaultValues: {
             [descriptor.name]: undefined,

--- a/src/components/Input/DynamicContent/ContentValueField/index.tsx
+++ b/src/components/Input/DynamicContent/ContentValueField/index.tsx
@@ -22,7 +22,7 @@ function getValueFieldError(fieldState: { error?: { message?: string }; isTouche
     return typeof fieldState.error === 'string' ? fieldState.error : (fieldState.error?.message ?? 'Invalid value');
 }
 
-type ValueFieldInputProps = Readonly<{
+type ValueFieldInputProps = {
     descriptor: CustomAttributeModel;
     id?: string;
     field: { value: any; onChange: (v: any) => void; onBlur: () => void };
@@ -30,7 +30,7 @@ type ValueFieldInputProps = Readonly<{
     fieldStepValue: number | undefined;
     options: { label: string; value: string }[];
     onCancel?: () => void;
-}>;
+};
 
 function normalizeDateValue(value: string | undefined): string | undefined {
     if (!value) return undefined;
@@ -130,7 +130,7 @@ function ListValueField({ descriptor, field, options, inputClassName }: ValueFie
     );
 }
 
-function ValueFieldInput({ descriptor, id, field, fieldState, fieldStepValue, options }: ValueFieldInputProps) {
+function ValueFieldInput({ descriptor, id, field, fieldState, fieldStepValue, options }: Readonly<ValueFieldInputProps>) {
     const inputType = ContentFieldConfiguration[descriptor.contentType].type;
     const displayValue = descriptor.contentType === AttributeContentType.Datetime ? getFormattedDateTime(field.value) : field.value;
     const error = getValueFieldError(fieldState);
@@ -205,15 +205,15 @@ function ValueFieldInput({ descriptor, id, field, fieldState, fieldStepValue, op
     }
 }
 
-type Props = Readonly<{
+type Props = {
     id?: string;
     descriptor: CustomAttributeModel;
     initialContent?: BaseAttributeContentModel[];
     onSubmit: (attributeUuid: string, content: BaseAttributeContentModel[]) => void;
     onCancel?: () => void;
-}>;
+};
 
-export default function ContentValueField({ id, descriptor, initialContent, onSubmit, onCancel }: Props) {
+export default function ContentValueField({ id, descriptor, initialContent, onSubmit, onCancel }: Readonly<Props>) {
     const { control, setValue } = useFormContext();
 
     const options = useMemo(

--- a/src/components/Input/DynamicContent/index.tsx
+++ b/src/components/Input/DynamicContent/index.tsx
@@ -22,12 +22,12 @@ const AllowedAttributeContentType = [
     AttributeContentType.Datetime,
 ];
 
-type Props = Readonly<{
+type Props = {
     editable: boolean;
     isList: boolean;
-}>;
+};
 
-export default function DynamicContent({ editable, isList }: Props) {
+export default function DynamicContent({ editable, isList }: Readonly<Props>) {
     const { control, setValue } = useFormContext();
     const contentTypeValue = useWatch({ control, name: 'contentType' });
     const attributeContentTypeEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.AttributeContentType));

--- a/src/components/Input/FileUpload/FileUpload.tsx
+++ b/src/components/Input/FileUpload/FileUpload.tsx
@@ -6,7 +6,7 @@ import TextInput from 'components/TextInput';
 import TextArea from 'components/TextArea';
 import Button from 'components/Button';
 
-type Props = Readonly<{
+type Props = {
     onFileContentLoaded: (fileContent: string) => void;
     onContentChange?: () => void;
     id?: string;
@@ -18,7 +18,7 @@ type Props = Readonly<{
     error?: string;
     contentPlaceholderText?: string;
     dropZoneHintText?: string;
-}>;
+};
 
 export default function FileUpload({
     id = '',
@@ -32,7 +32,7 @@ export default function FileUpload({
     error,
     contentPlaceholderText,
     dropZoneHintText,
-}: Props) {
+}: Readonly<Props>) {
     const [fileContent, setFileContent] = useState('');
     const fileContentRef = useRef('');
     const [fileName, setFileName] = useState('');

--- a/src/components/Input/HostnameListInput/index.tsx
+++ b/src/components/Input/HostnameListInput/index.tsx
@@ -22,7 +22,7 @@ export default function HostnameListInput({
     addLabel = 'Add',
     validateValue,
     invalid = false,
-}: Props) {
+}: Readonly<Props>) {
     const [draft, setDraft] = useState('');
     const [draftError, setDraftError] = useState<string | undefined>(undefined);
 

--- a/src/components/Input/MultipleValueTextInput/index.tsx
+++ b/src/components/Input/MultipleValueTextInput/index.tsx
@@ -7,7 +7,7 @@ interface OptionType {
     label: string;
 }
 
-type Props = Readonly<{
+type Props = {
     id?: string;
     selectedValues: string[];
     onValuesChange: (values: string[]) => void;
@@ -16,7 +16,7 @@ type Props = Readonly<{
     initialOptions?: OptionType[];
     options?: OptionType[];
     setOptions?: (options: OptionType[]) => void;
-}>;
+};
 
 export default function MultipleValueTextInput({
     id,
@@ -27,7 +27,7 @@ export default function MultipleValueTextInput({
     initialOptions = [],
     options: externalOptions,
     setOptions: externalSetOptions,
-}: Props) {
+}: Readonly<Props>) {
     const [newValue, setNewValue] = useState<string>('');
     const [internalOptions, setInternalOptions] = useState<OptionType[]>(initialOptions);
 

--- a/src/components/JsonViewer/index.tsx
+++ b/src/components/JsonViewer/index.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
 import cn from 'classnames';
 
-type Props = Readonly<{
+type Props = {
     value: string;
     height?: number | string;
     className?: string;
     paddingTop?: number;
-}>;
+};
 
 const STRING_CHAR = String.raw`\\u[\da-fA-F]{4}|\\[^u]|[^\\"]`;
 const JSON_STRING = `"(?:${STRING_CHAR})*"`;
@@ -65,7 +65,7 @@ const highlightJson = (source: string): string => {
     return result;
 };
 
-export default function JsonViewer({ value, height, className, paddingTop }: Props) {
+export default function JsonViewer({ value, height, className, paddingTop }: Readonly<Props>) {
     const normalizedJson = useMemo(() => {
         if (!value) return '';
 

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -3,7 +3,7 @@ import cn from 'classnames';
 export type SingleValue<T> = T | undefined;
 export type MultiValue<T> = T[] | undefined;
 
-type Props = Readonly<{
+type Props = {
     htmlFor?: string;
     title?: string;
     children?: React.ReactNode;
@@ -11,9 +11,9 @@ type Props = Readonly<{
     className?: string;
     onClick?: () => void;
     dataTestId?: string;
-}>;
+};
 
-function Label({ htmlFor, title, children, required, className, onClick, dataTestId }: Props) {
+function Label({ htmlFor, title, children, required, className, onClick, dataTestId }: Readonly<Props>) {
     const defaultClasses = 'block text-left text-sm font-medium mb-2 text-center dark:text-white text-[var(--dark-gray-color)]';
     if (onClick) {
         return (

--- a/src/components/Layout/Footer/FooterWithStore.tsx
+++ b/src/components/Layout/Footer/FooterWithStore.tsx
@@ -4,9 +4,9 @@ import { MemoryRouter } from 'react-router';
 import { createMockStore } from 'utils/test-helpers';
 import Footer from './index';
 
-export type FooterWithStoreProps = Readonly<React.ComponentProps<typeof Footer>>;
+export type FooterWithStoreProps = React.ComponentProps<typeof Footer>;
 
-export default function FooterWithStore(props: FooterWithStoreProps) {
+export default function FooterWithStore(props: Readonly<FooterWithStoreProps>) {
     const store = createMockStore();
     return (
         <Provider store={store}>

--- a/src/components/Layout/Footer/index.tsx
+++ b/src/components/Layout/Footer/index.tsx
@@ -2,11 +2,11 @@ import cn from 'classnames';
 
 import PlatformInfoDialogButton from 'components/Layout/PlatformInfoDialogButton';
 
-type Props = Readonly<{
+type Props = {
     className?: string;
-}>;
+};
 
-function Footer({ className }: Props) {
+function Footer({ className }: Readonly<Props>) {
     return (
         <footer className={cn('py-4 pt-12', className)} data-testid="footer">
             <div className="text-sm font-semibold">

--- a/src/components/Layout/Header/HeaderWithStore.tsx
+++ b/src/components/Layout/Header/HeaderWithStore.tsx
@@ -4,9 +4,9 @@ import { MemoryRouter } from 'react-router';
 import { createMockStore } from 'utils/test-helpers';
 import Header from './index';
 
-export type HeaderWithStoreProps = Readonly<React.ComponentProps<typeof Header>>;
+export type HeaderWithStoreProps = React.ComponentProps<typeof Header>;
 
-export default function HeaderWithStore(props: HeaderWithStoreProps) {
+export default function HeaderWithStore(props: Readonly<HeaderWithStoreProps>) {
     const store = createMockStore();
     return (
         <Provider store={store}>

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -8,11 +8,11 @@ import { selectors } from 'ducks/auth';
 
 import logo from '../../../resources/images/ot-logo-white.svg';
 
-type Props = Readonly<{
+type Props = {
     sidebarToggle: () => void;
-}>;
+};
 
-function Header({ sidebarToggle }: Props) {
+function Header({ sidebarToggle }: Readonly<Props>) {
     const profile = useSelector(selectors.profile);
     const navigate = useNavigate();
 

--- a/src/components/Layout/PlatformInfoDialogButton/PlatformInfoDialogButtonWithStore.tsx
+++ b/src/components/Layout/PlatformInfoDialogButton/PlatformInfoDialogButtonWithStore.tsx
@@ -16,17 +16,17 @@ const defaultPreloadedState = {
     },
 };
 
-export type PlatformInfoDialogButtonWithStoreProps = Readonly<{
+export type PlatformInfoDialogButtonWithStoreProps = {
     preloadedState?: Parameters<typeof createMockStore>[0];
     initiallyOpen?: boolean;
     forceOpen?: boolean;
-}>;
+};
 
 export default function PlatformInfoDialogButtonWithStore({
     preloadedState,
     initiallyOpen = false,
     forceOpen,
-}: PlatformInfoDialogButtonWithStoreProps) {
+}: Readonly<PlatformInfoDialogButtonWithStoreProps>) {
     const store = useMemo(() => createMockStore(preloadedState ?? defaultPreloadedState), [preloadedState]);
 
     return (

--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -388,10 +388,10 @@ function getAllowedMenuItems(allowedResources?: Resource[]): MenuItemMapping[] {
     return allowedLinks;
 }
 
-type Props = Readonly<{
+type Props = {
     allowedResources?: Resource[];
-}>;
-export default function Sidebar({ allowedResources }: Props) {
+};
+export default function Sidebar({ allowedResources }: Readonly<Props>) {
     const [defaultMenuSize, setDefaultMenuSize] = useLocalStorage<'small' | 'large'>('menu-size', 'small');
     const [menuSize, setMenuSize] = useState<'small' | 'large' | 'flying'>(defaultMenuSize);
     const location = useLocation();

--- a/src/components/Layout/TabLayout/TabLayoutSkeleton.tsx
+++ b/src/components/Layout/TabLayout/TabLayoutSkeleton.tsx
@@ -4,16 +4,23 @@ import TableSkeleton from 'components/CustomTable/TableSkeleton';
 const barClass = 'rounded bg-gray-200 dark:bg-neutral-700';
 const tabWidths = ['w-16', 'w-20', 'w-24', 'w-14', 'w-20'];
 
-type Props = Readonly<{
+type Props = {
     tabCount?: number;
     columnsCount?: number;
     noBorder?: boolean;
     hasPagination?: boolean;
     rowCount?: number;
     buttonsCount?: number;
-}>;
+};
 
-function TabLayoutSkeleton({ tabCount = 2, columnsCount = 4, noBorder = false, hasPagination = true, rowCount, buttonsCount = 0 }: Props) {
+function TabLayoutSkeleton({
+    tabCount = 2,
+    columnsCount = 4,
+    noBorder = false,
+    hasPagination = true,
+    rowCount,
+    buttonsCount = 0,
+}: Readonly<Props>) {
     return (
         <Widget noBorder={noBorder} dataTestId="tab-layout-skeleton">
             {buttonsCount > 0 && (

--- a/src/components/Layout/TabLayout/TabLayoutWithStore.tsx
+++ b/src/components/Layout/TabLayout/TabLayoutWithStore.tsx
@@ -4,9 +4,9 @@ import { MemoryRouter } from 'react-router';
 import { createMockStore } from 'utils/test-helpers';
 import TabLayout from './index';
 
-export type TabLayoutWithStoreProps = Readonly<React.ComponentProps<typeof TabLayout>>;
+export type TabLayoutWithStoreProps = React.ComponentProps<typeof TabLayout>;
 
-export default function TabLayoutWithStore(props: TabLayoutWithStoreProps) {
+export default function TabLayoutWithStore(props: Readonly<TabLayoutWithStoreProps>) {
     const store = createMockStore();
     return (
         <Provider store={store}>

--- a/src/components/Layout/TabLayout/index.tsx
+++ b/src/components/Layout/TabLayout/index.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState, useEffect } from 'react';
 import Widget from 'components/Widget';
 import TabLayoutSkeleton from './TabLayoutSkeleton';
 
-type Props = Readonly<{
+type Props = {
     tabs: {
         title: string | React.ReactNode;
         hidden?: boolean;
@@ -16,7 +16,7 @@ type Props = Readonly<{
     noBorder?: boolean;
     onTabChange?: (tab: number) => void;
     isLoading?: boolean;
-}>;
+};
 
 export default function TabLayout({
     tabs,
@@ -25,7 +25,7 @@ export default function TabLayout({
     noBorder = false,
     onTabChange,
     isLoading = false,
-}: Props) {
+}: Readonly<Props>) {
     const [activeTab, setActiveTab] = useState(selectedTab ?? 0);
 
     const memoizedTabs = useMemo(() => {

--- a/src/components/NumberInput/index.tsx
+++ b/src/components/NumberInput/index.tsx
@@ -1,6 +1,6 @@
 import { Minus, Plus } from 'lucide-react';
 
-type Props = Readonly<{
+type Props = {
     value: number;
     onChange: (value: number) => void;
     min?: number;
@@ -8,9 +8,9 @@ type Props = Readonly<{
     step?: number;
     disabled?: boolean;
     zeroPad?: boolean;
-}>;
+};
 
-export default function NumberInput({ value, onChange, min = 0, max = 999, step = 1, disabled = false, zeroPad = false }: Props) {
+export default function NumberInput({ value, onChange, min = 0, max = 999, step = 1, disabled = false, zeroPad = false }: Readonly<Props>) {
     const decrement = () => onChange(Math.max(min, value - step));
     const increment = () => onChange(Math.min(max, value + step));
 

--- a/src/components/PagedList/PagedList.tsx
+++ b/src/components/PagedList/PagedList.tsx
@@ -16,7 +16,7 @@ import type { Observable } from 'rxjs';
 import type { SearchFieldListModel, SearchFilterModel, SearchRequestModel } from 'types/certificate';
 import type { LockWidgetNameEnum } from 'types/user-interface';
 
-type Props = Readonly<{
+type Props = {
     entity: EntityType;
     headers: TableHeader[];
     data: TableDataRow[];
@@ -37,7 +37,7 @@ type Props = Readonly<{
     hasDetails?: boolean;
     columnForDetail?: string;
     extraFilterComponent?: React.ReactNode;
-}>;
+};
 
 function PagedList({
     headers,
@@ -60,7 +60,7 @@ function PagedList({
     hasDetails = false,
     columnForDetail,
     extraFilterComponent,
-}: Props) {
+}: Readonly<Props>) {
     const dispatch = useDispatch();
     const navigate = useNavigate();
 

--- a/src/components/PagedList/PagedListSkeleton.tsx
+++ b/src/components/PagedList/PagedListSkeleton.tsx
@@ -5,14 +5,14 @@ const barClass = 'rounded bg-gray-200 dark:bg-neutral-700';
 const cardClass =
     'relative flex flex-col rounded-xl border border-gray-200 dark:border-neutral-700 p-4 md:p-5 shadow-2xs bg-white dark:bg-neutral-900 w-full';
 
-type Props = Readonly<{
+type Props = {
     hasFilter?: boolean;
     filterTitle?: string;
     buttonsCount?: number;
     columnsCount?: number;
     hasCheckboxes?: boolean;
     hasExtraFilter?: boolean;
-}>;
+};
 
 function PagedListSkeleton({
     hasFilter = false,
@@ -21,7 +21,7 @@ function PagedListSkeleton({
     columnsCount = 4,
     hasCheckboxes = true,
     hasExtraFilter = false,
-}: Props) {
+}: Readonly<Props>) {
     return (
         <div className="flex flex-col gap-4 md:gap-8" data-testid="paged-list-skeleton">
             {hasFilter && <FilterWidgetSkeleton title={filterTitle} dataTestId="filter-widget-skeleton" hasExtraFilter={hasExtraFilter} />}

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,12 +1,12 @@
-type Props = Readonly<{
+type Props = {
     page: number;
     totalPages: number;
     onPageChange: (page: number) => void;
     dataTestId?: string;
     disabled?: boolean;
-}>;
+};
 
-function Pagination({ page, totalPages, onPageChange, dataTestId, disabled = false }: Props) {
+function Pagination({ page, totalPages, onPageChange, dataTestId, disabled = false }: Readonly<Props>) {
     const getPageNumbers = () => {
         const pages: (number | 'ellipsis')[] = [];
         const maxPagesToShow = 7; // Max page buttons to show

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -2,14 +2,14 @@ import { type ReactNode, useEffect, useRef } from 'react';
 
 export type PopoverPlacement = 'top' | 'bottom' | 'left' | 'right' | 'auto';
 
-type Props = Readonly<{
+type Props = {
     content: string | ReactNode;
     children: ReactNode;
     title?: string;
     width?: number;
-}>;
+};
 
-function Popover({ content, children, title, width = 300 }: Props) {
+function Popover({ content, children, title, width = 300 }: Readonly<Props>) {
     const contentRef = useRef<HTMLDivElement>(null);
     const toggleRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/ProgressButton/index.tsx
+++ b/src/components/ProgressButton/index.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames';
 import Button, { type ButtonColor } from 'components/Button';
 import Spinner from 'components/Spinner';
 
-type Props = Readonly<{
+type Props = {
     disabled?: boolean;
     inProgress: boolean | undefined;
     title: string;
@@ -12,7 +12,7 @@ type Props = Readonly<{
     type?: 'submit' | 'reset' | 'button';
     onClick?: () => void;
     dataTestId?: string;
-}>;
+};
 
 function ProgressButton({
     inProgress,
@@ -23,7 +23,7 @@ function ProgressButton({
     type = 'submit',
     onClick,
     dataTestId,
-}: Props) {
+}: Readonly<Props>) {
     const buttonProps = {
         color,
         disabled: disabled || inProgress,

--- a/src/components/RadioRow/index.tsx
+++ b/src/components/RadioRow/index.tsx
@@ -1,13 +1,13 @@
 import cn from 'classnames';
 
-type Props = Readonly<{
+type Props = {
     checked: boolean;
     onSelect: () => void;
     children: React.ReactNode;
     maxWidth?: number;
-}>;
+};
 
-export default function RadioRow({ checked, onSelect, children, maxWidth }: Props) {
+export default function RadioRow({ checked, onSelect, children, maxWidth }: Readonly<Props>) {
     return (
         <div style={{ maxWidth: maxWidth ?? '100%' }} className="mx-auto w-full">
             <label

--- a/src/components/Select/SelectHSCoverageHarness.tsx
+++ b/src/components/Select/SelectHSCoverageHarness.tsx
@@ -87,7 +87,7 @@ export function SelectTooltipSyncHarness() {
 // --------------------------------------------------------------------------------------------------------------
 type LateOptionsCapture = string | string[];
 
-type LateOptionsHarnessProps = Readonly<{
+type LateOptionsHarnessProps = {
     mode: 'single' | 'multi';
     id: string;
     stateKey: string;
@@ -95,7 +95,7 @@ type LateOptionsHarnessProps = Readonly<{
     loadOptions: { value: string; label: string }[];
     initialSingleValue?: string;
     initialMultiValue?: { value: string; label: string }[];
-}>;
+};
 
 export function SelectLateOptionsHarness({
     mode,
@@ -105,7 +105,7 @@ export function SelectLateOptionsHarness({
     loadOptions,
     initialSingleValue,
     initialMultiValue,
-}: LateOptionsHarnessProps) {
+}: Readonly<LateOptionsHarnessProps>) {
     const [options, setOptions] = useState<{ value: string; label: string }[]>([]);
 
     useLayoutEffect(() => {

--- a/src/components/SimpleBar/index.tsx
+++ b/src/components/SimpleBar/index.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useRef, useCallback } from 'react';
 import SimpleBarOriginal from 'simplebar-react';
 
-type Props = Readonly<
-    React.ComponentProps<typeof SimpleBarOriginal> & {
-        children: React.ReactNode;
-    }
->;
+type Props = React.ComponentProps<typeof SimpleBarOriginal> & {
+    children: React.ReactNode;
+};
 
-function SimpleBar({ children, ...props }: Props) {
+function SimpleBar({ children, ...props }: Readonly<Props>) {
     const simpleBarRef = useRef<any>(null);
     const containerRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -1,12 +1,12 @@
 import cn from 'classnames';
-type Props = Readonly<{
+type Props = {
     active?: boolean;
     color?: 'light' | 'primary';
     size?: 'sm' | 'md' | 'lg' | 'xl';
     dataTestId?: string;
-}>;
+};
 
-function Spinner({ active = true, color = 'primary', size = 'md', dataTestId }: Props) {
+function Spinner({ active = true, color = 'primary', size = 'md', dataTestId }: Readonly<Props>) {
     if (!active) return null;
 
     return (

--- a/src/components/StatusCircle/index.tsx
+++ b/src/components/StatusCircle/index.tsx
@@ -1,11 +1,11 @@
 import Badge from 'components/Badge';
 import { Check, HelpCircle, X } from 'lucide-react';
 
-type Props = Readonly<{
+type Props = {
     status?: boolean;
-}>;
+};
 
-function StatusCircle({ status }: Props) {
+function StatusCircle({ status }: Readonly<Props>) {
     switch (status) {
         case true:
             return (

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames';
 import { X, Check } from 'lucide-react';
 import Label from 'components/Label';
 
-type Props = Readonly<{
+type Props = {
     checked: boolean | undefined;
     onChange: (checked: boolean) => void;
     placeholder?: string;
@@ -13,9 +13,19 @@ type Props = Readonly<{
     className?: string;
     labelClassName?: string;
     dataTestId?: string;
-}>;
+};
 
-function Switch({ checked, onChange, id, label, secondaryLabel, disabled = false, className, labelClassName, dataTestId }: Props) {
+function Switch({
+    checked,
+    onChange,
+    id,
+    label,
+    secondaryLabel,
+    disabled = false,
+    className,
+    labelClassName,
+    dataTestId,
+}: Readonly<Props>) {
     return (
         <div className={cn('flex items-center gap-x-3', className)} data-testid={dataTestId ?? `switch-${id}`}>
             {label && (

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,16 +1,16 @@
 import cn from 'classnames';
 import SimpleBar from 'simplebar-react';
 
-type Props = Readonly<{
+type Props = {
     tabs: {
         title: React.ReactNode;
         onClick?: () => void;
     }[];
     selectedTab: number;
     onTabChange: (tab: number) => void;
-}>;
+};
 
-function Tabs({ tabs, selectedTab, onTabChange }: Props) {
+function Tabs({ tabs, selectedTab, onTabChange }: Readonly<Props>) {
     return (
         <SimpleBar forceVisible="x">
             <div className="flex gap-x-1" role="tablist" aria-label="Tabs" aria-orientation="horizontal">

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames';
 import Label from 'components/Label';
 
-type Props = Readonly<{
+type Props = {
     value?: string;
     onChange: (value: string) => void;
     onBlur?: () => void;
@@ -14,7 +14,7 @@ type Props = Readonly<{
     className?: string;
     required?: boolean;
     rows?: number;
-}>;
+};
 
 function TextArea({
     value,
@@ -29,7 +29,7 @@ function TextArea({
     className,
     required = false,
     rows = 3,
-}: Props) {
+}: Readonly<Props>) {
     return (
         <>
             {label && (

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -8,7 +8,7 @@ import { inputBaseClassName } from './inputStyles';
 
 export { inputBaseClassName } from './inputStyles';
 
-type Props = Readonly<{
+type Props = {
     value?: string;
     onChange: (value: string) => void;
     onBlur?: () => void;
@@ -23,7 +23,7 @@ type Props = Readonly<{
     required?: boolean;
     buttonRight?: ReactNode;
     dataTestId?: string;
-}>;
+};
 
 function TextInput({
     value,
@@ -40,7 +40,7 @@ function TextInput({
     required = false,
     buttonRight,
     dataTestId,
-}: Props) {
+}: Readonly<Props>) {
     const inputRef = useRef<HTMLInputElement>(null);
     const generatedId = useId();
     const [passwordVisible, setPasswordVisible] = useState(false);

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 
 export type TooltipPlacement = 'bottom';
 
-type Props = Readonly<{
+type Props = {
     content: string | ReactNode;
     placement?: TooltipPlacement;
     children: ReactNode;
@@ -11,9 +11,17 @@ type Props = Readonly<{
     triggerClassName?: string;
     contentClassName?: string;
     disabled?: boolean;
-}>;
+};
 
-function Tooltip({ content, placement = 'bottom', children, className, triggerClassName, contentClassName, disabled = false }: Props) {
+function Tooltip({
+    content,
+    placement = 'bottom',
+    children,
+    className,
+    triggerClassName,
+    contentClassName,
+    disabled = false,
+}: Readonly<Props>) {
     const getArrowClasses = () => {
         const baseClasses = 'absolute w-0 h-0 border-4';
         if (placement === 'bottom') {

--- a/src/components/TriggerEditorWidget/index.tsx
+++ b/src/components/TriggerEditorWidget/index.tsx
@@ -18,15 +18,15 @@ type OptionType = {
     value: string;
 };
 
-type Props = Readonly<{
+type Props = {
     resource?: Resource;
     event?: ResourceEvent;
     selectedTriggers: string[];
     onSelectedTriggersChange: (triggerUuids: string[]) => void;
     noteText?: string;
-}>;
+};
 
-export default function TriggerEditorWidget({ resource, event, selectedTriggers, onSelectedTriggersChange, noteText }: Props) {
+export default function TriggerEditorWidget({ resource, event, selectedTriggers, onSelectedTriggersChange, noteText }: Readonly<Props>) {
     const dispatch = useDispatch();
 
     const triggers = useSelector(rulesSelectors.triggers);

--- a/src/components/Widget/WidgetWithStore.tsx
+++ b/src/components/Widget/WidgetWithStore.tsx
@@ -5,7 +5,7 @@ import { createMockStore } from 'utils/test-helpers';
 import Widget from './index';
 import { LockWidgetNameEnum, LockTypeEnum, type WidgetLockModel } from 'types/user-interface';
 
-export type WidgetWithStoreProps = Readonly<{
+export type WidgetWithStoreProps = {
     preloadedState?: Parameters<typeof createMockStore>[0];
     title?: string;
     titleLink?: string;
@@ -13,7 +13,7 @@ export type WidgetWithStoreProps = Readonly<{
     children?: React.ReactNode;
     widgetLockName?: LockWidgetNameEnum;
     refreshAction?: () => void;
-}>;
+};
 
 const defaultPreloadedState: Parameters<typeof createMockStore>[0] = {
     userInterface: {
@@ -51,7 +51,7 @@ function WidgetWithStore({
     children,
     widgetLockName,
     refreshAction,
-}: WidgetWithStoreProps) {
+}: Readonly<WidgetWithStoreProps>) {
     const store = createMockStore(preloadedState ?? defaultPreloadedState);
     return (
         <Provider store={store}>

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -19,7 +19,7 @@ interface WidgetInfoCard {
     notesList?: string[];
 }
 
-type Props = Readonly<{
+type Props = {
     id?: string;
     title?: string;
     titleLink?: string;
@@ -40,7 +40,7 @@ type Props = Readonly<{
     dataTestId?: string;
     noBorder?: boolean;
     enableBusyOverlay?: boolean;
-}>;
+};
 
 function Widget({
     id,
@@ -63,7 +63,7 @@ function Widget({
     dataTestId,
     noBorder = false,
     enableBusyOverlay = false,
-}: Props) {
+}: Readonly<Props>) {
     const widgetLocks = useSelector(selectors.selectWidgetLocks) || [];
     const widgetLock = widgetLocks.find(
         (lock) => lock.widgetName === widgetLockName || (Array.isArray(widgetLockName) && widgetLockName.includes(lock.widgetName)),

--- a/src/components/WidgetButtons/index.tsx
+++ b/src/components/WidgetButtons/index.tsx
@@ -15,13 +15,13 @@ export interface WidgetButtonProps {
     className?: string;
 }
 
-type Props = Readonly<{
+type Props = {
     buttons: WidgetButtonProps[];
     justify?: 'start' | 'end' | 'center';
     className?: string;
-}>;
+};
 
-function WidgetButtons({ buttons, justify = 'center', className }: Props) {
+function WidgetButtons({ buttons, justify = 'center', className }: Readonly<Props>) {
     return (
         <div
             className={cn(

--- a/src/components/_pages/acme-profiles/form/index.tsx
+++ b/src/components/_pages/acme-profiles/form/index.tsx
@@ -39,11 +39,11 @@ import CertificateAssociationsFormWidget from 'components/CertificateAssociation
 import { collectFormAttributes, transformAttributes, mapProfileAttribute } from 'utils/attributes/attributes';
 import { deepEqual } from 'utils/deep-equal';
 
-type AcmeProfileFormProps = Readonly<{
+type AcmeProfileFormProps = {
     acmeProfileId?: string;
     onCancel?: () => void;
     onSuccess?: () => void;
-}>;
+};
 
 interface FormValues {
     name: string;
@@ -64,7 +64,7 @@ interface FormValues {
     deletedAttributes: string[];
 }
 
-export default function AcmeProfileForm({ acmeProfileId, onCancel, onSuccess }: AcmeProfileFormProps) {
+export default function AcmeProfileForm({ acmeProfileId, onCancel, onSuccess }: Readonly<AcmeProfileFormProps>) {
     const dispatch = useDispatch();
 
     const { id: routeId } = useParams();

--- a/src/components/_pages/approval-profiles/form/approval-step-field.tsx
+++ b/src/components/_pages/approval-profiles/form/approval-step-field.tsx
@@ -14,11 +14,11 @@ import { validateLength, validateNonZeroInteger, validatePositiveInteger, valida
 import { buildValidationRules, getFieldErrorMessage } from 'utils/validators-helper';
 import { Plus, X } from 'lucide-react';
 
-type Props = Readonly<{
+type Props = {
     approvalSteps: ApprovalStepRequestModel[];
     inProgress: boolean;
     onCancelClick: () => void;
-}>;
+};
 
 type SelectOptionApprover = { label: string; value: string } | null;
 type SelectOptionApproverType = { label: string; value: string };
@@ -28,7 +28,7 @@ const approverTypeOptions = Object.values(ApproverType).map((type) => ({
     label: type,
 }));
 
-export default function ApprovalStepField({ approvalSteps }: Props) {
+export default function ApprovalStepField({ approvalSteps }: Readonly<Props>) {
     const { control, setValue } = useFormContext<ProfileApprovalRequestModel>();
     const [selectedApprovalTypeList, setselectedApprovalTypeList] = useState<SelectOptionApproverType[] | undefined>(undefined);
     const [selectedApproverList, setSelectedApproverList] = useState<SelectOptionApprover[]>([]);

--- a/src/components/_pages/approval-profiles/form/index.tsx
+++ b/src/components/_pages/approval-profiles/form/index.tsx
@@ -29,13 +29,13 @@ const defaultApprovalSteps: ApprovalStepRequestModel[] = [
     },
 ];
 
-type ApprovalProfileFormProps = Readonly<{
+type ApprovalProfileFormProps = {
     approvalProfileId?: string;
     onCancel?: () => void;
     onSuccess?: () => void;
-}>;
+};
 
-function ApprovalProfileForm({ approvalProfileId, onCancel, onSuccess }: ApprovalProfileFormProps) {
+function ApprovalProfileForm({ approvalProfileId, onCancel, onSuccess }: Readonly<ApprovalProfileFormProps>) {
     const dispatch = useDispatch();
 
     const isCreating = useSelector(profileApprovalSelectors.isCreating);

--- a/src/components/_pages/auditLogs/ObjectValues/index.tsx
+++ b/src/components/_pages/auditLogs/ObjectValues/index.tsx
@@ -1,9 +1,9 @@
-type Props = Readonly<{
+type Props = {
     className?: string;
     obj: any;
-}>;
+};
 
-function ObjectValues({ className, obj }: Props) {
+function ObjectValues({ className, obj }: Readonly<Props>) {
     if (!obj) return null;
 
     if (typeof obj !== 'object') return obj;

--- a/src/components/_pages/auth-settings/form/index.tsx
+++ b/src/components/_pages/auth-settings/form/index.tsx
@@ -17,11 +17,11 @@ import { buildValidationRules, getFieldErrorMessage } from 'utils/validators-hel
 import type { OAuth2ProviderSettingsUpdateDto } from 'types/auth-settings';
 import { isValidJWTBearerProvider, isValidOAuth2FlowProvider } from 'utils/oauth2Providers';
 
-type OAuth2ProviderFormProps = Readonly<{
+type OAuth2ProviderFormProps = {
     providerName?: string;
     onCancel: () => void;
     onSuccess?: () => void;
-}>;
+};
 
 enum AuthenticationScheme {
     JwtBearer = 'JwtBearer',
@@ -62,7 +62,7 @@ interface FormValues {
     sessionMaxInactiveInterval: string;
 }
 
-export default function OAuth2ProviderForm({ providerName, onCancel, onSuccess }: OAuth2ProviderFormProps) {
+export default function OAuth2ProviderForm({ providerName, onCancel, onSuccess }: Readonly<OAuth2ProviderFormProps>) {
     const editMode = providerName !== undefined;
 
     const dispatch = useDispatch();

--- a/src/components/_pages/authorities/form/index.tsx
+++ b/src/components/_pages/authorities/form/index.tsx
@@ -30,11 +30,11 @@ import { collectFormAttributes } from 'utils/attributes/attributes';
 import { validateAlphaNumericWithSpecialChars, validateRequired } from 'utils/validators';
 import { buildValidationRules, getFieldErrorMessage } from 'utils/validators-helper';
 
-type AuthorityFormProps = Readonly<{
+type AuthorityFormProps = {
     authorityId?: string;
     onCancel?: () => void;
     onSuccess?: () => void;
-}>;
+};
 
 interface FormValues {
     name: string;
@@ -42,7 +42,7 @@ interface FormValues {
     storeKind: string;
 }
 
-export default function AuthorityForm({ authorityId, onCancel, onSuccess }: AuthorityFormProps) {
+export default function AuthorityForm({ authorityId, onCancel, onSuccess }: Readonly<AuthorityFormProps>) {
     const dispatch = useDispatch();
     const navigate = useNavigate();
 

--- a/src/components/_pages/cboms/CbomUploadDialog/index.tsx
+++ b/src/components/_pages/cboms/CbomUploadDialog/index.tsx
@@ -8,15 +8,15 @@ import ProgressButton from 'components/ProgressButton';
 import { actions as alertActions } from 'ducks/alerts';
 import { selectors as cbomSelectors } from 'ducks/cbom';
 
-type Props = Readonly<{
+type Props = {
     onCancel: () => void;
     onUpload: (data: { content: any }) => void;
     okButtonTitle?: string;
-}>;
+};
 
 type FormValues = Record<string, never>;
 
-export default function CbomUploadDialog({ onCancel, onUpload, okButtonTitle = 'Upload' }: Props) {
+export default function CbomUploadDialog({ onCancel, onUpload, okButtonTitle = 'Upload' }: Readonly<Props>) {
     const dispatch = useDispatch();
     const [fileContent, setFileContent] = useState<string>('');
 

--- a/src/components/_pages/certificates/Asn1Dialog/Asn1Dialog.tsx
+++ b/src/components/_pages/certificates/Asn1Dialog/Asn1Dialog.tsx
@@ -14,12 +14,12 @@ import { transformParseRequestResponseDtoToCertificateResponseDetailModelToAsn1S
 import { ParseCertificateRequestDtoParseTypeEnum, ParseRequestRequestDtoParseTypeEnum } from '../../../../types/openapi/utils';
 import { actions as userInterfaceActions } from 'ducks/user-interface';
 
-type Props = Readonly<{
+type Props = {
     content: string;
     isCSR?: boolean;
-}>;
+};
 
-export default function Asn1Dialog({ content, isCSR }: Props) {
+export default function Asn1Dialog({ content, isCSR }: Readonly<Props>) {
     const dispatch = useDispatch();
     const parsedCertificate = useSelector(utilsCertificateSelectors.parsedCertificate);
     const parsedCertificateRequest = useSelector(utilsCertificateRequestSelectors.parsedCertificateRequest);

--- a/src/components/_pages/certificates/CertificateGroupDialog/index.tsx
+++ b/src/components/_pages/certificates/CertificateGroupDialog/index.tsx
@@ -10,18 +10,18 @@ import Spinner from 'components/Spinner';
 import Button from 'components/Button';
 import Container from 'components/Container';
 
-type Props = Readonly<{
+type Props = {
     uuids: string[];
     onCancel: () => void;
     onUpdate: () => void;
-}>;
+};
 
 interface SelectChangeValue {
     value: string;
     label: string;
 }
 
-export default function CertificateGroupDialog({ uuids, onCancel, onUpdate }: Props) {
+export default function CertificateGroupDialog({ uuids, onCancel, onUpdate }: Readonly<Props>) {
     const dispatch = useDispatch();
 
     const groups = useSelector(groupsSelectors.certificateGroups);

--- a/src/components/_pages/certificates/CertificateOwnerDialog/index.tsx
+++ b/src/components/_pages/certificates/CertificateOwnerDialog/index.tsx
@@ -8,14 +8,14 @@ import Button from 'components/Button';
 import type { UserResponseModel } from 'types/users';
 import Container from 'components/Container';
 
-type Props = Readonly<{
+type Props = {
     uuids: string[];
     users: UserResponseModel[];
     onCancel: () => void;
     onUpdate: () => void;
-}>;
+};
 
-export default function CertificateOwnerDialog({ uuids, onCancel, onUpdate, users }: Props) {
+export default function CertificateOwnerDialog({ uuids, onCancel, onUpdate, users }: Readonly<Props>) {
     const dispatch = useDispatch();
 
     const [ownerUuid, setOwnerUuid] = useState<string>();

--- a/src/components/_pages/certificates/CertificateRAProfileDialog/index.tsx
+++ b/src/components/_pages/certificates/CertificateRAProfileDialog/index.tsx
@@ -10,13 +10,13 @@ import Spinner from 'components/Spinner';
 import Button from 'components/Button';
 import Container from 'components/Container';
 
-type Props = Readonly<{
+type Props = {
     uuids: string[];
     onCancel: () => void;
     onUpdate: () => void;
-}>;
+};
 
-export default function CertificateGroupDialog({ uuids, onCancel, onUpdate }: Props) {
+export default function CertificateGroupDialog({ uuids, onCancel, onUpdate }: Readonly<Props>) {
     const dispatch = useDispatch();
 
     const raProfiles = useSelector(raProfileSelectors.raProfiles);

--- a/src/components/_pages/certificates/CertificateRekeyDialog/index.tsx
+++ b/src/components/_pages/certificates/CertificateRekeyDialog/index.tsx
@@ -47,12 +47,12 @@ interface FormValues {
     altKey?: CryptographicKeyPairResponseModel;
 }
 
-type props = Readonly<{
+type props = {
     onCancel: () => void;
     certificate?: CertificateDetailResponseModel;
-}>;
+};
 
-export default function CertificateRekeyDialog({ onCancel, certificate }: props) {
+export default function CertificateRekeyDialog({ onCancel, certificate }: Readonly<props>) {
     const dispatch = useDispatch();
 
     const isFetchingCsrAttributes = useSelector(certificateSelectors.isFetchingIssuanceAttributes);

--- a/src/components/_pages/certificates/CertificateRenewDialog/index.tsx
+++ b/src/components/_pages/certificates/CertificateRenewDialog/index.tsx
@@ -14,13 +14,13 @@ import Button from 'components/Button';
 import Container from 'components/Container';
 import Switch from 'components/Switch';
 
-type Props = Readonly<{
+type Props = {
     onCancel: () => void;
     allowWithoutFile: boolean;
     onRenew: (data: { fileContent?: string }) => void;
-}>;
+};
 
-export default function CertificateRenewDialog({ onCancel, allowWithoutFile, onRenew }: Props) {
+export default function CertificateRenewDialog({ onCancel, allowWithoutFile, onRenew }: Readonly<Props>) {
     const dispatch = useDispatch();
 
     const [fileContent, setFileContent] = useState<string | undefined>();

--- a/src/components/_pages/certificates/CertificateUploadDialog/index.tsx
+++ b/src/components/_pages/certificates/CertificateUploadDialog/index.tsx
@@ -20,7 +20,7 @@ import Container from 'components/Container';
 
 type FormValues = Record<string, never>;
 
-type Props = Readonly<{
+type Props = {
     onCancel: () => void;
     onUpload: (data: {
         fileContent: string;
@@ -29,9 +29,14 @@ type Props = Readonly<{
     }) => void;
     okButtonTitle?: string;
     showCustomAttributes?: boolean;
-}>;
+};
 
-export default function CertificateUploadDialog({ onCancel, onUpload, okButtonTitle = 'Upload', showCustomAttributes = true }: Props) {
+export default function CertificateUploadDialog({
+    onCancel,
+    onUpload,
+    okButtonTitle = 'Upload',
+    showCustomAttributes = true,
+}: Readonly<Props>) {
     const dispatch = useDispatch();
 
     const [certificate, setCertificate] = useState<CertificateDetailResponseModel | undefined>();

--- a/src/components/_pages/notifications/events-settings/form/index.tsx
+++ b/src/components/_pages/notifications/events-settings/form/index.tsx
@@ -1,6 +1,5 @@
 import ProgressButton from 'components/ProgressButton';
 import Widget from 'components/Widget';
-import { selectors as enumSelectors } from 'ducks/enums';
 import { actions as settingsActions, selectors as settingsSelectors } from 'ducks/settings';
 
 import { actions as resourceActions, selectors as resourceSelectors } from 'ducks/resource';
@@ -13,7 +12,7 @@ import Button from 'components/Button';
 import Container from 'components/Container';
 import Breadcrumb from 'components/Breadcrumb';
 import { useAreDefaultValuesSame } from 'utils/common-hooks';
-import { type EventSettingsDto, PlatformEnum, Resource, type ResourceEvent } from 'types/openapi';
+import { type EventSettingsDto, Resource, type ResourceEvent } from 'types/openapi';
 import { LockWidgetNameEnum } from 'types/user-interface';
 import TriggerEditorWidget from 'components/TriggerEditorWidget';
 import Label from 'components/Label';

--- a/src/components/_pages/users/detail/index.tsx
+++ b/src/components/_pages/users/detail/index.tsx
@@ -18,10 +18,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link, useParams } from 'react-router';
 import Badge from 'components/Badge';
 import { LockWidgetNameEnum } from 'types/user-interface';
-import { PlatformEnum, Resource } from '../../../../types/openapi';
+import { Resource } from '../../../../types/openapi';
 import CustomAttributeWidget from '../../../Attributes/CustomAttributeWidget';
 import { createWidgetDetailHeaders } from 'utils/widget';
-import { selectors as enumSelectors } from 'ducks/enums';
 import Breadcrumb from 'components/Breadcrumb';
 import Container from 'components/Container';
 


### PR DESCRIPTION
## Summary
- Mark React component props as `Readonly<T>` across 102 component files (S6759: 188 issues fixed; 190 → 2 open)
- Remove 4 unused imports (S1128)

Total open SonarQube maintainability issues dropped from 1350 → ~537 (biome auto-formatting cleared additional issues across S7735, S4325, S6582, S1128, etc.)

## Test plan
- [x] `npm run test:vitest` — 2207 tests pass
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run build` — production build succeeds
- [x] SonarQube re-scan confirms reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)