### PR TITLE
Fix js-yaml DoS vulnerability (CVE-2026-53550)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "dompurify": "^3.3.3",
                 "highlight.js": "^11.11.1",
                 "html-react-parser": "^6.0.1",
-                "js-yaml": "^4.1.1",
+                "js-yaml": "^4.2.0",
                 "jszip": "^3.10.1",
                 "lodash.debounce": "^4.0.8",
                 "lucide-react": "^1.7.0",
@@ -1250,30 +1250,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/schema": {
@@ -9971,13 +9947,6 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true,
-            "license": "BSD-3-Clause"
         },
         "node_modules/stackback": {
             "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "dompurify": "^3.3.3",
         "highlight.js": "^11.11.1",
         "html-react-parser": "^6.0.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "jszip": "^3.10.1",
         "lodash.debounce": "^4.0.8",
         "lucide-react": "^1.7.0",
@@ -112,6 +112,7 @@
     },
     "overrides": {
         "typescript": "$typescript",
+        "js-yaml": "$js-yaml",
         "nodemailer": "^8.0.5",
         "shell-quote": "^1.8.4",
         "esbuild": "^0.28.1",


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#284](https://github.com/OmniTrustILM/fe-administrator/security/dependabot/284) (GHSA-h67p-54hq-rp68 / CVE-2026-53550) and clears all 5 moderate `npm audit` findings — they all stemmed from the same single transitive dependency.

## Root cause

The vulnerable package was **js-yaml 3.14.2** (quadratic-complexity DoS in merge-key handling), pulled in transitively as a dev dependency through the istanbul coverage chain:

`@istanbuljs/load-nyc-config` → `babel-plugin-istanbul` / `nyc` / `vite-plugin-istanbul`

Those four packages plus js-yaml itself were exactly the 5 `npm audit` entries.

## Fix

In `package.json`:
- Bumped direct dep `js-yaml` `^4.1.1` → `^4.2.0` (first patched version)
- Added global override `"js-yaml": "$js-yaml"` to force the nested 3.14.2 copy up to 4.2.0

Safe because `load-nyc-config` only calls js-yaml's `.load()`, which still exists in 4.x.

## Verification

- `npm audit` → **0 vulnerabilities** (was 5 moderate)
- Only one js-yaml in the tree now: **4.2.0**
- Smoke-tested the istanbul chain + `js-yaml.load()` — works

🤖 Generated with [Claude Code](https://claude.com/claude-code)