### PR TITLE
Enable Save when an authority name contains special characters

### DIFF
--- a/src/components/_pages/authorities/form/index.tsx
+++ b/src/components/_pages/authorities/form/index.tsx
@@ -366,6 +366,11 @@ export default function AuthorityForm({ authorityId, onCancel, onSuccess }: Read
                                 <Controller
                                     name="name"
                                     control={control}
+                                    // In edit mode the name is read-only and cannot be changed by the user.
+                                    // Disabling the field excludes it from RHF validation so an existing name that
+                                    // violates the stricter frontend regex (e.g. a CA named "demo.ejbca.org") does not
+                                    // poison `isValid` and permanently disable the Save button.
+                                    disabled={editMode}
                                     rules={buildValidationRules([validateRequired(), validateAlphaNumericWithSpecialChars()])}
                                     render={({ field, fieldState }) => (
                                         <TextInput


### PR DESCRIPTION
Fix #1740 