### PR TITLE
Fix CVE-2026-9277: bump shell-quote to ^1.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10374,9 +10374,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "overrides": {
         "typescript": "$typescript",
         "nodemailer": "^8.0.5",
+        "shell-quote": "^1.8.4",
         "nyc": {
             "istanbul-lib-processinfo": {
                 "uuid": "^14.0.0"


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#281](https://github.com/OmniTrustILM/fe-administrator/security/dependabot/281) (CVE-2026-9277, **critical**).

`shell-quote` `<= 1.8.3` has a command-injection vulnerability ([GHSA-w7jw-789q-3m8p](https://github.com/ljharb/shell-quote/security/advisories/GHSA-w7jw-789q-3m8p)): `quote()` does not escape line terminators in object `.op` values, so a literal newline passes through unescaped and any content after it executes as a second shell command.

It is pulled in transitively (dev scope only):

```
@openapitools/openapi-generator-cli → concurrently → shell-quote
```

## Change

- Added an npm `overrides` entry forcing `shell-quote` to `^1.8.4` (the first patched release).
- Updated `package-lock.json` to resolve `shell-quote@1.8.4`.

`npm audit` reports **0 vulnerabilities** after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)