### PR TITLE
Fix location key detail dialog title and layout

### DIFF
--- a/src/components/CustomTable/CustomTable.spec.tsx
+++ b/src/components/CustomTable/CustomTable.spec.tsx
@@ -275,6 +275,28 @@ test.describe('CustomTable', () => {
         await expect(component.locator('table')).toBeVisible();
     });
 
+    test('should use detailTitle as modal caption instead of jsxInnerText of first column', async ({ mount }) => {
+        const store = createMockStore();
+        const dataWithDetails: TableDataRow[] = [
+            {
+                id: 1,
+                columns: [
+                    <span key="col">
+                        Complex <b>JSX</b>
+                    </span>,
+                    'detail@example.com',
+                ],
+                detailColumns: ['Detail content'],
+                detailTitle: 'Clean Title',
+            },
+        ];
+        const component = await mount(
+            withProviders(<CustomTable headers={mockHeaders} data={dataWithDetails} hasDetails={true} />, { store }),
+        );
+        await component.getByRole('button', { name: /Complex JSX/ }).click();
+        expect(store.getState().userInterface.globalModal.title).toBe('Clean Title');
+    });
+
     test('should sort by date when header has sortType date', async ({ mount }) => {
         const dateHeaders: TableHeader[] = [{ id: 'date', content: 'Date', sortable: true, sortType: 'date' }];
         const dateData: TableDataRow[] = [

--- a/src/components/CustomTable/index.tsx
+++ b/src/components/CustomTable/index.tsx
@@ -222,7 +222,8 @@ function CustomTable({
                 },
             ];
 
-            const caption = typeof row.columns[0] === 'string' ? row.columns[0] : jsxInnerText(row.columns[0] as React.ReactNode);
+            const caption =
+                row.detailTitle ?? (typeof row.columns[0] === 'string' ? row.columns[0] : jsxInnerText(row.columns[0] as React.ReactNode));
 
             dispatch(
                 userInterfaceActions.showGlobalModal({

--- a/src/components/CustomTable/types.ts
+++ b/src/components/CustomTable/types.ts
@@ -15,6 +15,7 @@ export interface TableDataRow {
     id: number | string;
     columns: (string | React.ReactNode | React.ReactNode[])[];
     detailColumns?: (string | React.ReactNode | React.ReactNode[])[];
+    detailTitle?: string;
     options?: {
         useAccentBottomBorder?: boolean;
         rowClassName?: string;

--- a/src/components/_pages/locations/detail/index.tsx
+++ b/src/components/_pages/locations/detail/index.tsx
@@ -607,6 +607,7 @@ export default function LocationDetail() {
             location
                 ? location.certificates.map((cert) => ({
                       id: cert.certificateUuid,
+                      detailTitle: cert.commonName || 'empty',
                       columns: [
                           <>
                               {cert.commonName || 'empty'}
@@ -657,16 +658,14 @@ export default function LocationDetail() {
                       ],
 
                       detailColumns: [
-                          cert.metadata?.length ? (
-                              <AttributeViewer viewerType={ATTRIBUTE_VIEWER_TYPE.METADATA_FLAT} metadata={cert.metadata} />
-                          ) : (
-                              <></>
-                          ),
-                          cert.csrAttributes?.length ? (
-                              <AttributeViewer viewerType={ATTRIBUTE_VIEWER_TYPE.ATTRIBUTE} attributes={cert.csrAttributes} />
-                          ) : (
-                              <></>
-                          ),
+                          <div key="cert-detail" className="flex flex-col gap-6">
+                              {cert.metadata?.length ? (
+                                  <AttributeViewer viewerType={ATTRIBUTE_VIEWER_TYPE.METADATA_FLAT} metadata={cert.metadata} />
+                              ) : null}
+                              {cert.csrAttributes?.length ? (
+                                  <AttributeViewer viewerType={ATTRIBUTE_VIEWER_TYPE.ATTRIBUTE} attributes={cert.csrAttributes} />
+                              ) : null}
+                          </div>,
                       ],
                   }))
                 : [],


### PR DESCRIPTION
Closes #1584

Dialog opened from location certificate row showed garbled title and the
right detail table was not visible.

- Add `detailTitle` to `TableDataRow` so rows can provide a plain-text
  title for the detail modal instead of relying on `jsxInnerText`
- Use `detailTitle` in `CustomTable` when building the modal caption
- Stack metadata and CSR attribute tables vertically in the detail view
- Allow horizontal scroll in dialog body (`overflow-auto`)
