### PR TITLE
Pencil - Select component

### DIFF
--- a/src/components/Select/Select.pen
+++ b/src/components/Select/Select.pen
@@ -205,7 +205,7 @@
                 {
                   "type": "frame",
                   "id": "HtGLw",
-                  "name": "default Cell",
+                  "name": "Default Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -259,7 +259,7 @@
                 {
                   "type": "frame",
                   "id": "D1bVH",
-                  "name": "hover Cell",
+                  "name": "Hover Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -313,7 +313,7 @@
                 {
                   "type": "frame",
                   "id": "HW06Z",
-                  "name": "focus Cell",
+                  "name": "Focus Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -373,7 +373,7 @@
                 {
                   "type": "frame",
                   "id": "MLTBO",
-                  "name": "disabled Cell",
+                  "name": "Disabled Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -468,7 +468,7 @@
                 {
                   "type": "frame",
                   "id": "PdIko",
-                  "name": "default Cell",
+                  "name": "Default Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -522,7 +522,7 @@
                 {
                   "type": "frame",
                   "id": "MGZCN",
-                  "name": "hover Cell",
+                  "name": "Hover Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -576,7 +576,7 @@
                 {
                   "type": "frame",
                   "id": "tiWGT",
-                  "name": "focus Cell",
+                  "name": "Focus Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -636,7 +636,7 @@
                 {
                   "type": "frame",
                   "id": "U8DFKL",
-                  "name": "disabled Cell",
+                  "name": "Disabled Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -731,7 +731,7 @@
                 {
                   "type": "frame",
                   "id": "aOz1G",
-                  "name": "default Cell",
+                  "name": "Default Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -836,7 +836,7 @@
                 {
                   "type": "frame",
                   "id": "HvTUm",
-                  "name": "hover Cell",
+                  "name": "Hover Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -941,7 +941,7 @@
                 {
                   "type": "frame",
                   "id": "K24LF",
-                  "name": "focus Cell",
+                  "name": "Focus Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -1052,7 +1052,7 @@
                 {
                   "type": "frame",
                   "id": "TGX4c",
-                  "name": "disabled Cell",
+                  "name": "Disabled Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -1500,7 +1500,7 @@
                             {
                               "type": "text",
                               "id": "W8SPe",
-                              "name": "Search Placeholder",
+                              "name": "Search Query",
                               "fill": "$color.gray-900",
                               "content": "Cert",
                               "fontFamily": "Inter",
@@ -2126,7 +2126,7 @@
                 {
                   "type": "frame",
                   "id": "m1eBJn",
-                  "name": "default Cell",
+                  "name": "Default Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2180,7 +2180,7 @@
                 {
                   "type": "frame",
                   "id": "B14q6u",
-                  "name": "hover Cell",
+                  "name": "Hover Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2234,7 +2234,7 @@
                 {
                   "type": "frame",
                   "id": "MS2Wq",
-                  "name": "focus Cell",
+                  "name": "Focus Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2294,7 +2294,7 @@
                 {
                   "type": "frame",
                   "id": "Hr8lr",
-                  "name": "disabled Cell",
+                  "name": "Disabled Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2389,7 +2389,7 @@
                 {
                   "type": "frame",
                   "id": "S0k3f1",
-                  "name": "default Cell",
+                  "name": "Default Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2443,7 +2443,7 @@
                 {
                   "type": "frame",
                   "id": "fIcx1",
-                  "name": "hover Cell",
+                  "name": "Hover Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2497,7 +2497,7 @@
                 {
                   "type": "frame",
                   "id": "t7SDt",
-                  "name": "focus Cell",
+                  "name": "Focus Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2557,7 +2557,7 @@
                 {
                   "type": "frame",
                   "id": "WbzVP",
-                  "name": "disabled Cell",
+                  "name": "Disabled Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2652,7 +2652,7 @@
                 {
                   "type": "frame",
                   "id": "gZlYN",
-                  "name": "default Cell",
+                  "name": "Default Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2757,7 +2757,7 @@
                 {
                   "type": "frame",
                   "id": "Q4G7Rx",
-                  "name": "hover Cell",
+                  "name": "Hover Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2862,7 +2862,7 @@
                 {
                   "type": "frame",
                   "id": "nIqYi",
-                  "name": "focus Cell",
+                  "name": "Focus Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -2973,7 +2973,7 @@
                 {
                   "type": "frame",
                   "id": "WGKBv",
-                  "name": "disabled Cell",
+                  "name": "Disabled Cell",
                   "width": "fill_container",
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -3421,7 +3421,7 @@
                             {
                               "type": "text",
                               "id": "H0VTXE",
-                              "name": "Search Placeholder",
+                              "name": "Search Query",
                               "fill": "$color.neutral-300",
                               "content": "Cert",
                               "fontFamily": "Inter",

--- a/src/components/Select/Select.pen
+++ b/src/components/Select/Select.pen
@@ -1,0 +1,4025 @@
+{
+  "version": "2.13",
+  "children": [
+    {
+      "type": "frame",
+      "id": "NF6Bb",
+      "x": 0,
+      "y": 0,
+      "name": "Light",
+      "clip": true,
+      "width": 820,
+      "fill": "$color.white",
+      "cornerRadius": 12,
+      "stroke": "$color.gray-200",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "layout": "vertical",
+      "gap": 28,
+      "padding": [
+        44,
+        40,
+        40,
+        40
+      ],
+      "children": [
+        {
+          "type": "frame",
+          "id": "Z75eo",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "z9UMC",
+              "name": "Title",
+              "fill": "$color.gray-900",
+              "content": "Select",
+              "fontFamily": "Inter",
+              "fontSize": 20,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "pgXms",
+              "name": "Subtitle",
+              "fill": "$color.gray-700",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Dropdown select — single, multi, searchable & states",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "J21blu",
+          "name": "States Table",
+          "width": "fill_container",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "YYcHJ",
+              "name": "Header Row",
+              "width": "fill_container",
+              "padding": [
+                0,
+                0,
+                12,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "QHxb1",
+                  "name": "Label Spacer",
+                  "width": 90,
+                  "height": "fit_content(0)"
+                },
+                {
+                  "type": "frame",
+                  "id": "vfrmU",
+                  "name": "Default Header",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rLUmV",
+                      "name": "Label",
+                      "fill": "$color.gray-700",
+                      "content": "Default",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "J2XuQN",
+                  "name": "Hover Header",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "M0YAp",
+                      "name": "Label",
+                      "fill": "$color.gray-700",
+                      "content": "Hover",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "bxwJl",
+                  "name": "Focus Header",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "upYVy",
+                      "name": "Label",
+                      "fill": "$color.gray-700",
+                      "content": "Focus",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "amA5M",
+                  "name": "Disabled Header",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "k5sQR",
+                      "name": "Label",
+                      "fill": "$color.gray-700",
+                      "content": "Disabled",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "IguEW",
+              "name": "Divider",
+              "fill": "$color.gray-200",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "fxi2v",
+              "name": "Single Row",
+              "width": "fill_container",
+              "padding": [
+                16,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "kMZ9W",
+                  "name": "Label",
+                  "width": 90,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "RVtcD",
+                      "name": "Row Label",
+                      "fill": "$color.gray-700",
+                      "content": "Single",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HtGLw",
+                  "name": "default Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "v9eXFJ",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "BAJP8",
+                          "name": "Value",
+                          "fill": "$color.gray-400",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "c33hC",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "D1bVH",
+                  "name": "hover Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "XqSSZ",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.gray-100",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QfkOW",
+                          "name": "Value",
+                          "fill": "$color.gray-400",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "O8v9VK",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HW06Z",
+                  "name": "focus Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "EKIPb",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Z5Psj",
+                          "name": "Value",
+                          "fill": "$color.gray-400",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "tQx7g",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MLTBO",
+                  "name": "disabled Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Dz1pS",
+                      "name": "Select Trigger",
+                      "opacity": 0.5,
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bmbmZ",
+                          "name": "Value",
+                          "fill": "$color.gray-400",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "RWxML",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "PFKYG",
+              "name": "Divider",
+              "fill": "$color.gray-200",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "ffCKa",
+              "name": "Selected Row",
+              "width": "fill_container",
+              "padding": [
+                16,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "TuZjB",
+                  "name": "Label",
+                  "width": 90,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "VEkHf",
+                      "name": "Row Label",
+                      "fill": "$color.gray-700",
+                      "content": "Selected",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "PdIko",
+                  "name": "default Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "z2Bni",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qHCWu",
+                          "name": "Value",
+                          "fill": "$color.gray-900",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Certificate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "N4BXC",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MGZCN",
+                  "name": "hover Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "G8DJA",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.gray-100",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "s7Njh",
+                          "name": "Value",
+                          "fill": "$color.gray-900",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Certificate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "iRsN0",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "tiWGT",
+                  "name": "focus Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ekJHa",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "lS6lP",
+                          "name": "Value",
+                          "fill": "$color.gray-900",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Certificate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "T43YI",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "U8DFKL",
+                  "name": "disabled Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "oPlVM",
+                      "name": "Select Trigger",
+                      "opacity": 0.5,
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "y9Acd8",
+                          "name": "Value",
+                          "fill": "$color.gray-900",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Certificate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "D2FzXs",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "C5uAOP",
+              "name": "Divider",
+              "fill": "$color.gray-200",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "qUYNJ",
+              "name": "Multi Row",
+              "width": "fill_container",
+              "padding": [
+                16,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "kkidJ",
+                  "name": "Label",
+                  "width": 90,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "qa6f0",
+                      "name": "Row Label",
+                      "fill": "$color.gray-700",
+                      "content": "Multi",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "aOz1G",
+                  "name": "default Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "jvFkv",
+                      "name": "Multi Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "F6atc",
+                          "name": "Chips",
+                          "width": "fill_container",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "LeMDY",
+                              "name": "Chip",
+                              "fill": "$color.white",
+                              "cornerRadius": 999,
+                              "stroke": "$color.gray-200",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "q6Nef",
+                                  "name": "Chip Label",
+                                  "fill": "$color.gray-900",
+                                  "content": "Active",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Cr1Nu",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.gray-200",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "a2Drj",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.gray-800"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "T9MVyQ",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HvTUm",
+                  "name": "hover Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Z73wlq",
+                      "name": "Multi Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.gray-100",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "kPW9s",
+                          "name": "Chips",
+                          "width": "fill_container",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "gUW9K",
+                              "name": "Chip",
+                              "fill": "$color.white",
+                              "cornerRadius": 999,
+                              "stroke": "$color.gray-200",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "vtnnt",
+                                  "name": "Chip Label",
+                                  "fill": "$color.gray-900",
+                                  "content": "Active",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "eOhal",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.gray-200",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "XahTj",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.gray-800"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "kzvzj",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "K24LF",
+                  "name": "focus Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Lcvuh",
+                      "name": "Multi Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "u3K9v",
+                          "name": "Chips",
+                          "width": "fill_container",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "z7hGzX",
+                              "name": "Chip",
+                              "fill": "$color.white",
+                              "cornerRadius": 999,
+                              "stroke": "$color.gray-200",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "q6wAM",
+                                  "name": "Chip Label",
+                                  "fill": "$color.gray-900",
+                                  "content": "Active",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "B2o60",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.gray-200",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "Yn4aj",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.gray-800"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "l39E4V",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "TGX4c",
+                  "name": "disabled Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "jZGdY",
+                      "name": "Multi Trigger",
+                      "opacity": 0.5,
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "qGTOU",
+                          "name": "Chips",
+                          "width": "fill_container",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "LJklw",
+                              "name": "Chip",
+                              "fill": "$color.white",
+                              "cornerRadius": 999,
+                              "stroke": "$color.gray-200",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "D1JVR3",
+                                  "name": "Chip Label",
+                                  "fill": "$color.gray-900",
+                                  "content": "Active",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "xjegH",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.gray-200",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "kVLwo",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.gray-800"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "s8RHqi",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "id": "ZsiVL",
+          "name": "Section Divider",
+          "fill": "$color.gray-200",
+          "width": "fill_container",
+          "height": 1
+        },
+        {
+          "type": "frame",
+          "id": "OZAik",
+          "name": "Examples",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 18,
+          "children": [
+            {
+              "type": "text",
+              "id": "dhQyl",
+              "name": "Section: Examples",
+              "fill": "$color.gray-900",
+              "content": "Examples",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "huMT1",
+              "name": "Row 1",
+              "width": "fill_container",
+              "gap": 24,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "PBEcD",
+                  "name": "Open menu Example",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "L4zhGB",
+                      "name": "Caption",
+                      "fill": "$color.gray-700",
+                      "content": "Open menu",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "iyJ8b",
+                      "name": "Select Trigger",
+                      "width": "fill_container",
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "NM6i3",
+                          "name": "Value",
+                          "fill": "$color.gray-900",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Certificate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "xGVxt",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "f24qh0",
+                      "name": "Menu",
+                      "clip": true,
+                      "width": "fill_container",
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": 4,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "f88AV",
+                          "name": "Option",
+                          "width": "fill_container",
+                          "fill": "$color.transparent",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "m5nevp",
+                              "name": "Option Label",
+                              "fill": "$color.gray-900",
+                              "content": "Certificate",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "icon",
+                              "id": "MEIF8",
+                              "name": "Check",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "check",
+                              "library": "lucide",
+                              "fill": "$color.blue-600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "waEah",
+                          "name": "Option",
+                          "width": "fill_container",
+                          "fill": "$color.gray-100",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "TKemE",
+                              "name": "Option Label",
+                              "fill": "$color.gray-900",
+                              "content": "Certificate Profile",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "nHXsM",
+                          "name": "Option",
+                          "width": "fill_container",
+                          "fill": "$color.transparent",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "XA1Cw",
+                              "name": "Option Label",
+                              "fill": "$color.gray-900",
+                              "content": "Authority",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "FDlGL",
+                          "name": "Option",
+                          "opacity": 0.5,
+                          "width": "fill_container",
+                          "fill": "$color.transparent",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "NPUaM",
+                              "name": "Option Label",
+                              "fill": "$color.gray-900",
+                              "content": "Discovery",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "TjfNg",
+                  "name": "Searchable Example",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "m3iTn8",
+                      "name": "Caption",
+                      "fill": "$color.gray-700",
+                      "content": "Searchable",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UHy3v",
+                      "name": "Select Trigger",
+                      "width": "fill_container",
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "HQSqr",
+                          "name": "Value",
+                          "fill": "$color.gray-400",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "jllsI",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "VHfdQ",
+                      "name": "Menu",
+                      "clip": true,
+                      "width": "fill_container",
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": 4,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "iej0p",
+                          "name": "Search",
+                          "width": "fill_container",
+                          "fill": "$color.white",
+                          "cornerRadius": 8,
+                          "stroke": "$color.gray-200",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "W8SPe",
+                              "name": "Search Placeholder",
+                              "fill": "$color.gray-900",
+                              "content": "Cert",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "xMSHS",
+                          "name": "Option",
+                          "width": "fill_container",
+                          "fill": "$color.gray-100",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "hYtXg",
+                              "name": "Option Label",
+                              "fill": "$color.gray-900",
+                              "content": "Certificate",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "GGFZc",
+                          "name": "Option",
+                          "width": "fill_container",
+                          "fill": "$color.transparent",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ih3wx",
+                              "name": "Option Label",
+                              "fill": "$color.gray-900",
+                              "content": "Certificate Profile",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "pUD1L",
+              "name": "Row 2",
+              "width": "fill_container",
+              "gap": 24,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NX2IT",
+                  "name": "Multi-select (clearable) Example",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "sotwK",
+                      "name": "Caption",
+                      "fill": "$color.gray-700",
+                      "content": "Multi-select (clearable)",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Stwo0",
+                      "name": "Multi Trigger",
+                      "width": "fill_container",
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "b6fDz",
+                          "name": "Chips",
+                          "width": "fill_container",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "YEN6U",
+                              "name": "Chip",
+                              "fill": "$color.white",
+                              "cornerRadius": 999,
+                              "stroke": "$color.gray-200",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "O9eu34",
+                                  "name": "Chip Label",
+                                  "fill": "$color.gray-900",
+                                  "content": "Active",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "cC1xp",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.gray-200",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "N5GmD",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.gray-800"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "R0wsK",
+                              "name": "Chip",
+                              "fill": "$color.white",
+                              "cornerRadius": 999,
+                              "stroke": "$color.gray-200",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "hBr4o",
+                                  "name": "Chip Label",
+                                  "fill": "$color.gray-900",
+                                  "content": "Pending",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "KOX4p",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.gray-200",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "Nvm5u",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.gray-800"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "I1LOPV",
+                              "name": "Chip",
+                              "fill": "$color.white",
+                              "cornerRadius": 999,
+                              "stroke": "$color.gray-200",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "FAHMT",
+                                  "name": "Chip Label",
+                                  "fill": "$color.gray-900",
+                                  "content": "Revoked",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "TvCGL",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.gray-200",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "qla6x",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.gray-800"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "j5NuGk",
+                          "name": "Clear",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "x",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "IVxtO",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JIqt1",
+                  "name": "Validation Example",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CAj4I",
+                      "name": "Caption",
+                      "fill": "$color.gray-700",
+                      "content": "Validation",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OoUps",
+                      "name": "Label",
+                      "gap": 3,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "CZi7m",
+                          "name": "Label Text",
+                          "fill": "$color.gray-700",
+                          "content": "Resource Type",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "q6AMV",
+                          "name": "Required",
+                          "fill": "$color.red-500",
+                          "content": "*",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gXxKl",
+                      "name": "Select Trigger",
+                      "width": "fill_container",
+                      "height": 44,
+                      "fill": "$color.white",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ixvX4",
+                          "name": "Value",
+                          "fill": "$color.gray-400",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "rSjx3",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.gray-700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "olFjb",
+                      "name": "Error",
+                      "fill": "$color.red-500",
+                      "content": "This field is required.",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "qbfjd",
+      "x": 880,
+      "y": 0,
+      "name": "Dark",
+      "clip": true,
+      "width": 820,
+      "fill": "$color.neutral-900",
+      "cornerRadius": 12,
+      "stroke": "$color.neutral-700",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "layout": "vertical",
+      "gap": 28,
+      "padding": [
+        44,
+        40,
+        40,
+        40
+      ],
+      "children": [
+        {
+          "type": "frame",
+          "id": "QiXBU",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "D8isX",
+              "name": "Title",
+              "fill": "$color.white",
+              "content": "Select",
+              "fontFamily": "Inter",
+              "fontSize": 20,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "JHTD1",
+              "name": "Subtitle",
+              "fill": "$color.neutral-300",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Dropdown select — single, multi, searchable & states",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dGAC8",
+          "name": "States Table",
+          "width": "fill_container",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "yX7iz",
+              "name": "Header Row",
+              "width": "fill_container",
+              "padding": [
+                0,
+                0,
+                12,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "nEK7J",
+                  "name": "Label Spacer",
+                  "width": 90,
+                  "height": "fit_content(0)"
+                },
+                {
+                  "type": "frame",
+                  "id": "i63dhZ",
+                  "name": "Default Header",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "V346N",
+                      "name": "Label",
+                      "fill": "$color.neutral-300",
+                      "content": "Default",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "yHYa4",
+                  "name": "Hover Header",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "lds0o",
+                      "name": "Label",
+                      "fill": "$color.neutral-300",
+                      "content": "Hover",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "tRHN4",
+                  "name": "Focus Header",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rcYco",
+                      "name": "Label",
+                      "fill": "$color.neutral-300",
+                      "content": "Focus",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "j3BzN",
+                  "name": "Disabled Header",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "kKNxM",
+                      "name": "Label",
+                      "fill": "$color.neutral-300",
+                      "content": "Disabled",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "jHhIC",
+              "name": "Divider",
+              "fill": "$color.neutral-700",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "a5xv78",
+              "name": "Single Row",
+              "width": "fill_container",
+              "padding": [
+                16,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EiPrD",
+                  "name": "Label",
+                  "width": 90,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "s4ePS7",
+                      "name": "Row Label",
+                      "fill": "$color.neutral-300",
+                      "content": "Single",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "m1eBJn",
+                  "name": "default Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "M6Vhfr",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "soZaO",
+                          "name": "Value",
+                          "fill": "$color.neutral-500",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "MQF12",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "B14q6u",
+                  "name": "hover Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "z0j8i",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "IBwX7",
+                          "name": "Value",
+                          "fill": "$color.neutral-500",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "o59BrX",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MS2Wq",
+                  "name": "focus Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dW80y",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ldVWn",
+                          "name": "Value",
+                          "fill": "$color.neutral-500",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "YyDrB",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Hr8lr",
+                  "name": "disabled Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "WH13j",
+                      "name": "Select Trigger",
+                      "opacity": 0.5,
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bSSQ1",
+                          "name": "Value",
+                          "fill": "$color.neutral-500",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "OfS2O",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "CRxD9",
+              "name": "Divider",
+              "fill": "$color.neutral-700",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "zSlJO",
+              "name": "Selected Row",
+              "width": "fill_container",
+              "padding": [
+                16,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jWPpA",
+                  "name": "Label",
+                  "width": 90,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "UbDbX",
+                      "name": "Row Label",
+                      "fill": "$color.neutral-300",
+                      "content": "Selected",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "S0k3f1",
+                  "name": "default Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ig1Ng",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "wCtov",
+                          "name": "Value",
+                          "fill": "$color.neutral-300",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Certificate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "SRU0b",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "fIcx1",
+                  "name": "hover Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "e2G4M",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZOuAn",
+                          "name": "Value",
+                          "fill": "$color.neutral-300",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Certificate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "bO4y8",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "t7SDt",
+                  "name": "focus Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hnAmd",
+                      "name": "Select Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mNjkB",
+                          "name": "Value",
+                          "fill": "$color.neutral-300",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Certificate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "P3x2a6",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "WbzVP",
+                  "name": "disabled Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "DkFtL",
+                      "name": "Select Trigger",
+                      "opacity": 0.5,
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "d9SXcl",
+                          "name": "Value",
+                          "fill": "$color.neutral-300",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Certificate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "myffK",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "ODJyX",
+              "name": "Divider",
+              "fill": "$color.neutral-700",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "J6wiz",
+              "name": "Multi Row",
+              "width": "fill_container",
+              "padding": [
+                16,
+                0
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "iHU43",
+                  "name": "Label",
+                  "width": 90,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "L5ujkt",
+                      "name": "Row Label",
+                      "fill": "$color.neutral-300",
+                      "content": "Multi",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "gZlYN",
+                  "name": "default Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "b3WSX",
+                      "name": "Multi Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "oVRgX",
+                          "name": "Chips",
+                          "width": "fill_container",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Q0R75",
+                              "name": "Chip",
+                              "fill": "$color.neutral-800",
+                              "cornerRadius": 999,
+                              "stroke": "$color.neutral-600",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "CHx2l",
+                                  "name": "Chip Label",
+                                  "fill": "$color.neutral-300",
+                                  "content": "Active",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "QUVsi",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.neutral-600",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "t1W43",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.neutral-300"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "G2997B",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Q4G7Rx",
+                  "name": "hover Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "esweq",
+                      "name": "Multi Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "BsITA",
+                          "name": "Chips",
+                          "width": "fill_container",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "zDD5A",
+                              "name": "Chip",
+                              "fill": "$color.neutral-800",
+                              "cornerRadius": 999,
+                              "stroke": "$color.neutral-600",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "khrER",
+                                  "name": "Chip Label",
+                                  "fill": "$color.neutral-300",
+                                  "content": "Active",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "m69DQI",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.neutral-600",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "NflAM",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.neutral-300"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "GckRi",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "nIqYi",
+                  "name": "focus Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "gQ2kl",
+                      "name": "Multi Trigger",
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "A4HCSo",
+                          "name": "Chips",
+                          "width": "fill_container",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "VnFnw",
+                              "name": "Chip",
+                              "fill": "$color.neutral-800",
+                              "cornerRadius": 999,
+                              "stroke": "$color.neutral-600",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "MKi1B",
+                                  "name": "Chip Label",
+                                  "fill": "$color.neutral-300",
+                                  "content": "Active",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "TIHzn",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.neutral-600",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "SQxkA",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.neutral-300"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "Akzx1",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "WGKBv",
+                  "name": "disabled Cell",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "u0u0i",
+                      "name": "Multi Trigger",
+                      "opacity": 0.5,
+                      "width": 160,
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "I9Zp0x",
+                          "name": "Chips",
+                          "width": "fill_container",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "AqEYi",
+                              "name": "Chip",
+                              "fill": "$color.neutral-800",
+                              "cornerRadius": 999,
+                              "stroke": "$color.neutral-600",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "CeqxH",
+                                  "name": "Chip Label",
+                                  "fill": "$color.neutral-300",
+                                  "content": "Active",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "yaqTm",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.neutral-600",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "z8L7Ql",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.neutral-300"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "OH8V5",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "id": "w6C1W",
+          "name": "Section Divider",
+          "fill": "$color.neutral-700",
+          "width": "fill_container",
+          "height": 1
+        },
+        {
+          "type": "frame",
+          "id": "x9JkWb",
+          "name": "Examples",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 18,
+          "children": [
+            {
+              "type": "text",
+              "id": "KShO3",
+              "name": "Section: Examples",
+              "fill": "$color.white",
+              "content": "Examples",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "EmNJi",
+              "name": "Row 1",
+              "width": "fill_container",
+              "gap": 24,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "SqdM3",
+                  "name": "Open menu Example",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "OCiHp",
+                      "name": "Caption",
+                      "fill": "$color.neutral-300",
+                      "content": "Open menu",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "R4TqF",
+                      "name": "Select Trigger",
+                      "width": "fill_container",
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Q07Isr",
+                          "name": "Value",
+                          "fill": "$color.neutral-300",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Certificate",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "HrLqN",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vOO9R",
+                      "name": "Menu",
+                      "clip": true,
+                      "width": "fill_container",
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": 4,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "LXkFi",
+                          "name": "Option",
+                          "width": "fill_container",
+                          "fill": "$color.transparent",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "n27Nxm",
+                              "name": "Option Label",
+                              "fill": "$color.neutral-300",
+                              "content": "Certificate",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "icon",
+                              "id": "vOUco",
+                              "name": "Check",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "check",
+                              "library": "lucide",
+                              "fill": "$color.blue-500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Rz1rw",
+                          "name": "Option",
+                          "width": "fill_container",
+                          "fill": "$color.neutral-800",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "suC98",
+                              "name": "Option Label",
+                              "fill": "$color.neutral-300",
+                              "content": "Certificate Profile",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ZuPX3",
+                          "name": "Option",
+                          "width": "fill_container",
+                          "fill": "$color.transparent",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Ny3WN",
+                              "name": "Option Label",
+                              "fill": "$color.neutral-300",
+                              "content": "Authority",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "o4PgtL",
+                          "name": "Option",
+                          "opacity": 0.5,
+                          "width": "fill_container",
+                          "fill": "$color.transparent",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "nhOAC",
+                              "name": "Option Label",
+                              "fill": "$color.neutral-300",
+                              "content": "Discovery",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HflMk",
+                  "name": "Searchable Example",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "OXq9O",
+                      "name": "Caption",
+                      "fill": "$color.neutral-300",
+                      "content": "Searchable",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "S59PE",
+                      "name": "Select Trigger",
+                      "width": "fill_container",
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Opm09",
+                          "name": "Value",
+                          "fill": "$color.neutral-500",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "xQRRx",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "SGgRb",
+                      "name": "Menu",
+                      "clip": true,
+                      "width": "fill_container",
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": 4,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "i8GLpy",
+                          "name": "Search",
+                          "width": "fill_container",
+                          "fill": "$color.neutral-900",
+                          "cornerRadius": 8,
+                          "stroke": "$color.neutral-700",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "H0VTXE",
+                              "name": "Search Placeholder",
+                              "fill": "$color.neutral-300",
+                              "content": "Cert",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "QFJhE",
+                          "name": "Option",
+                          "width": "fill_container",
+                          "fill": "$color.neutral-800",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "SaTHw",
+                              "name": "Option Label",
+                              "fill": "$color.neutral-300",
+                              "content": "Certificate",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "CxJVK",
+                          "name": "Option",
+                          "width": "fill_container",
+                          "fill": "$color.transparent",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "justifyContent": "space_between",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "mL3Jq",
+                              "name": "Option Label",
+                              "fill": "$color.neutral-300",
+                              "content": "Certificate Profile",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "K5Deal",
+              "name": "Row 2",
+              "width": "fill_container",
+              "gap": 24,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "i6fYM",
+                  "name": "Multi-select (clearable) Example",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Fxgzv",
+                      "name": "Caption",
+                      "fill": "$color.neutral-300",
+                      "content": "Multi-select (clearable)",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Be3Ln",
+                      "name": "Multi Trigger",
+                      "width": "fill_container",
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.blue-500",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "$color.blue-300",
+                        "spread": 2
+                      },
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "HM6LX",
+                          "name": "Chips",
+                          "width": "fill_container",
+                          "gap": 4,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "E2M7KE",
+                              "name": "Chip",
+                              "fill": "$color.neutral-800",
+                              "cornerRadius": 999,
+                              "stroke": "$color.neutral-600",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "d9rAm",
+                                  "name": "Chip Label",
+                                  "fill": "$color.neutral-300",
+                                  "content": "Active",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "JhgWw",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.neutral-600",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "uL3GB",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.neutral-300"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "KU2RN",
+                              "name": "Chip",
+                              "fill": "$color.neutral-800",
+                              "cornerRadius": 999,
+                              "stroke": "$color.neutral-600",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "cg9TM",
+                                  "name": "Chip Label",
+                                  "fill": "$color.neutral-300",
+                                  "content": "Pending",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "LXXNq",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.neutral-600",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "gZH0J",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.neutral-300"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "S6w3h",
+                              "name": "Chip",
+                              "fill": "$color.neutral-800",
+                              "cornerRadius": 999,
+                              "stroke": "$color.neutral-600",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                3,
+                                4,
+                                3,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "DX8XK",
+                                  "name": "Chip Label",
+                                  "fill": "$color.neutral-300",
+                                  "content": "Revoked",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "axEvX",
+                                  "name": "Remove",
+                                  "width": 20,
+                                  "height": 20,
+                                  "fill": "$color.neutral-600",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "o3pbf4",
+                                      "name": "X",
+                                      "width": 12,
+                                      "height": 12,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.neutral-300"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "C84iW",
+                          "name": "Clear",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "x",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "TsgLp",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Pt4s3",
+                  "name": "Validation Example",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ldAhH",
+                      "name": "Caption",
+                      "fill": "$color.neutral-300",
+                      "content": "Validation",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Ly9tP",
+                      "name": "Label",
+                      "gap": 3,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "GjQeo",
+                          "name": "Label Text",
+                          "fill": "$color.neutral-300",
+                          "content": "Resource Type",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "K478oo",
+                          "name": "Required",
+                          "fill": "$color.red-500",
+                          "content": "*",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "eDOdA",
+                      "name": "Select Trigger",
+                      "width": "fill_container",
+                      "height": 44,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12,
+                        0,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bddSD",
+                          "name": "Value",
+                          "fill": "$color.neutral-500",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Select...",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "D9LpZ",
+                          "name": "Chevron",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevrons-up-down",
+                          "library": "lucide",
+                          "fill": "$color.neutral-500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "v6m9i",
+                      "name": "Error",
+                      "fill": "$color.red-500",
+                      "content": "This field is required.",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "color.blue-100": {
+      "type": "color",
+      "value": "#cce5ff"
+    },
+    "color.blue-200": {
+      "type": "color",
+      "value": "#99ccff"
+    },
+    "color.blue-300": {
+      "type": "color",
+      "value": "#66b2ff"
+    },
+    "color.blue-400": {
+      "type": "color",
+      "value": "#3399ff"
+    },
+    "color.blue-50": {
+      "type": "color",
+      "value": "#e6f2ff"
+    },
+    "color.blue-500": {
+      "type": "color",
+      "value": "#0085e6"
+    },
+    "color.blue-600": {
+      "type": "color",
+      "value": "#0073cf"
+    },
+    "color.blue-700": {
+      "type": "color",
+      "value": "#005ba6"
+    },
+    "color.blue-800": {
+      "type": "color",
+      "value": "#004480"
+    },
+    "color.blue-900": {
+      "type": "color",
+      "value": "#002d59"
+    },
+    "color.blue-950": {
+      "type": "color",
+      "value": "#001a33"
+    },
+    "color.gray-100": {
+      "type": "color",
+      "value": "#f5f5f5"
+    },
+    "color.gray-200": {
+      "type": "color",
+      "value": "#e8e8e8"
+    },
+    "color.gray-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.gray-400": {
+      "type": "color",
+      "value": "#c7c7c7"
+    },
+    "color.gray-500": {
+      "type": "color",
+      "value": "#a8a8a8"
+    },
+    "color.gray-600": {
+      "type": "color",
+      "value": "#b4b4b4"
+    },
+    "color.gray-700": {
+      "type": "color",
+      "value": "#8c8c8c"
+    },
+    "color.gray-800": {
+      "type": "color",
+      "value": "#666666"
+    },
+    "color.gray-900": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-200": {
+      "type": "color",
+      "value": "#e5e5e5"
+    },
+    "color.neutral-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.neutral-400": {
+      "type": "color",
+      "value": "#a3a3a3"
+    },
+    "color.neutral-500": {
+      "type": "color",
+      "value": "#737373"
+    },
+    "color.neutral-600": {
+      "type": "color",
+      "value": "#525252"
+    },
+    "color.neutral-700": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-800": {
+      "type": "color",
+      "value": "#262626"
+    },
+    "color.neutral-900": {
+      "type": "color",
+      "value": "#171717"
+    },
+    "color.red-100": {
+      "type": "color",
+      "value": "#fee2e2"
+    },
+    "color.red-400": {
+      "type": "color",
+      "value": "#f87171"
+    },
+    "color.red-500": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "color.red-600": {
+      "type": "color",
+      "value": "#dc2626"
+    },
+    "color.red-800": {
+      "type": "color",
+      "value": "#991b1b"
+    },
+    "color.red-800-30": {
+      "type": "color",
+      "value": "#991b1b4d"
+    },
+    "color.transparent": {
+      "type": "color",
+      "value": "#00000000"
+    },
+    "color.white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "color.white-10": {
+      "type": "color",
+      "value": "#ffffff1a"
+    },
+    "color.white-20": {
+      "type": "color",
+      "value": "#ffffff33"
+    },
+    "color.yellow-100": {
+      "type": "color",
+      "value": "#fef9c3"
+    },
+    "color.yellow-400": {
+      "type": "color",
+      "value": "#facc15"
+    },
+    "color.yellow-500": {
+      "type": "color",
+      "value": "#eab308"
+    },
+    "color.yellow-600": {
+      "type": "color",
+      "value": "#ca8a04"
+    },
+    "color.yellow-800": {
+      "type": "color",
+      "value": "#854d0e"
+    },
+    "color.yellow-800-30": {
+      "type": "color",
+      "value": "#854d0e4d"
+    }
+  }
+}

--- a/src/design-system/Design.pen
+++ b/src/design-system/Design.pen
@@ -3348,7 +3348,7 @@
           "type": "text",
           "id": "VEqvF",
           "name": "Value",
-          "fill": "$color.gray-500",
+          "fill": "$color.gray-400",
           "textGrowth": "fixed-width",
           "width": "fill_container",
           "content": "Placeholder",

--- a/src/design-system/Design.pen
+++ b/src/design-system/Design.pen
@@ -52,6 +52,7 @@
           "id": "W3Yt2",
           "name": "Body",
           "width": 2220,
+          "layout": "vertical",
           "gap": 40,
           "padding": [
             40,
@@ -62,1447 +63,1016 @@
           "children": [
             {
               "type": "frame",
-              "id": "u771O",
-              "name": "Buttons Group",
-              "width": 200,
-              "layout": "vertical",
-              "gap": 16,
+              "id": "LO8oA",
+              "name": "Row 1",
+              "gap": 40,
               "children": [
                 {
                   "type": "frame",
-                  "id": "w2uPl",
-                  "name": "Group Header",
-                  "width": "fill_container",
+                  "id": "u771O",
+                  "name": "Buttons Group",
+                  "width": 200,
                   "layout": "vertical",
-                  "gap": 10,
+                  "gap": 16,
                   "children": [
                     {
-                      "type": "text",
-                      "id": "W4cwVs",
-                      "name": "Group Title",
-                      "fill": "$color.gray-500",
-                      "content": "BUTTON",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "600"
+                      "type": "frame",
+                      "id": "w2uPl",
+                      "name": "Group Header",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "W4cwVs",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "BUTTON",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "JATWF",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
+                        }
+                      ]
                     },
                     {
-                      "type": "rectangle",
-                      "id": "JATWF",
-                      "name": "Divider",
-                      "fill": "$color.gray-300",
+                      "type": "frame",
+                      "id": "g9zzXA",
+                      "name": "Items",
                       "width": "fill_container",
-                      "height": 1
+                      "layout": "vertical",
+                      "gap": 20,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "cUUVV",
+                          "name": "Primary",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "oAtQy",
+                              "type": "ref",
+                              "ref": "i4PcLp",
+                              "name": "Primary Button"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Y4gtB",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Primary",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "MNDbd",
+                          "name": "Danger",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "G5RoWb",
+                              "type": "ref",
+                              "ref": "E6DLJ0",
+                              "name": "Danger Button"
+                            },
+                            {
+                              "type": "text",
+                              "id": "V6NiO8",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Danger",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Bc9wO",
+                          "name": "Secondary",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "qGTIs",
+                              "type": "ref",
+                              "ref": "dThoL",
+                              "name": "Secondary Button"
+                            },
+                            {
+                              "type": "text",
+                              "id": "z9V1C",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Secondary",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TgPXN",
+                          "name": "Outline",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "S2a4Z",
+                              "type": "ref",
+                              "ref": "uXBGa",
+                              "name": "Outline Button"
+                            },
+                            {
+                              "type": "text",
+                              "id": "he5FV",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Outline",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Qah6w",
+                          "name": "Ghost",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "J2jNX5",
+                              "type": "ref",
+                              "ref": "sGgkm",
+                              "name": "Ghost Button"
+                            },
+                            {
+                              "type": "text",
+                              "id": "SUJXJ",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Ghost",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "g9zzXA",
-                  "name": "Items",
-                  "width": "fill_container",
+                  "id": "cUhHc",
+                  "name": "Checkboxes Group",
+                  "width": 220,
                   "layout": "vertical",
-                  "gap": 20,
+                  "gap": 16,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "cUUVV",
-                      "name": "Primary",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "oAtQy",
-                          "type": "ref",
-                          "ref": "i4PcLp",
-                          "name": "Primary Button"
-                        },
-                        {
-                          "type": "text",
-                          "id": "Y4gtB",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Primary",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "MNDbd",
-                      "name": "Danger",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "G5RoWb",
-                          "type": "ref",
-                          "ref": "E6DLJ0",
-                          "name": "Danger Button"
-                        },
-                        {
-                          "type": "text",
-                          "id": "V6NiO8",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Danger",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "Bc9wO",
-                      "name": "Secondary",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "qGTIs",
-                          "type": "ref",
-                          "ref": "dThoL",
-                          "name": "Secondary Button"
-                        },
-                        {
-                          "type": "text",
-                          "id": "z9V1C",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Secondary",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "TgPXN",
-                      "name": "Outline",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "S2a4Z",
-                          "type": "ref",
-                          "ref": "uXBGa",
-                          "name": "Outline Button"
-                        },
-                        {
-                          "type": "text",
-                          "id": "he5FV",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Outline",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "Qah6w",
-                      "name": "Ghost",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "J2jNX5",
-                          "type": "ref",
-                          "ref": "sGgkm",
-                          "name": "Ghost Button"
-                        },
-                        {
-                          "type": "text",
-                          "id": "SUJXJ",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Ghost",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "cUhHc",
-              "name": "Checkboxes Group",
-              "width": 220,
-              "layout": "vertical",
-              "gap": 16,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "LkH2l",
-                  "name": "Group Header",
-                  "width": "fill_container",
-                  "layout": "vertical",
-                  "gap": 10,
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "uRT8A",
-                      "name": "Group Title",
-                      "fill": "$color.gray-500",
-                      "content": "CHECKBOX",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "rectangle",
-                      "id": "T9JBsl",
-                      "name": "Divider",
-                      "fill": "$color.gray-300",
+                      "id": "LkH2l",
+                      "name": "Group Header",
                       "width": "fill_container",
-                      "height": 1
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "uRT8A",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "CHECKBOX",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "T9JBsl",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "x3odGx",
+                      "name": "Items",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 20,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "t9fWlf",
+                          "name": "Unchecked",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "LcZZI",
+                              "type": "ref",
+                              "ref": "nyrTw",
+                              "name": "Unchecked Checkbox"
+                            },
+                            {
+                              "type": "text",
+                              "id": "jIKdN",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Unchecked",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "by8zK",
+                          "name": "Checked",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "xhmBf",
+                              "type": "ref",
+                              "ref": "H5ZN7s",
+                              "name": "Checked Checkbox"
+                            },
+                            {
+                              "type": "text",
+                              "id": "J6Snrm",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Checked",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ILAWo",
+                          "name": "With label",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "kdA9T",
+                              "type": "ref",
+                              "ref": "BKQ1x",
+                              "name": "With label Checkbox"
+                            },
+                            {
+                              "type": "text",
+                              "id": "bayCA",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "With label",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TyBEX",
+                          "name": "With label (checked)",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "uTh8q",
+                              "type": "ref",
+                              "ref": "OcXD9",
+                              "name": "With label (checked) Checkbox"
+                            },
+                            {
+                              "type": "text",
+                              "id": "bhENZ",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "With label (checked)",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "x3odGx",
-                  "name": "Items",
-                  "width": "fill_container",
+                  "id": "u1VmEr",
+                  "name": "Switches Group",
+                  "width": 200,
                   "layout": "vertical",
-                  "gap": 20,
+                  "gap": 16,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "t9fWlf",
-                      "name": "Unchecked",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "LcZZI",
-                          "type": "ref",
-                          "ref": "nyrTw",
-                          "name": "Unchecked Checkbox"
-                        },
-                        {
-                          "type": "text",
-                          "id": "jIKdN",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Unchecked",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "by8zK",
-                      "name": "Checked",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "xhmBf",
-                          "type": "ref",
-                          "ref": "H5ZN7s",
-                          "name": "Checked Checkbox"
-                        },
-                        {
-                          "type": "text",
-                          "id": "J6Snrm",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Checked",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "ILAWo",
-                      "name": "With label",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "kdA9T",
-                          "type": "ref",
-                          "ref": "BKQ1x",
-                          "name": "With label Checkbox"
-                        },
-                        {
-                          "type": "text",
-                          "id": "bayCA",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "With label",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "TyBEX",
-                      "name": "With label (checked)",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "uTh8q",
-                          "type": "ref",
-                          "ref": "OcXD9",
-                          "name": "With label (checked) Checkbox"
-                        },
-                        {
-                          "type": "text",
-                          "id": "bhENZ",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "With label (checked)",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "u1VmEr",
-              "name": "Switches Group",
-              "width": 200,
-              "layout": "vertical",
-              "gap": 16,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "oy3W0",
-                  "name": "Group Header",
-                  "width": "fill_container",
-                  "layout": "vertical",
-                  "gap": 10,
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "A3nk2",
-                      "name": "Group Title",
-                      "fill": "$color.gray-500",
-                      "content": "SWITCH",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "rectangle",
-                      "id": "YJ4NK",
-                      "name": "Divider",
-                      "fill": "$color.gray-300",
+                      "id": "oy3W0",
+                      "name": "Group Header",
                       "width": "fill_container",
-                      "height": 1
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "A3nk2",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "SWITCH",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "YJ4NK",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "u6SHM",
+                      "name": "Items",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 20,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "gzLMM",
+                          "name": "Switch/Off",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "ZP9cC",
+                              "type": "ref",
+                              "ref": "yLFn5",
+                              "name": "Off instance"
+                            },
+                            {
+                              "type": "text",
+                              "id": "n2yurS",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Off",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "g6gHI",
+                          "name": "Switch/On",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "ACNT3",
+                              "type": "ref",
+                              "ref": "Hm8f2",
+                              "name": "On instance"
+                            },
+                            {
+                              "type": "text",
+                              "id": "V4WLYd",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "On",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "u6SHM",
-                  "name": "Items",
-                  "width": "fill_container",
+                  "id": "AOqJC",
+                  "name": "Cards Group",
+                  "width": 280,
+                  "height": 171,
                   "layout": "vertical",
-                  "gap": 20,
+                  "gap": 16,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "gzLMM",
-                      "name": "Switch/Off",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "ZP9cC",
-                          "type": "ref",
-                          "ref": "yLFn5",
-                          "name": "Off instance"
-                        },
-                        {
-                          "type": "text",
-                          "id": "n2yurS",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Off",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "g6gHI",
-                      "name": "Switch/On",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "ACNT3",
-                          "type": "ref",
-                          "ref": "Hm8f2",
-                          "name": "On instance"
-                        },
-                        {
-                          "type": "text",
-                          "id": "V4WLYd",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "On",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "AOqJC",
-              "name": "Cards Group",
-              "width": 280,
-              "height": 171,
-              "layout": "vertical",
-              "gap": 16,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "OBvEP",
-                  "name": "Group Header",
-                  "width": "fill_container",
-                  "layout": "vertical",
-                  "gap": 10,
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "VABl4",
-                      "name": "Group Title",
-                      "fill": "$color.gray-500",
-                      "content": "CARD",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "rectangle",
-                      "id": "WMaKt",
-                      "name": "Divider",
-                      "fill": "$color.gray-300",
+                      "id": "OBvEP",
+                      "name": "Group Header",
                       "width": "fill_container",
-                      "height": 1
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "VABl4",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "CARD",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "WMaKt",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "tAXtF",
+                      "name": "Items",
+                      "width": "fill_container",
+                      "height": 131,
+                      "layout": "vertical",
+                      "gap": 20,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "WDsiy",
+                          "name": "Card default",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "d8F5yh",
+                              "type": "ref",
+                              "ref": "maUy6",
+                              "name": "Card instance"
+                            },
+                            {
+                              "type": "text",
+                              "id": "P7PgkZ",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Default",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "tAXtF",
-                  "name": "Items",
-                  "width": "fill_container",
-                  "height": 131,
-                  "layout": "vertical",
-                  "gap": 20,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "WDsiy",
-                      "name": "Card default",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "d8F5yh",
-                          "type": "ref",
-                          "ref": "maUy6",
-                          "name": "Card instance"
-                        },
-                        {
-                          "type": "text",
-                          "id": "P7PgkZ",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Default",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "vPxft",
-              "name": "Breadcrumb Column",
-              "width": 240,
-              "height": 200,
-              "layout": "none",
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "w02pn1",
-                  "x": 0,
-                  "y": 0,
-                  "name": "BC Heading",
+                  "id": "vPxft",
+                  "name": "Breadcrumb Column",
                   "width": 240,
-                  "height": 24,
+                  "height": 200,
                   "layout": "none",
                   "children": [
                     {
-                      "type": "text",
-                      "id": "YOo0u",
+                      "type": "frame",
+                      "id": "w02pn1",
                       "x": 0,
                       "y": 0,
-                      "name": "Label",
-                      "fill": "$color.gray-500",
-                      "content": "BREADCRUMB",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "rectangle",
-                      "id": "CvCTE",
-                      "x": 0,
-                      "y": 23,
-                      "name": "Divider",
-                      "fill": "$color.gray-300",
+                      "name": "BC Heading",
                       "width": 240,
-                      "height": 1
+                      "height": 24,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "YOo0u",
+                          "x": 0,
+                          "y": 0,
+                          "name": "Label",
+                          "fill": "$color.gray-500",
+                          "content": "BREADCRUMB",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "CvCTE",
+                          "x": 0,
+                          "y": 23,
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": 240,
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Xsyb5",
+                      "x": 0,
+                      "y": 40,
+                      "name": "BC Body",
+                      "width": 240,
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "id": "QEJwt",
+                          "type": "ref",
+                          "ref": "UEZoP",
+                          "name": "Breadcrumb",
+                          "width": 240
+                        },
+                        {
+                          "type": "text",
+                          "id": "fnrLC",
+                          "name": "Label",
+                          "fill": "#8c8c8c",
+                          "content": "Breadcrumb",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "Xsyb5",
-                  "x": 0,
-                  "y": 40,
-                  "name": "BC Body",
-                  "width": 240,
+                  "id": "Ompod",
+                  "name": "Text Inputs Group",
+                  "width": 260,
                   "layout": "vertical",
-                  "gap": 8,
-                  "children": [
-                    {
-                      "id": "QEJwt",
-                      "type": "ref",
-                      "ref": "UEZoP",
-                      "name": "Breadcrumb",
-                      "width": 240
-                    },
-                    {
-                      "type": "text",
-                      "id": "fnrLC",
-                      "name": "Label",
-                      "fill": "#8c8c8c",
-                      "content": "Breadcrumb",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "normal"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "Ompod",
-              "name": "Text Inputs Group",
-              "width": 260,
-              "layout": "vertical",
-              "gap": 16,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "Yk70W",
-                  "name": "Group Header",
-                  "width": "fill_container",
-                  "layout": "vertical",
-                  "gap": 10,
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "OF3HY",
-                      "name": "Group Title",
-                      "fill": "$color.gray-500",
-                      "content": "TEXT INPUT",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "rectangle",
-                      "id": "Cd5eh",
-                      "name": "Divider",
-                      "fill": "$color.gray-300",
-                      "width": "fill_container",
-                      "height": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "eEL5R",
-                  "name": "Items",
-                  "width": "fill_container",
-                  "layout": "vertical",
-                  "gap": 20,
+                  "gap": 16,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "XJAJQ",
-                      "name": "TextInput/Default",
+                      "id": "Yk70W",
+                      "name": "Group Header",
                       "width": "fill_container",
                       "layout": "vertical",
-                      "gap": 8,
+                      "gap": 10,
                       "children": [
                         {
-                          "id": "GIqJN",
-                          "type": "ref",
-                          "ref": "QxVfY",
-                          "name": "instance",
+                          "type": "text",
+                          "id": "OF3HY",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "TEXT INPUT",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "Cd5eh",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
                           "width": "fill_container",
-                          "descendants": {
-                            "vMtqi": {
-                              "content": "Placeholder",
-                              "fill": "$color.gray-500"
-                            }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "opZ8t",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Default",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
+                          "height": 1
                         }
                       ]
                     },
                     {
                       "type": "frame",
-                      "id": "bq8TM",
-                      "name": "TextInput/Filled",
+                      "id": "eEL5R",
+                      "name": "Items",
                       "width": "fill_container",
                       "layout": "vertical",
-                      "gap": 8,
+                      "gap": 20,
                       "children": [
                         {
-                          "id": "bA6LN",
-                          "type": "ref",
-                          "ref": "QxVfY",
-                          "name": "instance",
+                          "type": "frame",
+                          "id": "XJAJQ",
+                          "name": "TextInput/Default",
                           "width": "fill_container",
-                          "descendants": {
-                            "vMtqi": {
-                              "content": "Acme Corp",
-                              "fill": "$color.gray-900"
-                            }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "C5BvVa",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Filled",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "fN0Vt",
-                      "name": "TextInput/Focus",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "loB55",
-                          "type": "ref",
-                          "ref": "QxVfY",
-                          "name": "instance",
-                          "width": "fill_container",
-                          "stroke": "$color.blue-500",
-                          "effect": {
-                            "type": "shadow",
-                            "shadowType": "outer",
-                            "color": "$color.blue-300",
-                            "spread": 2
-                          },
-                          "descendants": {
-                            "vMtqi": {
-                              "content": "Placeholder",
-                              "fill": "$color.gray-500"
-                            }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "EUI3v",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Focus",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "fGrJI",
-                      "name": "TextInput/Error",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "SO1Nr",
-                          "type": "ref",
-                          "ref": "QxVfY",
-                          "name": "instance",
-                          "width": "fill_container",
-                          "stroke": "$color.red-500",
-                          "descendants": {
-                            "vMtqi": {
-                              "content": "user@@example",
-                              "fill": "$color.gray-900"
-                            }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "pdJdW",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Error",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "mBR6Y",
-                      "name": "TextInput/Disabled",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "f0gLz",
-                          "type": "ref",
-                          "ref": "QxVfY",
-                          "name": "instance",
-                          "width": "fill_container",
-                          "opacity": 0.5,
-                          "fill": "$color.gray-100",
-                          "descendants": {
-                            "vMtqi": {
-                              "content": "ACC-009912",
-                              "fill": "$color.gray-900"
-                            }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "BiqSP",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Disabled",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "NaNF6",
-              "name": "Number Inputs Group",
-              "width": 200,
-              "layout": "vertical",
-              "gap": 16,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "J5Y3NF",
-                  "name": "Group Header",
-                  "width": "fill_container",
-                  "layout": "vertical",
-                  "gap": 10,
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "ywNHS",
-                      "name": "Group Title",
-                      "fill": "$color.gray-500",
-                      "content": "NUMBER INPUT",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "rectangle",
-                      "id": "t4x8mq",
-                      "name": "Divider",
-                      "fill": "$color.gray-300",
-                      "width": "fill_container",
-                      "height": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "X4YYpP",
-                  "name": "Items",
-                  "width": "fill_container",
-                  "layout": "vertical",
-                  "gap": 20,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "l9gjpU",
-                      "name": "NumberInput/Default",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "PZp7j",
-                          "type": "ref",
-                          "ref": "mXtap",
-                          "name": "instance",
-                          "width": "fit_content",
-                          "descendants": {
-                            "gvKCH": {
-                              "content": "5"
-                            }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "sQNR2",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Default",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "sRuE4",
-                      "name": "NumberInput/Focus",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "JXnGd",
-                          "type": "ref",
-                          "ref": "mXtap",
-                          "name": "instance",
-                          "width": "fit_content",
-                          "effect": {
-                            "type": "shadow",
-                            "shadowType": "outer",
-                            "color": "$color.blue-300",
-                            "spread": 3
-                          },
-                          "descendants": {
-                            "gvKCH": {
-                              "content": "5"
-                            }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "B2r6Z",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Focus",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "H7Wln",
-                      "name": "NumberInput/At minimum",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "KxwoB",
-                          "type": "ref",
-                          "ref": "mXtap",
-                          "name": "instance",
-                          "width": "fit_content",
-                          "descendants": {
-                            "hZD8e": {
-                              "opacity": 0.5
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "GIqJN",
+                              "type": "ref",
+                              "ref": "QxVfY",
+                              "name": "instance",
+                              "width": "fill_container",
+                              "descendants": {
+                                "vMtqi": {
+                                  "content": "Placeholder",
+                                  "fill": "$color.gray-500"
+                                }
+                              }
                             },
-                            "gvKCH": {
-                              "content": "0"
+                            {
+                              "type": "text",
+                              "id": "opZ8t",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Default",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
                             }
-                          }
+                          ]
                         },
                         {
-                          "type": "text",
-                          "id": "c7Q44J",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Min reached",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "Q8j6o",
-                      "name": "NumberInput/At maximum",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "O5dK7",
-                          "type": "ref",
-                          "ref": "mXtap",
-                          "name": "instance",
-                          "width": "fit_content",
-                          "descendants": {
-                            "gvKCH": {
-                              "content": "999"
+                          "type": "frame",
+                          "id": "bq8TM",
+                          "name": "TextInput/Filled",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "bA6LN",
+                              "type": "ref",
+                              "ref": "QxVfY",
+                              "name": "instance",
+                              "width": "fill_container",
+                              "descendants": {
+                                "vMtqi": {
+                                  "content": "Acme Corp",
+                                  "fill": "$color.gray-900"
+                                }
+                              }
                             },
-                            "ocIhq": {
-                              "opacity": 0.5
+                            {
+                              "type": "text",
+                              "id": "C5BvVa",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Filled",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
                             }
-                          }
+                          ]
                         },
                         {
-                          "type": "text",
-                          "id": "IWlNf",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Max reached",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "XZ1qz",
-                      "name": "NumberInput/Disabled",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "uha1U",
-                          "type": "ref",
-                          "ref": "mXtap",
-                          "name": "instance",
-                          "width": "fit_content",
-                          "opacity": 0.5,
-                          "descendants": {
-                            "gvKCH": {
-                              "content": "5"
-                            }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "JYy6v",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Disabled",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "t6baJn",
-              "name": "Text Areas Group",
-              "width": 260,
-              "layout": "vertical",
-              "gap": 16,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "n10zY",
-                  "name": "Group Header",
-                  "width": "fill_container",
-                  "layout": "vertical",
-                  "gap": 10,
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "cYbT4",
-                      "name": "Group Title",
-                      "fill": "$color.gray-500",
-                      "content": "TEXT AREA",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "rectangle",
-                      "id": "dFcQE",
-                      "name": "Divider",
-                      "fill": "$color.gray-300",
-                      "width": "fill_container",
-                      "height": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "jZX0L",
-                  "name": "Items",
-                  "width": "fill_container",
-                  "layout": "vertical",
-                  "gap": 20,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "e4PGHQ",
-                      "name": "TextArea/Default",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "KuqDl",
-                          "type": "ref",
-                          "ref": "RE61E",
-                          "name": "instance",
+                          "type": "frame",
+                          "id": "fN0Vt",
+                          "name": "TextInput/Focus",
                           "width": "fill_container",
-                          "descendants": {
-                            "YsVOe": {
-                              "content": "Enter description...",
-                              "fill": "$color.gray-500"
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "loB55",
+                              "type": "ref",
+                              "ref": "QxVfY",
+                              "name": "instance",
+                              "width": "fill_container",
+                              "stroke": "$color.blue-500",
+                              "effect": {
+                                "type": "shadow",
+                                "shadowType": "outer",
+                                "color": "$color.blue-300",
+                                "spread": 2
+                              },
+                              "descendants": {
+                                "vMtqi": {
+                                  "content": "Placeholder",
+                                  "fill": "$color.gray-500"
+                                }
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "id": "EUI3v",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Focus",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
                             }
-                          }
+                          ]
                         },
                         {
-                          "type": "text",
-                          "id": "YqCJW",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Default",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "lprrV",
-                      "name": "TextArea/Filled",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "suMYm",
-                          "type": "ref",
-                          "ref": "RE61E",
-                          "name": "instance",
+                          "type": "frame",
+                          "id": "fGrJI",
+                          "name": "TextInput/Error",
                           "width": "fill_container",
-                          "descendants": {
-                            "YsVOe": {
-                              "content": "Issues TLS certificates for internal services.",
-                              "fill": "$color.gray-900"
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "SO1Nr",
+                              "type": "ref",
+                              "ref": "QxVfY",
+                              "name": "instance",
+                              "width": "fill_container",
+                              "stroke": "$color.red-500",
+                              "descendants": {
+                                "vMtqi": {
+                                  "content": "user@@example",
+                                  "fill": "$color.gray-900"
+                                }
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "id": "pdJdW",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Error",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
                             }
-                          }
+                          ]
                         },
                         {
-                          "type": "text",
-                          "id": "zmIli",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Filled",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "Nv97H",
-                      "name": "TextArea/Focus",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "E9V5w",
-                          "type": "ref",
-                          "ref": "RE61E",
-                          "name": "instance",
+                          "type": "frame",
+                          "id": "mBR6Y",
+                          "name": "TextInput/Disabled",
                           "width": "fill_container",
-                          "stroke": "$color.blue-500",
-                          "effect": {
-                            "type": "shadow",
-                            "shadowType": "outer",
-                            "color": "$color.blue-300",
-                            "spread": 2
-                          },
-                          "descendants": {
-                            "YsVOe": {
-                              "content": "Enter description...",
-                              "fill": "$color.gray-500"
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "f0gLz",
+                              "type": "ref",
+                              "ref": "QxVfY",
+                              "name": "instance",
+                              "width": "fill_container",
+                              "opacity": 0.5,
+                              "fill": "$color.gray-100",
+                              "descendants": {
+                                "vMtqi": {
+                                  "content": "ACC-009912",
+                                  "fill": "$color.gray-900"
+                                }
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "id": "BiqSP",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Disabled",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
                             }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "Gg8fJ",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Focus",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
+                          ]
                         }
                       ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "x9ThBj",
-                      "name": "TextArea/Error",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "W6bG26",
-                          "type": "ref",
-                          "ref": "RE61E",
-                          "name": "instance",
-                          "width": "fill_container",
-                          "stroke": "$color.red-500",
-                          "descendants": {
-                            "YsVOe": {
-                              "content": "Too short.",
-                              "fill": "$color.gray-900"
-                            }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "f3x6b",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Error",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "D05aAV",
-                      "name": "TextArea/Disabled",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "MZmWX",
-                          "type": "ref",
-                          "ref": "RE61E",
-                          "name": "instance",
-                          "width": "fill_container",
-                          "fill": "$color.gray-100",
-                          "opacity": 0.5,
-                          "descendants": {
-                            "YsVOe": {
-                              "content": "Imported from legacy system.",
-                              "fill": "$color.gray-900"
-                            }
-                          }
-                        },
-                        {
-                          "type": "text",
-                          "id": "yv6cE",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Disabled",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "r385du",
-              "name": "Selects Group",
-              "width": 260,
-              "layout": "vertical",
-              "gap": 16,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "dHdAR",
-                  "name": "Group Header",
-                  "width": "fill_container",
-                  "layout": "vertical",
-                  "gap": 10,
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "SknYJ",
-                      "name": "Group Title",
-                      "fill": "$color.gray-500",
-                      "content": "SELECT",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "rectangle",
-                      "id": "iijp0",
-                      "name": "Divider",
-                      "fill": "$color.gray-300",
-                      "width": "fill_container",
-                      "height": 1
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "nJbU3",
-                  "name": "Items",
-                  "width": "fill_container",
+                  "id": "NaNF6",
+                  "name": "Number Inputs Group",
+                  "width": 200,
                   "layout": "vertical",
-                  "gap": 20,
+                  "gap": 16,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "f9G9fd",
-                      "name": "Select/Default",
+                      "id": "J5Y3NF",
+                      "name": "Group Header",
                       "width": "fill_container",
                       "layout": "vertical",
-                      "gap": 8,
+                      "gap": 10,
                       "children": [
                         {
-                          "id": "IWBXg",
-                          "type": "ref",
-                          "ref": "qkMSt",
-                          "name": "instance",
-                          "width": "fill_container",
-                          "descendants": {
-                            "VEqvF": {
-                              "content": "Select...",
-                              "fill": "$color.gray-500"
-                            }
-                          }
+                          "type": "text",
+                          "id": "ywNHS",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "NUMBER INPUT",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600"
                         },
                         {
-                          "type": "text",
-                          "id": "jUf9r",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Default",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
+                          "type": "rectangle",
+                          "id": "t4x8mq",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
                         }
                       ]
                     },
                     {
                       "type": "frame",
-                      "id": "nvwVB",
-                      "name": "Select/Filled",
+                      "id": "X4YYpP",
+                      "name": "Items",
                       "width": "fill_container",
                       "layout": "vertical",
-                      "gap": 8,
+                      "gap": 20,
                       "children": [
                         {
-                          "id": "j1QOL",
-                          "type": "ref",
-                          "ref": "qkMSt",
-                          "name": "instance",
+                          "type": "frame",
+                          "id": "l9gjpU",
+                          "name": "NumberInput/Default",
                           "width": "fill_container",
-                          "descendants": {
-                            "VEqvF": {
-                              "content": "Certificate",
-                              "fill": "$color.gray-900"
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "PZp7j",
+                              "type": "ref",
+                              "ref": "mXtap",
+                              "name": "instance",
+                              "width": "fit_content",
+                              "descendants": {
+                                "gvKCH": {
+                                  "content": "5"
+                                }
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "id": "sQNR2",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Default",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
                             }
-                          }
+                          ]
                         },
                         {
-                          "type": "text",
-                          "id": "qUL9S",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Filled",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "vDDmU",
-                      "name": "Select/Focus",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "wbojd",
-                          "type": "ref",
-                          "ref": "qkMSt",
-                          "name": "instance",
+                          "type": "frame",
+                          "id": "sRuE4",
+                          "name": "NumberInput/Focus",
                           "width": "fill_container",
-                          "stroke": "$color.blue-500",
-                          "effect": {
-                            "type": "shadow",
-                            "shadowType": "outer",
-                            "color": "$color.blue-300",
-                            "spread": 2
-                          },
-                          "descendants": {
-                            "VEqvF": {
-                              "content": "Select...",
-                              "fill": "$color.gray-500"
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "JXnGd",
+                              "type": "ref",
+                              "ref": "mXtap",
+                              "name": "instance",
+                              "width": "fit_content",
+                              "effect": {
+                                "type": "shadow",
+                                "shadowType": "outer",
+                                "color": "$color.blue-300",
+                                "spread": 3
+                              },
+                              "descendants": {
+                                "gvKCH": {
+                                  "content": "5"
+                                }
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "id": "B2r6Z",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Focus",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
                             }
-                          }
+                          ]
                         },
                         {
-                          "type": "text",
-                          "id": "yuwDx",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Focus",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "b304Sr",
-                      "name": "Select/Multi",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "xhwc0",
-                          "type": "ref",
-                          "ref": "QmsCq",
-                          "name": "instance",
-                          "width": "fill_container"
-                        },
-                        {
-                          "type": "text",
-                          "id": "NQPvO",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Multi",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "MXBT9",
-                      "name": "Select/Disabled",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 8,
-                      "children": [
-                        {
-                          "id": "fro9J",
-                          "type": "ref",
-                          "ref": "qkMSt",
-                          "name": "instance",
+                          "type": "frame",
+                          "id": "H7Wln",
+                          "name": "NumberInput/At minimum",
                           "width": "fill_container",
-                          "fill": "$color.gray-100",
-                          "opacity": 0.5,
-                          "descendants": {
-                            "VEqvF": {
-                              "content": "Discovery",
-                              "fill": "$color.gray-900"
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "KxwoB",
+                              "type": "ref",
+                              "ref": "mXtap",
+                              "name": "instance",
+                              "width": "fit_content",
+                              "descendants": {
+                                "hZD8e": {
+                                  "opacity": 0.5
+                                },
+                                "gvKCH": {
+                                  "content": "0"
+                                }
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "id": "c7Q44J",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Min reached",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
                             }
-                          }
+                          ]
                         },
                         {
-                          "type": "text",
-                          "id": "gGlB0",
-                          "name": "Label",
-                          "fill": "$color.gray-700",
-                          "content": "Disabled",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "normal"
+                          "type": "frame",
+                          "id": "Q8j6o",
+                          "name": "NumberInput/At maximum",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "O5dK7",
+                              "type": "ref",
+                              "ref": "mXtap",
+                              "name": "instance",
+                              "width": "fit_content",
+                              "descendants": {
+                                "gvKCH": {
+                                  "content": "999"
+                                },
+                                "ocIhq": {
+                                  "opacity": 0.5
+                                }
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "id": "IWlNf",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Max reached",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "XZ1qz",
+                          "name": "NumberInput/Disabled",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "id": "uha1U",
+                              "type": "ref",
+                              "ref": "mXtap",
+                              "name": "instance",
+                              "width": "fit_content",
+                              "opacity": 0.5,
+                              "descendants": {
+                                "gvKCH": {
+                                  "content": "5"
+                                }
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "id": "JYy6v",
+                              "name": "Label",
+                              "fill": "$color.gray-700",
+                              "content": "Disabled",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -1546,7 +1116,7 @@
                   "y": 0,
                   "name": "Top Divider",
                   "fill": "$color.gray-300",
-                  "width": 1680,
+                  "width": 2220,
                   "height": 1
                 },
                 {
@@ -1556,7 +1126,7 @@
                   "y": 39,
                   "name": "Bottom Divider",
                   "fill": "$color.gray-300",
-                  "width": 1680,
+                  "width": 2220,
                   "height": 1
                 }
               ]
@@ -1660,6 +1230,229 @@
                           "fontWeight": "normal"
                         }
                       ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "t6baJn",
+                      "name": "Text Areas Group",
+                      "width": 260,
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "n10zY",
+                          "name": "Group Header",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 10,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "cYbT4",
+                              "name": "Group Title",
+                              "fill": "$color.gray-500",
+                              "content": "TEXT AREA",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "rectangle",
+                              "id": "dFcQE",
+                              "name": "Divider",
+                              "fill": "$color.gray-300",
+                              "width": "fill_container",
+                              "height": 1
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jZX0L",
+                          "name": "Items",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 20,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "e4PGHQ",
+                              "name": "TextArea/Default",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "id": "KuqDl",
+                                  "type": "ref",
+                                  "ref": "RE61E",
+                                  "name": "instance",
+                                  "width": "fill_container",
+                                  "descendants": {
+                                    "YsVOe": {
+                                      "content": "Enter description...",
+                                      "fill": "$color.gray-500"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "YqCJW",
+                                  "name": "Label",
+                                  "fill": "$color.gray-700",
+                                  "content": "Default",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "lprrV",
+                              "name": "TextArea/Filled",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "id": "suMYm",
+                                  "type": "ref",
+                                  "ref": "RE61E",
+                                  "name": "instance",
+                                  "width": "fill_container",
+                                  "descendants": {
+                                    "YsVOe": {
+                                      "content": "Issues TLS certificates for internal services.",
+                                      "fill": "$color.gray-900"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "zmIli",
+                                  "name": "Label",
+                                  "fill": "$color.gray-700",
+                                  "content": "Filled",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Nv97H",
+                              "name": "TextArea/Focus",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "id": "E9V5w",
+                                  "type": "ref",
+                                  "ref": "RE61E",
+                                  "name": "instance",
+                                  "width": "fill_container",
+                                  "stroke": "$color.blue-500",
+                                  "effect": {
+                                    "type": "shadow",
+                                    "shadowType": "outer",
+                                    "color": "$color.blue-300",
+                                    "spread": 2
+                                  },
+                                  "descendants": {
+                                    "YsVOe": {
+                                      "content": "Enter description...",
+                                      "fill": "$color.gray-500"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Gg8fJ",
+                                  "name": "Label",
+                                  "fill": "$color.gray-700",
+                                  "content": "Focus",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "x9ThBj",
+                              "name": "TextArea/Error",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "id": "W6bG26",
+                                  "type": "ref",
+                                  "ref": "RE61E",
+                                  "name": "instance",
+                                  "width": "fill_container",
+                                  "stroke": "$color.red-500",
+                                  "descendants": {
+                                    "YsVOe": {
+                                      "content": "Too short.",
+                                      "fill": "$color.gray-900"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "f3x6b",
+                                  "name": "Label",
+                                  "fill": "$color.gray-700",
+                                  "content": "Error",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "D05aAV",
+                              "name": "TextArea/Disabled",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "id": "MZmWX",
+                                  "type": "ref",
+                                  "ref": "RE61E",
+                                  "name": "instance",
+                                  "width": "fill_container",
+                                  "fill": "$color.gray-100",
+                                  "opacity": 0.5,
+                                  "descendants": {
+                                    "YsVOe": {
+                                      "content": "Imported from legacy system.",
+                                      "fill": "$color.gray-900"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "yv6cE",
+                                  "name": "Label",
+                                  "fill": "$color.gray-700",
+                                  "content": "Disabled",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 },
@@ -1750,6 +1543,222 @@
                           "fontWeight": "normal"
                         }
                       ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "r385du",
+                      "name": "Selects Group",
+                      "width": 260,
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dHdAR",
+                          "name": "Group Header",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 10,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "SknYJ",
+                              "name": "Group Title",
+                              "fill": "$color.gray-500",
+                              "content": "SELECT",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "rectangle",
+                              "id": "iijp0",
+                              "name": "Divider",
+                              "fill": "$color.gray-300",
+                              "width": "fill_container",
+                              "height": 1
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "nJbU3",
+                          "name": "Items",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 20,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "f9G9fd",
+                              "name": "Select/Default",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "id": "IWBXg",
+                                  "type": "ref",
+                                  "ref": "qkMSt",
+                                  "name": "instance",
+                                  "width": "fill_container",
+                                  "descendants": {
+                                    "VEqvF": {
+                                      "content": "Select...",
+                                      "fill": "$color.gray-500"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "jUf9r",
+                                  "name": "Label",
+                                  "fill": "$color.gray-700",
+                                  "content": "Default",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "nvwVB",
+                              "name": "Select/Filled",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "id": "j1QOL",
+                                  "type": "ref",
+                                  "ref": "qkMSt",
+                                  "name": "instance",
+                                  "width": "fill_container",
+                                  "descendants": {
+                                    "VEqvF": {
+                                      "content": "Certificate",
+                                      "fill": "$color.gray-900"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "qUL9S",
+                                  "name": "Label",
+                                  "fill": "$color.gray-700",
+                                  "content": "Filled",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "vDDmU",
+                              "name": "Select/Focus",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "id": "wbojd",
+                                  "type": "ref",
+                                  "ref": "qkMSt",
+                                  "name": "instance",
+                                  "width": "fill_container",
+                                  "stroke": "$color.blue-500",
+                                  "effect": {
+                                    "type": "shadow",
+                                    "shadowType": "outer",
+                                    "color": "$color.blue-300",
+                                    "spread": 2
+                                  },
+                                  "descendants": {
+                                    "VEqvF": {
+                                      "content": "Select...",
+                                      "fill": "$color.gray-500"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "yuwDx",
+                                  "name": "Label",
+                                  "fill": "$color.gray-700",
+                                  "content": "Focus",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "b304Sr",
+                              "name": "Select/Multi",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "id": "xhwc0",
+                                  "type": "ref",
+                                  "ref": "QmsCq",
+                                  "name": "instance",
+                                  "width": "fill_container"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "NQPvO",
+                                  "name": "Label",
+                                  "fill": "$color.gray-700",
+                                  "content": "Multi",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "MXBT9",
+                              "name": "Select/Disabled",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 8,
+                              "children": [
+                                {
+                                  "id": "fro9J",
+                                  "type": "ref",
+                                  "ref": "qkMSt",
+                                  "name": "instance",
+                                  "width": "fill_container",
+                                  "fill": "$color.gray-100",
+                                  "opacity": 0.5,
+                                  "descendants": {
+                                    "VEqvF": {
+                                      "content": "Discovery",
+                                      "fill": "$color.gray-900"
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "gGlB0",
+                                  "name": "Label",
+                                  "fill": "$color.gray-700",
+                                  "content": "Disabled",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }
@@ -1762,8 +1771,8 @@
     {
       "type": "frame",
       "id": "i4PcLp",
-      "x": 2000,
-      "y": 0,
+      "x": 0,
+      "y": 2000,
       "name": "Button/Primary",
       "reusable": true,
       "height": 40,
@@ -1791,8 +1800,8 @@
     {
       "type": "frame",
       "id": "E6DLJ0",
-      "x": 2000,
-      "y": 60,
+      "x": 141,
+      "y": 2000,
       "name": "Button/Danger",
       "reusable": true,
       "height": 40,
@@ -1820,8 +1829,8 @@
     {
       "type": "frame",
       "id": "dThoL",
-      "x": 2000,
-      "y": 120,
+      "x": 278,
+      "y": 2000,
       "name": "Button/Secondary",
       "reusable": true,
       "height": 40,
@@ -1849,8 +1858,8 @@
     {
       "type": "frame",
       "id": "uXBGa",
-      "x": 2000,
-      "y": 180,
+      "x": 439,
+      "y": 2000,
       "name": "Button/Outline",
       "reusable": true,
       "height": 40,
@@ -1881,8 +1890,8 @@
     {
       "type": "frame",
       "id": "sGgkm",
-      "x": 2000,
-      "y": 240,
+      "x": 575,
+      "y": 2000,
       "name": "Button/Ghost",
       "reusable": true,
       "height": 40,
@@ -1910,8 +1919,8 @@
     {
       "type": "frame",
       "id": "yLFn5",
-      "x": 2000,
-      "y": 320,
+      "x": 703,
+      "y": 2000,
       "name": "Switch/Off",
       "reusable": true,
       "width": 44,
@@ -1936,8 +1945,8 @@
     {
       "type": "frame",
       "id": "Hm8f2",
-      "x": 2000,
-      "y": 320,
+      "x": 795,
+      "y": 2000,
       "name": "Switch/On",
       "reusable": true,
       "width": 44,
@@ -1962,8 +1971,8 @@
     {
       "type": "frame",
       "id": "nyrTw",
-      "x": 2000,
-      "y": 380,
+      "x": 887,
+      "y": 2000,
       "name": "Checkbox/Unchecked",
       "reusable": true,
       "width": 20,
@@ -1977,8 +1986,8 @@
     {
       "type": "frame",
       "id": "H5ZN7s",
-      "x": 2000,
-      "y": 380,
+      "x": 955,
+      "y": 2000,
       "name": "Checkbox/Checked",
       "reusable": true,
       "width": 20,
@@ -2003,8 +2012,8 @@
     {
       "type": "frame",
       "id": "BKQ1x",
-      "x": 2000,
-      "y": 420,
+      "x": 1023,
+      "y": 2000,
       "name": "Checkbox/Label-Unchecked",
       "reusable": true,
       "gap": 10,
@@ -2037,8 +2046,8 @@
     {
       "type": "frame",
       "id": "OcXD9",
-      "x": 2000,
-      "y": 460,
+      "x": 1181,
+      "y": 2000,
       "name": "Checkbox/Label-Checked",
       "reusable": true,
       "gap": 10,
@@ -2082,8 +2091,8 @@
     {
       "type": "frame",
       "id": "maUy6",
-      "x": 2000,
-      "y": 520,
+      "x": 1339,
+      "y": 2000,
       "name": "Card",
       "reusable": true,
       "width": 240,
@@ -2146,8 +2155,8 @@
     {
       "type": "frame",
       "id": "RLZEG",
-      "x": 2000,
-      "y": 668,
+      "x": 1627,
+      "y": 2000,
       "name": "Input/DurationInput",
       "reusable": true,
       "width": 280,
@@ -2214,8 +2223,8 @@
     {
       "type": "frame",
       "id": "M8MdxZ",
-      "x": 2000,
-      "y": 766,
+      "x": 1955,
+      "y": 2000,
       "name": "Input/HostnameListInput",
       "reusable": true,
       "width": 280,
@@ -2395,8 +2404,8 @@
     {
       "type": "frame",
       "id": "n122a2",
-      "x": 2000,
-      "y": 859,
+      "x": 2283,
+      "y": 2000,
       "name": "Input/FileUpload",
       "reusable": true,
       "width": 280,
@@ -2603,8 +2612,8 @@
     {
       "type": "frame",
       "id": "BsErV",
-      "x": 2000,
-      "y": 1095,
+      "x": 2611,
+      "y": 2000,
       "name": "Input/MultipleValueTextInput",
       "reusable": true,
       "width": 280,
@@ -2750,8 +2759,8 @@
     {
       "type": "frame",
       "id": "cTiD9",
-      "x": 2000,
-      "y": 1152,
+      "x": 2939,
+      "y": 2000,
       "name": "Input/CodeEditor",
       "reusable": true,
       "clip": true,
@@ -2910,8 +2919,8 @@
     {
       "type": "frame",
       "id": "fIa5W",
-      "x": 2000,
-      "y": 1296,
+      "x": 3267,
+      "y": 2000,
       "name": "Input/DynamicContent",
       "reusable": true,
       "width": 280,
@@ -3054,8 +3063,8 @@
     {
       "type": "frame",
       "id": "UEZoP",
-      "x": 2000,
-      "y": 1474,
+      "x": 3595,
+      "y": 2000,
       "name": "Breadcrumb",
       "reusable": true,
       "width": 280,
@@ -3135,8 +3144,8 @@
     {
       "type": "frame",
       "id": "QxVfY",
-      "x": 0,
-      "y": 1605,
+      "x": 3923,
+      "y": 2000,
       "name": "TextInput/Field",
       "reusable": true,
       "width": 260,
@@ -3169,8 +3178,8 @@
     {
       "type": "frame",
       "id": "mXtap",
-      "x": 2340,
-      "y": 0,
+      "x": 4231,
+      "y": 2000,
       "name": "NumberInput",
       "reusable": true,
       "fill": "$color.white",
@@ -3283,8 +3292,8 @@
     {
       "type": "frame",
       "id": "RE61E",
-      "x": 0,
-      "y": 1706,
+      "x": 4387,
+      "y": 2000,
       "name": "TextArea/Field",
       "reusable": true,
       "width": 260,
@@ -3318,8 +3327,8 @@
     {
       "type": "frame",
       "id": "qkMSt",
-      "x": 0,
-      "y": 1838,
+      "x": 4695,
+      "y": 2000,
       "name": "Select/Single",
       "reusable": true,
       "width": 260,
@@ -3362,8 +3371,8 @@
     {
       "type": "frame",
       "id": "QmsCq",
-      "x": 0,
-      "y": 1939,
+      "x": 5003,
+      "y": 2000,
       "name": "Select/Multi",
       "reusable": true,
       "width": 260,

--- a/src/design-system/Design.pen
+++ b/src/design-system/Design.pen
@@ -1293,6 +1293,222 @@
                   ]
                 }
               ]
+            },
+            {
+              "type": "frame",
+              "id": "r385du",
+              "name": "Selects Group",
+              "width": 260,
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dHdAR",
+                  "name": "Group Header",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "SknYJ",
+                      "name": "Group Title",
+                      "fill": "$color.gray-500",
+                      "content": "SELECT",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "iijp0",
+                      "name": "Divider",
+                      "fill": "$color.gray-300",
+                      "width": "fill_container",
+                      "height": 1
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "nJbU3",
+                  "name": "Items",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 20,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "f9G9fd",
+                      "name": "Select/Default",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "id": "IWBXg",
+                          "type": "ref",
+                          "ref": "qkMSt",
+                          "name": "instance",
+                          "width": "fill_container",
+                          "descendants": {
+                            "VEqvF": {
+                              "content": "Select...",
+                              "fill": "$color.gray-500"
+                            }
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "id": "jUf9r",
+                          "name": "Label",
+                          "fill": "$color.gray-700",
+                          "content": "Default",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "nvwVB",
+                      "name": "Select/Filled",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "id": "j1QOL",
+                          "type": "ref",
+                          "ref": "qkMSt",
+                          "name": "instance",
+                          "width": "fill_container",
+                          "descendants": {
+                            "VEqvF": {
+                              "content": "Certificate",
+                              "fill": "$color.gray-900"
+                            }
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "id": "qUL9S",
+                          "name": "Label",
+                          "fill": "$color.gray-700",
+                          "content": "Filled",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vDDmU",
+                      "name": "Select/Focus",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "id": "wbojd",
+                          "type": "ref",
+                          "ref": "qkMSt",
+                          "name": "instance",
+                          "width": "fill_container",
+                          "stroke": "$color.blue-500",
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "$color.blue-300",
+                            "spread": 2
+                          },
+                          "descendants": {
+                            "VEqvF": {
+                              "content": "Select...",
+                              "fill": "$color.gray-500"
+                            }
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "id": "yuwDx",
+                          "name": "Label",
+                          "fill": "$color.gray-700",
+                          "content": "Focus",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "b304Sr",
+                      "name": "Select/Multi",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "id": "xhwc0",
+                          "type": "ref",
+                          "ref": "QmsCq",
+                          "name": "instance",
+                          "width": "fill_container"
+                        },
+                        {
+                          "type": "text",
+                          "id": "NQPvO",
+                          "name": "Label",
+                          "fill": "$color.gray-700",
+                          "content": "Multi",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "MXBT9",
+                      "name": "Select/Disabled",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "id": "fro9J",
+                          "type": "ref",
+                          "ref": "qkMSt",
+                          "name": "instance",
+                          "width": "fill_container",
+                          "fill": "$color.gray-100",
+                          "opacity": 0.5,
+                          "descendants": {
+                            "VEqvF": {
+                              "content": "Discovery",
+                              "fill": "$color.gray-900"
+                            }
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "id": "gGlB0",
+                          "name": "Label",
+                          "fill": "$color.gray-700",
+                          "content": "Disabled",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
@@ -3096,6 +3312,198 @@
           "fontFamily": "Inter",
           "fontSize": 14,
           "fontWeight": "normal"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "qkMSt",
+      "x": 0,
+      "y": 1838,
+      "name": "Select/Single",
+      "reusable": true,
+      "width": 260,
+      "fill": "$color.white",
+      "cornerRadius": 8,
+      "stroke": "$color.gray-200",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "gap": 8,
+      "padding": [
+        12,
+        16
+      ],
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "text",
+          "id": "VEqvF",
+          "name": "Value",
+          "fill": "$color.gray-500",
+          "textGrowth": "fixed-width",
+          "width": "fill_container",
+          "content": "Placeholder",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "icon",
+          "id": "DOYAN",
+          "name": "Chevron",
+          "width": 14,
+          "height": 14,
+          "icon": "chevrons-up-down",
+          "library": "lucide",
+          "fill": "$color.gray-700"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "QmsCq",
+      "x": 0,
+      "y": 1939,
+      "name": "Select/Multi",
+      "reusable": true,
+      "width": 260,
+      "fill": "$color.white",
+      "cornerRadius": 8,
+      "stroke": "$color.gray-200",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "gap": 6,
+      "padding": [
+        8,
+        12
+      ],
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "dN0tO",
+          "name": "Chips",
+          "width": "fill_container",
+          "gap": 4,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "wkDYW",
+              "name": "Chip",
+              "fill": "$color.white",
+              "cornerRadius": 999,
+              "stroke": "$color.gray-200",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": 6,
+              "padding": [
+                3,
+                4,
+                3,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "W3MsQA",
+                  "name": "Chip Label",
+                  "fill": "$color.gray-900",
+                  "content": "Active",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "jlwtN",
+                  "name": "Remove",
+                  "width": 20,
+                  "height": 20,
+                  "fill": "$color.gray-200",
+                  "cornerRadius": 999,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "F4D6S",
+                      "name": "X",
+                      "width": 12,
+                      "height": 12,
+                      "icon": "x",
+                      "library": "lucide",
+                      "fill": "$color.gray-800"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GVgYJ",
+              "name": "Chip",
+              "fill": "$color.white",
+              "cornerRadius": 999,
+              "stroke": "$color.gray-200",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": 6,
+              "padding": [
+                3,
+                4,
+                3,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "L5aAK",
+                  "name": "Chip Label",
+                  "fill": "$color.gray-900",
+                  "content": "Pending",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "F4LHb",
+                  "name": "Remove",
+                  "width": 20,
+                  "height": 20,
+                  "fill": "$color.gray-200",
+                  "cornerRadius": 999,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "itL4G",
+                      "name": "X",
+                      "width": 12,
+                      "height": 12,
+                      "icon": "x",
+                      "library": "lucide",
+                      "fill": "$color.gray-800"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "icon",
+          "id": "vczvf",
+          "name": "Chevron",
+          "width": 14,
+          "height": 14,
+          "icon": "chevrons-up-down",
+          "library": "lucide",
+          "fill": "$color.gray-700"
         }
       ]
     }

--- a/src/design-system/PENCIL.md
+++ b/src/design-system/PENCIL.md
@@ -216,6 +216,7 @@ Always set `name` on every node. Use descriptive, hierarchical names:
 | Input | `src/components/Input/Input.pen` |
 | NumberInput | `src/components/NumberInput/NumberInput.pen` |
 | TextArea | `src/components/TextArea/TextArea.pen` |
+| Select | `src/components/Select/Select.pen` |
 
 Button.pen is the most complete reference — it has 6 pages (Light/Dark × Solid/Outline/Transparent) showing all 5 color variants across 4 states.
 
@@ -241,6 +242,7 @@ Switch.pen has the richest single-page structure: States Table + Sizes + Example
 | Card visual (border, shadow, layout, typography) | `Card` |
 | TextInput visual (border, radius, focus ring, padding) | `TextInput/Field` |
 | TextArea visual (border, radius, focus ring, padding, height) | `TextArea/Field` |
+| Select visual (trigger border, radius, focus ring, chevron, chips) | `Select/Single`, `Select/Multi` |
 | NumberInput visual (container, stepper buttons, value) | `NumberInput` |
 | Input sub-component visual (any of the 6 types) | `Input/DurationInput`, `Input/HostnameListInput`, `Input/FileUpload`, `Input/MultipleValueTextInput`, `Input/CodeEditor`, `Input/DynamicContent` |
 | New component `.pen` created | Add new reusable components + a new column in the showcase |
@@ -274,6 +276,8 @@ These IDs change if components are ever deleted and recreated. Re-read `get_edit
 | Card | `maUy6` | Card.pen |
 | TextInput/Field | `QxVfY` | TextInput.pen |
 | TextArea/Field | `RE61E` | TextArea.pen |
+| Select/Single | `qkMSt` | Select.pen |
+| Select/Multi | `QmsCq` | Select.pen |
 | NumberInput | `mXtap` | NumberInput.pen |
 | Breadcrumb | `UEZoP` | Breadcrumb.pen |
 | Input/DurationInput | `RLZEG` | Input.pen |


### PR DESCRIPTION
Closes #1707

Adds the **Select** component to the Pencil design system.

## Select.pen
- **Light + Dark pages** following the standard section order (Header → States Table → Examples).
- **States Table** — rows: Single (placeholder), Selected (value), Multi (chips); columns: Default · Hover · Focus · Disabled.
- **Examples** — open menu (selected + highlighted + disabled options), searchable dropdown (search field + filtered list), multi-select with clearable chips, and validation (label + required + error message).
- Tokenised colors only, focus rings via shadow effect, descriptive node names. Dropdown panel uses a border only (matches `CONTENT_CLASSES`, which has no drop shadow).

## Design.pen sync
- New reusable components `Select/Single` and `Select/Multi`.
- New **SELECT** showcase column (Default / Filled / Focus / Multi / Disabled).
- Widened the library frame to fit the new column; consolidated all reusable definitions into a single parking column below the showcase.

## Docs
- PENCIL.md §8 (component files), §9 (Design.pen sync table + reusable IDs) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)