### PR TITLE
Pencil - StatusCircle component

### DIFF
--- a/src/components/Dialog/Dialog.pen
+++ b/src/components/Dialog/Dialog.pen
@@ -1,0 +1,2991 @@
+{
+  "version": "2.13",
+  "children": [
+    {
+      "type": "frame",
+      "id": "H7MEt",
+      "x": 0,
+      "y": 0,
+      "name": "Dialog / Light",
+      "clip": true,
+      "width": 680,
+      "fill": "$color.white",
+      "cornerRadius": 12,
+      "stroke": "$color.gray-200",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "KKIxb",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "N3glwm",
+              "name": "Title",
+              "fill": "$color.neutral-900",
+              "content": "Dialog",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "qK26F",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Modal dialog built on Radix. Optional circular icon, caption heading, scrollable body, and a right-aligned footer button row. Delete/destroy variants are centered and borderless.",
+              "lineHeight": 1.4,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "M5bdnW",
+          "name": "Preview Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "FEcTK",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "PREVIEW",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "XKNgR",
+              "name": "Scrim",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$color.dialog-scrim",
+              "cornerRadius": 10,
+              "padding": 40,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "S7CYg",
+                  "name": "Default Dialog",
+                  "width": 480,
+                  "fill": "$color.white",
+                  "cornerRadius": 12,
+                  "stroke": "$color.gray-200",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000002e",
+                    "offset": {
+                      "x": 0,
+                      "y": 10
+                    },
+                    "blur": 30,
+                    "spread": -5
+                  },
+                  "layout": "vertical",
+                  "padding": [
+                    24,
+                    24,
+                    16,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "KAZGI",
+                      "layoutPosition": "absolute",
+                      "x": 440,
+                      "y": 8,
+                      "name": "Close",
+                      "width": 32,
+                      "height": 32,
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "mCzew",
+                          "name": "X",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "x",
+                          "library": "lucide",
+                          "fill": "$color.gray-500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "n2LuGL",
+                      "name": "Dialog Header",
+                      "width": "fill_container",
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": {
+                        "bottom": 1
+                      },
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "padding": [
+                        0,
+                        0,
+                        16,
+                        0
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "q818oT",
+                          "name": "Caption",
+                          "fill": "$color.neutral-900",
+                          "content": "Rename signing profile",
+                          "fontFamily": "Inter",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "VtM5n",
+                      "name": "Dialog Body",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "padding": [
+                        16,
+                        0
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "FqyTn",
+                          "name": "Body Text",
+                          "fill": "$color.gray-500",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Enter a new name for this signing profile. The change is applied immediately and will be visible to everyone with access.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xDUQJ",
+                      "name": "Dialog Footer",
+                      "width": "fill_container",
+                      "gap": 16,
+                      "padding": [
+                        16,
+                        0
+                      ],
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "n0xj1U",
+                          "name": "Cancel Button",
+                          "fill": "$color.gray-100",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            10,
+                            14
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "u99Ow",
+                              "name": "Label",
+                              "fill": "$color.gray-800",
+                              "content": "Cancel",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "imopu",
+                          "name": "Save Button",
+                          "fill": "$color.blue-600",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            10,
+                            14
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "g98nPP",
+                              "name": "Label",
+                              "fill": "$color.white",
+                              "content": "Save",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "qTTvN",
+          "name": "Icon Variants Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "GQsp0",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "ICON VARIANTS",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "e6a0x",
+              "name": "Variants Grid",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "G5PpV",
+                  "name": "Variants Row 1",
+                  "width": "fill_container",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "gse8Y",
+                      "name": "Del Card",
+                      "width": "fill_container",
+                      "fill": "$color.white",
+                      "cornerRadius": 12,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#00000026",
+                        "offset": {
+                          "x": 0,
+                          "y": 8
+                        },
+                        "blur": 24,
+                        "spread": -6
+                      },
+                      "layout": "vertical",
+                      "padding": [
+                        20,
+                        20,
+                        12,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "VbV8t",
+                          "name": "Del Head",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 12,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "E8hMMa",
+                              "name": "Del Circle",
+                              "width": 64,
+                              "height": 64,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "rsIEt",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "Del Outer",
+                                  "fill": "$color.red-800-6",
+                                  "width": 64,
+                                  "height": 64
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "P77BY",
+                                  "x": 8,
+                                  "y": 8,
+                                  "name": "Del Inner",
+                                  "fill": "$color.red-800-12",
+                                  "width": 48,
+                                  "height": 48
+                                },
+                                {
+                                  "type": "icon",
+                                  "id": "We9uf",
+                                  "x": 20,
+                                  "y": 20,
+                                  "name": "Del Icon",
+                                  "width": 24,
+                                  "height": 24,
+                                  "icon": "trash-2",
+                                  "library": "lucide",
+                                  "fill": "$color.red-800"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "qATRc",
+                              "name": "Del Caption",
+                              "fill": "$color.neutral-900",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Delete profile?",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 18,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "loSgo",
+                          "name": "Del BodyWrap",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "wWZx1",
+                              "name": "Del Body",
+                              "fill": "$color.gray-500",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "This action cannot be undone. The signing profile and all of its records will be permanently removed.",
+                              "lineHeight": 1.5,
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "G7BFl",
+                          "name": "Del Foot",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "justifyContent": "end",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "JBw5B",
+                              "name": "Del Cancel Btn",
+                              "fill": "$color.gray-100",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "M7Nkh",
+                                  "name": "Del Cancel Lbl",
+                                  "fill": "$color.gray-800",
+                                  "content": "Cancel",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "CEKjZ",
+                              "name": "Del Delete Btn",
+                              "fill": "$color.red-500",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "qNSMi",
+                                  "name": "Del Delete Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Delete",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "h3Z0er",
+                      "name": "Warn Card",
+                      "width": "fill_container",
+                      "fill": "$color.white",
+                      "cornerRadius": 12,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#00000026",
+                        "offset": {
+                          "x": 0,
+                          "y": 8
+                        },
+                        "blur": 24,
+                        "spread": -6
+                      },
+                      "layout": "vertical",
+                      "padding": [
+                        20,
+                        20,
+                        12,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hJL3G",
+                          "name": "Warn Head",
+                          "width": "fill_container",
+                          "stroke": "$color.gray-200",
+                          "strokeWidth": {
+                            "bottom": 1
+                          },
+                          "strokeAlignment": "inner",
+                          "layout": "vertical",
+                          "gap": 12,
+                          "padding": [
+                            0,
+                            0,
+                            16,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "uU792",
+                              "name": "Warn Circle",
+                              "width": 64,
+                              "height": 64,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "L8ZMZ",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "Warn Outer",
+                                  "fill": "$color.red-800-6",
+                                  "width": 64,
+                                  "height": 64
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "zkyvt",
+                                  "x": 8,
+                                  "y": 8,
+                                  "name": "Warn Inner",
+                                  "fill": "$color.red-800-12",
+                                  "width": 48,
+                                  "height": 48
+                                },
+                                {
+                                  "type": "icon",
+                                  "id": "VB668",
+                                  "x": 20,
+                                  "y": 20,
+                                  "name": "Warn Icon",
+                                  "width": 24,
+                                  "height": 24,
+                                  "icon": "triangle-alert",
+                                  "library": "lucide",
+                                  "fill": "$color.red-800"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "cKPAy",
+                              "name": "Warn Caption",
+                              "fill": "$color.neutral-900",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Certificates in use",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 18,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "rah74",
+                          "name": "Warn BodyWrap",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "mZlTY",
+                              "name": "Warn Body",
+                              "fill": "$color.gray-500",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Some certificates are still associated with this entity. Proceeding may affect dependent services.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "VM244",
+                          "name": "Warn Foot",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "justifyContent": "end",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "DAZGE",
+                              "name": "Warn Cancel Btn",
+                              "fill": "$color.gray-100",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "U69sn",
+                                  "name": "Warn Cancel Lbl",
+                                  "fill": "$color.gray-800",
+                                  "content": "Cancel",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "mgDG1",
+                              "name": "Warn Proceed Btn",
+                              "fill": "$color.red-500",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "lBeL4",
+                                  "name": "Warn Proceed Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Proceed",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ti2RJ",
+                  "name": "Variants Row 2",
+                  "width": "fill_container",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Sw4qh",
+                      "name": "Info Card",
+                      "width": "fill_container",
+                      "fill": "$color.white",
+                      "cornerRadius": 12,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#00000026",
+                        "offset": {
+                          "x": 0,
+                          "y": 8
+                        },
+                        "blur": 24,
+                        "spread": -6
+                      },
+                      "layout": "vertical",
+                      "padding": [
+                        20,
+                        20,
+                        12,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "traZh",
+                          "name": "Info Head",
+                          "width": "fill_container",
+                          "stroke": "$color.gray-200",
+                          "strokeWidth": {
+                            "bottom": 1
+                          },
+                          "strokeAlignment": "inner",
+                          "layout": "vertical",
+                          "gap": 12,
+                          "padding": [
+                            0,
+                            0,
+                            16,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Y0X0Hg",
+                              "name": "Info Circle",
+                              "width": 64,
+                              "height": 64,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "iA4Ds",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "Info Outer",
+                                  "fill": "$color.icon-default-6",
+                                  "width": 64,
+                                  "height": 64
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "OP4YN",
+                                  "x": 8,
+                                  "y": 8,
+                                  "name": "Info Inner",
+                                  "fill": "$color.icon-default-12",
+                                  "width": 48,
+                                  "height": 48
+                                },
+                                {
+                                  "type": "icon",
+                                  "id": "k6dTPO",
+                                  "x": 20,
+                                  "y": 20,
+                                  "name": "Info Icon",
+                                  "width": 24,
+                                  "height": 24,
+                                  "icon": "info",
+                                  "library": "lucide",
+                                  "fill": "$color.icon-default"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "LXqpS",
+                              "name": "Info Caption",
+                              "fill": "$color.neutral-900",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Update available",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 18,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ZciQH",
+                          "name": "Info BodyWrap",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ZJ29O",
+                              "name": "Info Body",
+                              "fill": "$color.gray-500",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "A new connector version is available. Review the changelog before updating to the latest release.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Yqx4o",
+                          "name": "Info Foot",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "justifyContent": "end",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "T4Y8e",
+                              "name": "Info Cancel Btn",
+                              "fill": "$color.gray-100",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "w8RAwP",
+                                  "name": "Info Cancel Lbl",
+                                  "fill": "$color.gray-800",
+                                  "content": "Cancel",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Ds7k8",
+                              "name": "Info Got it Btn",
+                              "fill": "$color.blue-600",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "q1j92Y",
+                                  "name": "Info Got it Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Got it",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bi7cM",
+                      "name": "Succ Card",
+                      "width": "fill_container",
+                      "fill": "$color.white",
+                      "cornerRadius": 12,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#00000026",
+                        "offset": {
+                          "x": 0,
+                          "y": 8
+                        },
+                        "blur": 24,
+                        "spread": -6
+                      },
+                      "layout": "vertical",
+                      "padding": [
+                        20,
+                        20,
+                        12,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "NgP4s",
+                          "name": "Succ Head",
+                          "width": "fill_container",
+                          "stroke": "$color.gray-200",
+                          "strokeWidth": {
+                            "bottom": 1
+                          },
+                          "strokeAlignment": "inner",
+                          "layout": "vertical",
+                          "gap": 12,
+                          "padding": [
+                            0,
+                            0,
+                            16,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "UHB04",
+                              "name": "Succ Circle",
+                              "width": 64,
+                              "height": 64,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "nwas7",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "Succ Outer",
+                                  "fill": "$color.teal-100-30",
+                                  "width": 64,
+                                  "height": 64
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "CcB1O",
+                                  "x": 8,
+                                  "y": 8,
+                                  "name": "Succ Inner",
+                                  "fill": "$color.teal-100",
+                                  "width": 48,
+                                  "height": 48
+                                },
+                                {
+                                  "type": "icon",
+                                  "id": "Y3aWZM",
+                                  "x": 20,
+                                  "y": 20,
+                                  "name": "Succ Icon",
+                                  "width": 24,
+                                  "height": 24,
+                                  "icon": "check",
+                                  "library": "lucide",
+                                  "fill": "$color.teal-800"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "A0MsA",
+                              "name": "Succ Caption",
+                              "fill": "$color.neutral-900",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Profile created",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 18,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "p5OMn",
+                          "name": "Succ BodyWrap",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "JxO9r",
+                              "name": "Succ Body",
+                              "fill": "$color.gray-500",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "The signing profile was created successfully and is now ready to issue certificates.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "t7Z1e",
+                          "name": "Succ Foot",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "justifyContent": "end",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "eOi62",
+                              "name": "Succ Cancel Btn",
+                              "fill": "$color.gray-100",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "bGLEK",
+                                  "name": "Succ Cancel Lbl",
+                                  "fill": "$color.gray-800",
+                                  "content": "Cancel",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "fpJCm",
+                              "name": "Succ Done Btn",
+                              "fill": "$color.blue-600",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "FatOz",
+                                  "name": "Succ Done Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Done",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "vin9T",
+          "name": "Sizes Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "c3CO2",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "SIZES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "X8YnYV",
+              "name": "Sizes List",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dmYLu",
+                  "name": "Size sm Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ccQ3z",
+                      "name": "Size sm Bar",
+                      "width": 200,
+                      "height": 40,
+                      "fill": "$color.gray-100",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "rpWUw",
+                          "name": "Size sm Name",
+                          "fill": "$color.neutral-900",
+                          "content": "sm",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "PrfxB",
+                      "name": "Size sm Dim",
+                      "fill": "$color.gray-500",
+                      "content": "max-w-sm · 384px",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "P5PzKA",
+                  "name": "Size md Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "PNynI",
+                      "name": "Size md Bar",
+                      "width": 267,
+                      "height": 40,
+                      "fill": "$color.gray-100",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "aMzPp",
+                          "name": "Size md Name",
+                          "fill": "$color.neutral-900",
+                          "content": "md",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "G5sRG0",
+                      "name": "Size md Dim",
+                      "fill": "$color.gray-500",
+                      "content": "max-w-lg · 512px",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "iark7",
+                  "name": "Size lg Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "lMfpX",
+                      "name": "Size lg Bar",
+                      "width": 300,
+                      "height": 40,
+                      "fill": "$color.gray-100",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "iUGuW",
+                          "name": "Size lg Name",
+                          "fill": "$color.neutral-900",
+                          "content": "lg",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "A8i0n",
+                      "name": "Size lg Dim",
+                      "fill": "$color.gray-500",
+                      "content": "max-w-xl · 576px",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dQwq3",
+                  "name": "Size xl Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "MGhZl",
+                      "name": "Size xl Bar",
+                      "width": 467,
+                      "height": 40,
+                      "fill": "$color.gray-100",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JLkbl",
+                          "name": "Size xl Name",
+                          "fill": "$color.neutral-900",
+                          "content": "xl",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Jy8l7",
+                      "name": "Size xl Dim",
+                      "fill": "$color.gray-500",
+                      "content": "max-w-4xl · 896px",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "UArgt",
+                  "name": "Size xxl Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "tTiB8",
+                      "name": "Size xxl Bar",
+                      "width": 600,
+                      "height": 40,
+                      "fill": "$color.gray-100",
+                      "cornerRadius": 8,
+                      "stroke": "$color.gray-200",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "s6Vo4",
+                          "name": "Size xxl Name",
+                          "fill": "$color.neutral-900",
+                          "content": "xxl",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Pownn",
+                      "name": "Size xxl Dim",
+                      "fill": "$color.gray-500",
+                      "content": "max-w-6xl · 1152px",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "YDmSf",
+      "x": 740,
+      "y": 0,
+      "name": "Dialog / Dark",
+      "clip": true,
+      "width": 680,
+      "fill": "$color.neutral-900",
+      "cornerRadius": 12,
+      "stroke": "$color.neutral-700",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "nKuQP",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "J9hXr",
+              "name": "Title",
+              "fill": "$color.neutral-200",
+              "content": "Dialog",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "hdKK4",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Modal dialog built on Radix. Optional circular icon, caption heading, scrollable body, and a right-aligned footer button row. Delete/destroy variants are centered and borderless.",
+              "lineHeight": 1.4,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "G4C1Vr",
+          "name": "Preview Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "bseQF",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "PREVIEW",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "Own8a",
+              "name": "Scrim",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$color.dialog-scrim",
+              "cornerRadius": 10,
+              "padding": 40,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NRpbl",
+                  "name": "Default Dialog",
+                  "width": 480,
+                  "fill": "$color.neutral-800",
+                  "cornerRadius": 12,
+                  "stroke": "$color.neutral-700",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#0000002e",
+                    "offset": {
+                      "x": 0,
+                      "y": 10
+                    },
+                    "blur": 30,
+                    "spread": -5
+                  },
+                  "layout": "vertical",
+                  "padding": [
+                    24,
+                    24,
+                    16,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Blyd8",
+                      "layoutPosition": "absolute",
+                      "x": 440,
+                      "y": 8,
+                      "name": "Close",
+                      "width": 32,
+                      "height": 32,
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "A1NJw",
+                          "name": "X",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "x",
+                          "library": "lucide",
+                          "fill": "$color.white"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "K3qjM",
+                      "name": "Dialog Header",
+                      "width": "fill_container",
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": {
+                        "bottom": 1
+                      },
+                      "strokeAlignment": "inner",
+                      "layout": "vertical",
+                      "padding": [
+                        0,
+                        0,
+                        16,
+                        0
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Gkum9",
+                          "name": "Caption",
+                          "fill": "$color.white",
+                          "content": "Rename signing profile",
+                          "fontFamily": "Inter",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "g4q6V",
+                      "name": "Dialog Body",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "padding": [
+                        16,
+                        0
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dCaCZ",
+                          "name": "Body Text",
+                          "fill": "$color.neutral-300",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Enter a new name for this signing profile. The change is applied immediately and will be visible to everyone with access.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oIteh",
+                      "name": "Dialog Footer",
+                      "width": "fill_container",
+                      "gap": 16,
+                      "padding": [
+                        16,
+                        0
+                      ],
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "IGxRH",
+                          "name": "Cancel Button",
+                          "fill": "$color.white-10",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            10,
+                            14
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "t6Ijhi",
+                              "name": "Label",
+                              "fill": "$color.white",
+                              "content": "Cancel",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "JdGmb",
+                          "name": "Save Button",
+                          "fill": "$color.blue-600",
+                          "cornerRadius": 8,
+                          "gap": 8,
+                          "padding": [
+                            10,
+                            14
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "l7laR",
+                              "name": "Label",
+                              "fill": "$color.white",
+                              "content": "Save",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "I9jyA",
+          "name": "Icon Variants Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "kfpEp",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "ICON VARIANTS",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "UNMR5",
+              "name": "Variants Grid",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "VYYFC",
+                  "name": "Variants Row 1",
+                  "width": "fill_container",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "MXrJW",
+                      "name": "Del Card",
+                      "width": "fill_container",
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 12,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#00000026",
+                        "offset": {
+                          "x": 0,
+                          "y": 8
+                        },
+                        "blur": 24,
+                        "spread": -6
+                      },
+                      "layout": "vertical",
+                      "padding": [
+                        20,
+                        20,
+                        12,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "LbBMZ",
+                          "name": "Del Head",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 12,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "roGFC",
+                              "name": "Del Circle",
+                              "width": 64,
+                              "height": 64,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "UOvj9",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "Del Outer",
+                                  "fill": "$color.red-800-6",
+                                  "width": 64,
+                                  "height": 64
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "J7IuMQ",
+                                  "x": 8,
+                                  "y": 8,
+                                  "name": "Del Inner",
+                                  "fill": "$color.red-800-12",
+                                  "width": 48,
+                                  "height": 48
+                                },
+                                {
+                                  "type": "icon",
+                                  "id": "gXka6",
+                                  "x": 20,
+                                  "y": 20,
+                                  "name": "Del Icon",
+                                  "width": 24,
+                                  "height": 24,
+                                  "icon": "trash-2",
+                                  "library": "lucide",
+                                  "fill": "$color.red-800"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "TPwG6",
+                              "name": "Del Caption",
+                              "fill": "$color.white",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Delete profile?",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 18,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "h5pJ3d",
+                          "name": "Del BodyWrap",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "vBtxy",
+                              "name": "Del Body",
+                              "fill": "$color.neutral-300",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "This action cannot be undone. The signing profile and all of its records will be permanently removed.",
+                              "lineHeight": 1.5,
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "EH97h",
+                          "name": "Del Foot",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "justifyContent": "end",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "GLQPH",
+                              "name": "Del Cancel Btn",
+                              "fill": "$color.white-10",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "HDPKs",
+                                  "name": "Del Cancel Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Cancel",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "p9PKJt",
+                              "name": "Del Delete Btn",
+                              "fill": "$color.red-500",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Xuatk",
+                                  "name": "Del Delete Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Delete",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yyUEl",
+                      "name": "Warn Card",
+                      "width": "fill_container",
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 12,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#00000026",
+                        "offset": {
+                          "x": 0,
+                          "y": 8
+                        },
+                        "blur": 24,
+                        "spread": -6
+                      },
+                      "layout": "vertical",
+                      "padding": [
+                        20,
+                        20,
+                        12,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "VR3aZ",
+                          "name": "Warn Head",
+                          "width": "fill_container",
+                          "stroke": "$color.neutral-700",
+                          "strokeWidth": {
+                            "bottom": 1
+                          },
+                          "strokeAlignment": "inner",
+                          "layout": "vertical",
+                          "gap": 12,
+                          "padding": [
+                            0,
+                            0,
+                            16,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "fZujz",
+                              "name": "Warn Circle",
+                              "width": 64,
+                              "height": 64,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "FUUpU",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "Warn Outer",
+                                  "fill": "$color.red-800-6",
+                                  "width": 64,
+                                  "height": 64
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "NhOTQ",
+                                  "x": 8,
+                                  "y": 8,
+                                  "name": "Warn Inner",
+                                  "fill": "$color.red-800-12",
+                                  "width": 48,
+                                  "height": 48
+                                },
+                                {
+                                  "type": "icon",
+                                  "id": "iY1S1",
+                                  "x": 20,
+                                  "y": 20,
+                                  "name": "Warn Icon",
+                                  "width": 24,
+                                  "height": 24,
+                                  "icon": "triangle-alert",
+                                  "library": "lucide",
+                                  "fill": "$color.red-800"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "t6vyq",
+                              "name": "Warn Caption",
+                              "fill": "$color.white",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Certificates in use",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 18,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "GDsJO",
+                          "name": "Warn BodyWrap",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "qeSGC",
+                              "name": "Warn Body",
+                              "fill": "$color.neutral-300",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Some certificates are still associated with this entity. Proceeding may affect dependent services.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "cCZX7",
+                          "name": "Warn Foot",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "justifyContent": "end",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "fzHeH",
+                              "name": "Warn Cancel Btn",
+                              "fill": "$color.white-10",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "lFE4Q",
+                                  "name": "Warn Cancel Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Cancel",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "BPEtc",
+                              "name": "Warn Proceed Btn",
+                              "fill": "$color.red-500",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "RaTGt",
+                                  "name": "Warn Proceed Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Proceed",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dw32c",
+                  "name": "Variants Row 2",
+                  "width": "fill_container",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "DH1Kv",
+                      "name": "Info Card",
+                      "width": "fill_container",
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 12,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#00000026",
+                        "offset": {
+                          "x": 0,
+                          "y": 8
+                        },
+                        "blur": 24,
+                        "spread": -6
+                      },
+                      "layout": "vertical",
+                      "padding": [
+                        20,
+                        20,
+                        12,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "vTKGH",
+                          "name": "Info Head",
+                          "width": "fill_container",
+                          "stroke": "$color.neutral-700",
+                          "strokeWidth": {
+                            "bottom": 1
+                          },
+                          "strokeAlignment": "inner",
+                          "layout": "vertical",
+                          "gap": 12,
+                          "padding": [
+                            0,
+                            0,
+                            16,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "J16gBb",
+                              "name": "Info Circle",
+                              "width": 64,
+                              "height": 64,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "d8IRu",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "Info Outer",
+                                  "fill": "$color.icon-default-6",
+                                  "width": 64,
+                                  "height": 64
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "u1hw2c",
+                                  "x": 8,
+                                  "y": 8,
+                                  "name": "Info Inner",
+                                  "fill": "$color.icon-default-12",
+                                  "width": 48,
+                                  "height": 48
+                                },
+                                {
+                                  "type": "icon",
+                                  "id": "K3iV9V",
+                                  "x": 20,
+                                  "y": 20,
+                                  "name": "Info Icon",
+                                  "width": 24,
+                                  "height": 24,
+                                  "icon": "info",
+                                  "library": "lucide",
+                                  "fill": "$color.icon-default"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "hhkc1",
+                              "name": "Info Caption",
+                              "fill": "$color.white",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Update available",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 18,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "tWwWl",
+                          "name": "Info BodyWrap",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "L9KXBa",
+                              "name": "Info Body",
+                              "fill": "$color.neutral-300",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "A new connector version is available. Review the changelog before updating to the latest release.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "v8ziVY",
+                          "name": "Info Foot",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "justifyContent": "end",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "z17ZL3",
+                              "name": "Info Cancel Btn",
+                              "fill": "$color.white-10",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "wsdml",
+                                  "name": "Info Cancel Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Cancel",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "z0b0p",
+                              "name": "Info Got it Btn",
+                              "fill": "$color.blue-600",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "RsKcB",
+                                  "name": "Info Got it Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Got it",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rC8o2",
+                      "name": "Succ Card",
+                      "width": "fill_container",
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 12,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#00000026",
+                        "offset": {
+                          "x": 0,
+                          "y": 8
+                        },
+                        "blur": 24,
+                        "spread": -6
+                      },
+                      "layout": "vertical",
+                      "padding": [
+                        20,
+                        20,
+                        12,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "R1Twi",
+                          "name": "Succ Head",
+                          "width": "fill_container",
+                          "stroke": "$color.neutral-700",
+                          "strokeWidth": {
+                            "bottom": 1
+                          },
+                          "strokeAlignment": "inner",
+                          "layout": "vertical",
+                          "gap": 12,
+                          "padding": [
+                            0,
+                            0,
+                            16,
+                            0
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "LU8sS",
+                              "name": "Succ Circle",
+                              "width": 64,
+                              "height": 64,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "JBCku",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "Succ Outer",
+                                  "fill": "$color.teal-100-30",
+                                  "width": 64,
+                                  "height": 64
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "csES5",
+                                  "x": 8,
+                                  "y": 8,
+                                  "name": "Succ Inner",
+                                  "fill": "$color.teal-100",
+                                  "width": 48,
+                                  "height": 48
+                                },
+                                {
+                                  "type": "icon",
+                                  "id": "S1m4c",
+                                  "x": 20,
+                                  "y": 20,
+                                  "name": "Succ Icon",
+                                  "width": 24,
+                                  "height": 24,
+                                  "icon": "check",
+                                  "library": "lucide",
+                                  "fill": "$color.teal-800"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "fOVyZ",
+                              "name": "Succ Caption",
+                              "fill": "$color.white",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Profile created",
+                              "textAlign": "center",
+                              "fontFamily": "Inter",
+                              "fontSize": 18,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fsQJk",
+                          "name": "Succ BodyWrap",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "YMMmZ",
+                              "name": "Succ Body",
+                              "fill": "$color.neutral-300",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "The signing profile was created successfully and is now ready to issue certificates.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "OxNrn",
+                          "name": "Succ Foot",
+                          "width": "fill_container",
+                          "gap": 12,
+                          "padding": [
+                            12,
+                            0
+                          ],
+                          "justifyContent": "end",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "wLktL",
+                              "name": "Succ Cancel Btn",
+                              "fill": "$color.white-10",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Thpbr",
+                                  "name": "Succ Cancel Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Cancel",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "tgTC3",
+                              "name": "Succ Done Btn",
+                              "fill": "$color.blue-600",
+                              "cornerRadius": 8,
+                              "gap": 8,
+                              "padding": [
+                                9,
+                                13
+                              ],
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "L9zaO",
+                                  "name": "Succ Done Lbl",
+                                  "fill": "$color.white",
+                                  "content": "Done",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "xcuU1",
+          "name": "Sizes Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "MoDq6",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "SIZES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "Lfk2d",
+              "name": "Sizes List",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RfFSz",
+                  "name": "Size sm Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "PA2sv",
+                      "name": "Size sm Bar",
+                      "width": 200,
+                      "height": 40,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "AGuzj",
+                          "name": "Size sm Name",
+                          "fill": "$color.white",
+                          "content": "sm",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "KeYsV",
+                      "name": "Size sm Dim",
+                      "fill": "$color.gray-500",
+                      "content": "max-w-sm · 384px",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MeyyE",
+                  "name": "Size md Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "U70LYR",
+                      "name": "Size md Bar",
+                      "width": 267,
+                      "height": 40,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JxLVD",
+                          "name": "Size md Name",
+                          "fill": "$color.white",
+                          "content": "md",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "VdzEB",
+                      "name": "Size md Dim",
+                      "fill": "$color.gray-500",
+                      "content": "max-w-lg · 512px",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "g6wINc",
+                  "name": "Size lg Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "QwGtd",
+                      "name": "Size lg Bar",
+                      "width": 300,
+                      "height": 40,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "A2K6qk",
+                          "name": "Size lg Name",
+                          "fill": "$color.white",
+                          "content": "lg",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "q4Y4X",
+                      "name": "Size lg Dim",
+                      "fill": "$color.gray-500",
+                      "content": "max-w-xl · 576px",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rQbZ9",
+                  "name": "Size xl Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "MSIOL",
+                      "name": "Size xl Bar",
+                      "width": 467,
+                      "height": 40,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "avOEG",
+                          "name": "Size xl Name",
+                          "fill": "$color.white",
+                          "content": "xl",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "KecMr",
+                      "name": "Size xl Dim",
+                      "fill": "$color.gray-500",
+                      "content": "max-w-4xl · 896px",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KwBvG",
+                  "name": "Size xxl Row",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "q3rcd",
+                      "name": "Size xxl Bar",
+                      "width": 600,
+                      "height": 40,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 8,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        0,
+                        14
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jAigO",
+                          "name": "Size xxl Name",
+                          "fill": "$color.white",
+                          "content": "xxl",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "H2J7tF",
+                      "name": "Size xxl Dim",
+                      "fill": "$color.gray-500",
+                      "content": "max-w-6xl · 1152px",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "color.blue-100": {
+      "type": "color",
+      "value": "#cce5ff"
+    },
+    "color.blue-200": {
+      "type": "color",
+      "value": "#99ccff"
+    },
+    "color.blue-300": {
+      "type": "color",
+      "value": "#66b2ff"
+    },
+    "color.blue-400": {
+      "type": "color",
+      "value": "#3399ff"
+    },
+    "color.blue-50": {
+      "type": "color",
+      "value": "#e6f2ff"
+    },
+    "color.blue-500": {
+      "type": "color",
+      "value": "#0085e6"
+    },
+    "color.blue-600": {
+      "type": "color",
+      "value": "#0073cf"
+    },
+    "color.blue-700": {
+      "type": "color",
+      "value": "#005ba6"
+    },
+    "color.blue-800": {
+      "type": "color",
+      "value": "#004480"
+    },
+    "color.blue-900": {
+      "type": "color",
+      "value": "#002d59"
+    },
+    "color.blue-950": {
+      "type": "color",
+      "value": "#001a33"
+    },
+    "color.dialog-scrim": {
+      "type": "color",
+      "value": "#171717cc"
+    },
+    "color.gray-100": {
+      "type": "color",
+      "value": "#f5f5f5"
+    },
+    "color.gray-200": {
+      "type": "color",
+      "value": "#e8e8e8"
+    },
+    "color.gray-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.gray-400": {
+      "type": "color",
+      "value": "#c7c7c7"
+    },
+    "color.gray-500": {
+      "type": "color",
+      "value": "#a8a8a8"
+    },
+    "color.gray-600": {
+      "type": "color",
+      "value": "#b4b4b4"
+    },
+    "color.gray-700": {
+      "type": "color",
+      "value": "#8c8c8c"
+    },
+    "color.gray-800": {
+      "type": "color",
+      "value": "#666666"
+    },
+    "color.gray-900": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.icon-default": {
+      "type": "color",
+      "value": "#6b7280"
+    },
+    "color.icon-default-12": {
+      "type": "color",
+      "value": "#6b72801f"
+    },
+    "color.icon-default-6": {
+      "type": "color",
+      "value": "#6b72800f"
+    },
+    "color.neutral-200": {
+      "type": "color",
+      "value": "#e5e5e5"
+    },
+    "color.neutral-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.neutral-400": {
+      "type": "color",
+      "value": "#a3a3a3"
+    },
+    "color.neutral-500": {
+      "type": "color",
+      "value": "#737373"
+    },
+    "color.neutral-600": {
+      "type": "color",
+      "value": "#525252"
+    },
+    "color.neutral-700": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-800": {
+      "type": "color",
+      "value": "#262626"
+    },
+    "color.neutral-900": {
+      "type": "color",
+      "value": "#171717"
+    },
+    "color.red-100": {
+      "type": "color",
+      "value": "#fee2e2"
+    },
+    "color.red-400": {
+      "type": "color",
+      "value": "#f87171"
+    },
+    "color.red-500": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "color.red-600": {
+      "type": "color",
+      "value": "#dc2626"
+    },
+    "color.red-800": {
+      "type": "color",
+      "value": "#991b1b"
+    },
+    "color.red-800-12": {
+      "type": "color",
+      "value": "#991b1b1f"
+    },
+    "color.red-800-30": {
+      "type": "color",
+      "value": "#991b1b4d"
+    },
+    "color.red-800-6": {
+      "type": "color",
+      "value": "#991b1b0f"
+    },
+    "color.teal-100": {
+      "type": "color",
+      "value": "#ccfbf1"
+    },
+    "color.teal-100-30": {
+      "type": "color",
+      "value": "#ccfbf14d"
+    },
+    "color.teal-800": {
+      "type": "color",
+      "value": "#115e59"
+    },
+    "color.transparent": {
+      "type": "color",
+      "value": "#00000000"
+    },
+    "color.white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "color.white-10": {
+      "type": "color",
+      "value": "#ffffff1a"
+    },
+    "color.white-20": {
+      "type": "color",
+      "value": "#ffffff33"
+    },
+    "color.yellow-100": {
+      "type": "color",
+      "value": "#fef9c3"
+    },
+    "color.yellow-400": {
+      "type": "color",
+      "value": "#facc15"
+    },
+    "color.yellow-500": {
+      "type": "color",
+      "value": "#eab308"
+    },
+    "color.yellow-600": {
+      "type": "color",
+      "value": "#ca8a04"
+    },
+    "color.yellow-800": {
+      "type": "color",
+      "value": "#854d0e"
+    },
+    "color.yellow-800-30": {
+      "type": "color",
+      "value": "#854d0e4d"
+    }
+  }
+}

--- a/src/components/Label/Label.pen
+++ b/src/components/Label/Label.pen
@@ -1,0 +1,529 @@
+{
+  "version": "2.13",
+  "children": [
+    {
+      "type": "frame",
+      "id": "jruD7",
+      "x": 0,
+      "y": 0,
+      "name": "Label / Light",
+      "clip": true,
+      "width": 600,
+      "fill": "$color.white",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "aS9l5",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "jsQeM",
+              "name": "Title",
+              "fill": "$color.neutral-900",
+              "content": "Label",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "QMHjl",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Form field label — text with an optional required asterisk; renders as a button when clickable.",
+              "lineHeight": 1.4,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ANZMq",
+          "name": "States",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "children": [
+            {
+              "type": "text",
+              "id": "LZZpz",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "STATES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "gqOUf",
+              "name": "Default",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "SJNfT",
+                  "name": "Label",
+                  "fill": "$color.neutral-700",
+                  "content": "Email address",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "z6Tl5",
+                  "name": "Caption",
+                  "fill": "$color.neutral-400",
+                  "content": "default",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "uhH8a",
+              "name": "Required",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "FNBYC",
+                  "name": "Label",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "FAQEB",
+                      "name": "Text",
+                      "fill": "$color.neutral-700",
+                      "content": "Email address",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "LLDFl",
+                      "name": "Asterisk",
+                      "fill": "$color.red-500",
+                      "content": " *",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "eqMFz",
+                  "name": "Caption",
+                  "fill": "$color.neutral-400",
+                  "content": "required",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Dc9VN",
+              "name": "Clickable",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "H08AW",
+                  "name": "Label",
+                  "fill": "$color.neutral-700",
+                  "content": "Email address",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "eC4H9",
+                  "name": "Caption",
+                  "fill": "$color.neutral-400",
+                  "content": "clickable (renders as button)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "MdgL5",
+      "x": 660,
+      "y": 0,
+      "name": "Label / Dark",
+      "clip": true,
+      "width": 600,
+      "fill": "$color.neutral-900",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "Z70iY",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "lU9Ka",
+              "name": "Title",
+              "fill": "$color.neutral-200",
+              "content": "Label",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "s388F",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Form field label — text with an optional required asterisk; renders as a button when clickable.",
+              "lineHeight": 1.4,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "s6DZAt",
+          "name": "States",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "children": [
+            {
+              "type": "text",
+              "id": "EPjrz",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "STATES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "zwO7a",
+              "name": "Default",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "xdgJU",
+                  "name": "Label",
+                  "fill": "$color.white",
+                  "content": "Email address",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "uMGNs",
+                  "name": "Caption",
+                  "fill": "$color.neutral-400",
+                  "content": "default",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "G5htnb",
+              "name": "Required",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Q7TCqF",
+                  "name": "Label",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ASpLV",
+                      "name": "Text",
+                      "fill": "$color.white",
+                      "content": "Email address",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xNtCb",
+                      "name": "Asterisk",
+                      "fill": "$color.red-500",
+                      "content": " *",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "ZasTT",
+                  "name": "Caption",
+                  "fill": "$color.neutral-400",
+                  "content": "required",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ans2K",
+              "name": "Clickable",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "zojFm",
+                  "name": "Label",
+                  "fill": "$color.white",
+                  "content": "Email address",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "rilCu",
+                  "name": "Caption",
+                  "fill": "$color.neutral-400",
+                  "content": "clickable (renders as button)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "color.blue-100": {
+      "type": "color",
+      "value": "#cce5ff"
+    },
+    "color.blue-200": {
+      "type": "color",
+      "value": "#99ccff"
+    },
+    "color.blue-300": {
+      "type": "color",
+      "value": "#66b2ff"
+    },
+    "color.blue-400": {
+      "type": "color",
+      "value": "#3399ff"
+    },
+    "color.blue-50": {
+      "type": "color",
+      "value": "#e6f2ff"
+    },
+    "color.blue-500": {
+      "type": "color",
+      "value": "#0085e6"
+    },
+    "color.blue-600": {
+      "type": "color",
+      "value": "#0073cf"
+    },
+    "color.blue-700": {
+      "type": "color",
+      "value": "#005ba6"
+    },
+    "color.blue-800": {
+      "type": "color",
+      "value": "#004480"
+    },
+    "color.blue-900": {
+      "type": "color",
+      "value": "#002d59"
+    },
+    "color.blue-950": {
+      "type": "color",
+      "value": "#001a33"
+    },
+    "color.gray-100": {
+      "type": "color",
+      "value": "#f5f5f5"
+    },
+    "color.gray-200": {
+      "type": "color",
+      "value": "#e8e8e8"
+    },
+    "color.gray-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.gray-400": {
+      "type": "color",
+      "value": "#c7c7c7"
+    },
+    "color.gray-500": {
+      "type": "color",
+      "value": "#a8a8a8"
+    },
+    "color.gray-600": {
+      "type": "color",
+      "value": "#b4b4b4"
+    },
+    "color.gray-700": {
+      "type": "color",
+      "value": "#8c8c8c"
+    },
+    "color.gray-800": {
+      "type": "color",
+      "value": "#666666"
+    },
+    "color.gray-900": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-200": {
+      "type": "color",
+      "value": "#e5e5e5"
+    },
+    "color.neutral-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.neutral-400": {
+      "type": "color",
+      "value": "#a3a3a3"
+    },
+    "color.neutral-500": {
+      "type": "color",
+      "value": "#737373"
+    },
+    "color.neutral-600": {
+      "type": "color",
+      "value": "#525252"
+    },
+    "color.neutral-700": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-800": {
+      "type": "color",
+      "value": "#262626"
+    },
+    "color.neutral-900": {
+      "type": "color",
+      "value": "#171717"
+    },
+    "color.red-100": {
+      "type": "color",
+      "value": "#fee2e2"
+    },
+    "color.red-400": {
+      "type": "color",
+      "value": "#f87171"
+    },
+    "color.red-500": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "color.red-600": {
+      "type": "color",
+      "value": "#dc2626"
+    },
+    "color.red-800": {
+      "type": "color",
+      "value": "#991b1b"
+    },
+    "color.red-800-30": {
+      "type": "color",
+      "value": "#991b1b4d"
+    },
+    "color.transparent": {
+      "type": "color",
+      "value": "#00000000"
+    },
+    "color.white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "color.white-10": {
+      "type": "color",
+      "value": "#ffffff1a"
+    },
+    "color.white-20": {
+      "type": "color",
+      "value": "#ffffff33"
+    },
+    "color.yellow-100": {
+      "type": "color",
+      "value": "#fef9c3"
+    },
+    "color.yellow-400": {
+      "type": "color",
+      "value": "#facc15"
+    },
+    "color.yellow-500": {
+      "type": "color",
+      "value": "#eab308"
+    },
+    "color.yellow-600": {
+      "type": "color",
+      "value": "#ca8a04"
+    },
+    "color.yellow-800": {
+      "type": "color",
+      "value": "#854d0e"
+    },
+    "color.yellow-800-30": {
+      "type": "color",
+      "value": "#854d0e4d"
+    }
+  }
+}

--- a/src/components/Spinner/Spinner.pen
+++ b/src/components/Spinner/Spinner.pen
@@ -1,0 +1,907 @@
+{
+  "version": "2.13",
+  "children": [
+    {
+      "type": "frame",
+      "id": "tcvTf",
+      "x": 0,
+      "y": 0,
+      "name": "Spinner / Light",
+      "clip": true,
+      "width": 600,
+      "fill": "$color.white",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "Y3qiL",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "d05csl",
+              "name": "Title",
+              "fill": "$color.neutral-900",
+              "content": "Spinner",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "mDPjO",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Loading indicator — an animated ring with one open segment. Four sizes and two colors (primary on light, light on dark).",
+              "lineHeight": 1.4,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "X4g6xX",
+          "name": "Sizes",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "nu2gu",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "SIZES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "ZjIoF",
+              "name": "Sizes Row",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "m5R8v",
+                  "name": "Cell sm",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "c1SQL",
+                      "name": "Box",
+                      "width": 48,
+                      "height": 48,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "oiHu1",
+                          "name": "Spinner sm",
+                          "innerRadius": 0.625,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.blue-600",
+                          "width": 16,
+                          "height": 16
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "kKdmA",
+                      "name": "Caption sm",
+                      "fill": "$color.neutral-400",
+                      "content": "sm",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KXiwu",
+                  "name": "Cell md",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "oHRqM",
+                      "name": "Box",
+                      "width": 48,
+                      "height": 48,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "U2bmPR",
+                          "name": "Spinner md",
+                          "innerRadius": 0.75,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.blue-600",
+                          "width": 24,
+                          "height": 24
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Y8vbGF",
+                      "name": "Caption md",
+                      "fill": "$color.neutral-400",
+                      "content": "md",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Q9NjoG",
+                  "name": "Cell lg",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "B2rhKR",
+                      "name": "Box",
+                      "width": 48,
+                      "height": 48,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "Pbx0Z",
+                          "name": "Spinner lg",
+                          "innerRadius": 0.8125,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.blue-600",
+                          "width": 32,
+                          "height": 32
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "bGFEQ",
+                      "name": "Caption lg",
+                      "fill": "$color.neutral-400",
+                      "content": "lg",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "w2TKW",
+                  "name": "Cell xl",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "O1OIbg",
+                      "name": "Box",
+                      "width": 48,
+                      "height": 48,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "E6e4H",
+                          "name": "Spinner xl",
+                          "innerRadius": 0.85,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.blue-600",
+                          "width": 40,
+                          "height": 40
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Ho4zg",
+                      "name": "Caption xl",
+                      "fill": "$color.neutral-400",
+                      "content": "xl",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "GIxSJ",
+          "name": "Colors",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "UTcgy",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "COLORS",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "ajDpl",
+              "name": "Colors Row",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ENI6R",
+                  "name": "Cell primary",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "w3Cgo3",
+                      "name": "Box",
+                      "width": 64,
+                      "height": 64,
+                      "fill": "$color.gray-100",
+                      "cornerRadius": 10,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "zrJvw",
+                          "name": "Spinner primary",
+                          "innerRadius": 0.8125,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.blue-600",
+                          "width": 32,
+                          "height": 32
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "H2Bdo",
+                      "name": "Caption primary",
+                      "fill": "$color.neutral-400",
+                      "content": "primary",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Z8zbU",
+                  "name": "Cell light",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "DeOVg",
+                      "name": "Box",
+                      "width": 64,
+                      "height": 64,
+                      "fill": "$color.neutral-900",
+                      "cornerRadius": 10,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "NfpdB",
+                          "name": "Spinner light",
+                          "innerRadius": 0.8125,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.white",
+                          "width": 32,
+                          "height": 32
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "r33OiJ",
+                      "name": "Caption light",
+                      "fill": "$color.neutral-400",
+                      "content": "light (on dark)",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "F7tWo",
+      "x": 660,
+      "y": 0,
+      "name": "Spinner / Dark",
+      "clip": true,
+      "width": 600,
+      "fill": "$color.neutral-900",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "qZ4Hj",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "LLwht",
+              "name": "Title",
+              "fill": "$color.neutral-200",
+              "content": "Spinner",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "A36if3",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Loading indicator — an animated ring with one open segment. Four sizes and two colors (primary on light, light on dark).",
+              "lineHeight": 1.4,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "e9by5",
+          "name": "Sizes",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "X6ecRe",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "SIZES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "LNXQi",
+              "name": "Sizes Row",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Y3Cm8t",
+                  "name": "Cell sm",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zVEW4",
+                      "name": "Box",
+                      "width": 48,
+                      "height": 48,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "HJ1zA",
+                          "name": "Spinner sm",
+                          "innerRadius": 0.625,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.blue-500",
+                          "width": 16,
+                          "height": 16
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "USmvr",
+                      "name": "Caption sm",
+                      "fill": "$color.neutral-400",
+                      "content": "sm",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ekAXK",
+                  "name": "Cell md",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "JDE46",
+                      "name": "Box",
+                      "width": 48,
+                      "height": 48,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "TJ5bg",
+                          "name": "Spinner md",
+                          "innerRadius": 0.75,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.blue-500",
+                          "width": 24,
+                          "height": 24
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "b4Qfx",
+                      "name": "Caption md",
+                      "fill": "$color.neutral-400",
+                      "content": "md",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qj5Nx",
+                  "name": "Cell lg",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "VaESc",
+                      "name": "Box",
+                      "width": 48,
+                      "height": 48,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "UXJon",
+                          "name": "Spinner lg",
+                          "innerRadius": 0.8125,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.blue-500",
+                          "width": 32,
+                          "height": 32
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "iMchJ",
+                      "name": "Caption lg",
+                      "fill": "$color.neutral-400",
+                      "content": "lg",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MUqag",
+                  "name": "Cell xl",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "o6sCRM",
+                      "name": "Box",
+                      "width": 48,
+                      "height": 48,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "gU1tQ",
+                          "name": "Spinner xl",
+                          "innerRadius": 0.85,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.blue-500",
+                          "width": 40,
+                          "height": 40
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "PyMGL",
+                      "name": "Caption xl",
+                      "fill": "$color.neutral-400",
+                      "content": "xl",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "syBqp",
+          "name": "Colors",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "tRYqj",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "COLORS",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "lB3rb",
+              "name": "Colors Row",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "p3VQQX",
+                  "name": "Cell primary",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "qhSeA",
+                      "name": "Box",
+                      "width": 64,
+                      "height": 64,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 10,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "p65Fxs",
+                          "name": "Spinner primary",
+                          "innerRadius": 0.8125,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.blue-500",
+                          "width": 32,
+                          "height": 32
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "MgIiH",
+                      "name": "Caption primary",
+                      "fill": "$color.neutral-400",
+                      "content": "primary",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "LUxlh",
+                  "name": "Cell light",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "r34Rp",
+                      "name": "Box",
+                      "width": 64,
+                      "height": 64,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 10,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "Q5YV5",
+                          "name": "Spinner light",
+                          "innerRadius": 0.8125,
+                          "startAngle": 135,
+                          "sweepAngle": 270,
+                          "fill": "$color.white",
+                          "width": 32,
+                          "height": 32
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "PSpRZ",
+                      "name": "Caption light",
+                      "fill": "$color.neutral-400",
+                      "content": "light (on dark)",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "color.blue-100": {
+      "type": "color",
+      "value": "#cce5ff"
+    },
+    "color.blue-200": {
+      "type": "color",
+      "value": "#99ccff"
+    },
+    "color.blue-300": {
+      "type": "color",
+      "value": "#66b2ff"
+    },
+    "color.blue-400": {
+      "type": "color",
+      "value": "#3399ff"
+    },
+    "color.blue-50": {
+      "type": "color",
+      "value": "#e6f2ff"
+    },
+    "color.blue-500": {
+      "type": "color",
+      "value": "#0085e6"
+    },
+    "color.blue-600": {
+      "type": "color",
+      "value": "#0073cf"
+    },
+    "color.blue-700": {
+      "type": "color",
+      "value": "#005ba6"
+    },
+    "color.blue-800": {
+      "type": "color",
+      "value": "#004480"
+    },
+    "color.blue-900": {
+      "type": "color",
+      "value": "#002d59"
+    },
+    "color.blue-950": {
+      "type": "color",
+      "value": "#001a33"
+    },
+    "color.gray-100": {
+      "type": "color",
+      "value": "#f5f5f5"
+    },
+    "color.gray-200": {
+      "type": "color",
+      "value": "#e8e8e8"
+    },
+    "color.gray-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.gray-400": {
+      "type": "color",
+      "value": "#c7c7c7"
+    },
+    "color.gray-500": {
+      "type": "color",
+      "value": "#a8a8a8"
+    },
+    "color.gray-600": {
+      "type": "color",
+      "value": "#b4b4b4"
+    },
+    "color.gray-700": {
+      "type": "color",
+      "value": "#8c8c8c"
+    },
+    "color.gray-800": {
+      "type": "color",
+      "value": "#666666"
+    },
+    "color.gray-900": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-200": {
+      "type": "color",
+      "value": "#e5e5e5"
+    },
+    "color.neutral-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.neutral-400": {
+      "type": "color",
+      "value": "#a3a3a3"
+    },
+    "color.neutral-500": {
+      "type": "color",
+      "value": "#737373"
+    },
+    "color.neutral-600": {
+      "type": "color",
+      "value": "#525252"
+    },
+    "color.neutral-700": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-800": {
+      "type": "color",
+      "value": "#262626"
+    },
+    "color.neutral-900": {
+      "type": "color",
+      "value": "#171717"
+    },
+    "color.red-100": {
+      "type": "color",
+      "value": "#fee2e2"
+    },
+    "color.red-400": {
+      "type": "color",
+      "value": "#f87171"
+    },
+    "color.red-500": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "color.red-600": {
+      "type": "color",
+      "value": "#dc2626"
+    },
+    "color.red-800": {
+      "type": "color",
+      "value": "#991b1b"
+    },
+    "color.red-800-30": {
+      "type": "color",
+      "value": "#991b1b4d"
+    },
+    "color.transparent": {
+      "type": "color",
+      "value": "#00000000"
+    },
+    "color.white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "color.white-10": {
+      "type": "color",
+      "value": "#ffffff1a"
+    },
+    "color.white-20": {
+      "type": "color",
+      "value": "#ffffff33"
+    },
+    "color.yellow-100": {
+      "type": "color",
+      "value": "#fef9c3"
+    },
+    "color.yellow-400": {
+      "type": "color",
+      "value": "#facc15"
+    },
+    "color.yellow-500": {
+      "type": "color",
+      "value": "#eab308"
+    },
+    "color.yellow-600": {
+      "type": "color",
+      "value": "#ca8a04"
+    },
+    "color.yellow-800": {
+      "type": "color",
+      "value": "#854d0e"
+    },
+    "color.yellow-800-30": {
+      "type": "color",
+      "value": "#854d0e4d"
+    }
+  }
+}

--- a/src/components/StatusCircle/StatusCircle.pen
+++ b/src/components/StatusCircle/StatusCircle.pen
@@ -1,0 +1,665 @@
+{
+  "version": "2.13",
+  "children": [
+    {
+      "type": "frame",
+      "id": "GjhGw",
+      "x": 0,
+      "y": 0,
+      "name": "StatusCircle / Light",
+      "width": 600,
+      "fill": "$color.white",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "g4tdCE",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "JMMsI",
+              "name": "Title",
+              "fill": "$color.neutral-900",
+              "content": "StatusCircle",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "sWlTL",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "content": "Icon badge reflecting a boolean status — true, false, or unknown.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "NAA6p",
+          "name": "States",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "ZMU6J",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "STATES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 0.5
+            },
+            {
+              "type": "frame",
+              "id": "V6gV4x",
+              "name": "States Row",
+              "width": "fill_container",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RxzWB",
+                  "name": "True Cell",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "uJnb4",
+                      "name": "True Badge",
+                      "fill": "$color.status-success",
+                      "cornerRadius": 6,
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "qUs9a",
+                          "name": "Icon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "check",
+                          "library": "lucide",
+                          "fill": "$color.white"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "hK4pu",
+                      "name": "Caption",
+                      "fill": "$color.neutral-400",
+                      "content": "status: true",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "c6nPl",
+                  "name": "False Cell",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "uc0uY",
+                      "name": "False Badge",
+                      "fill": "$color.status-danger",
+                      "cornerRadius": 6,
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "eccMt",
+                          "name": "Icon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "x",
+                          "library": "lucide",
+                          "fill": "$color.white"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "WZR2P",
+                      "name": "Caption",
+                      "fill": "$color.neutral-400",
+                      "content": "status: false",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "h3FcHf",
+                  "name": "Unknown Cell",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "cQJBY",
+                      "name": "Unknown Badge",
+                      "fill": "$color.gray-500",
+                      "cornerRadius": 6,
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "NoPVv",
+                          "name": "Icon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "circle-question-mark",
+                          "library": "lucide",
+                          "fill": "$color.white"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "sZpRJ",
+                      "name": "Caption",
+                      "fill": "$color.neutral-400",
+                      "content": "status: undefined",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "q0pfVX",
+      "x": 660,
+      "y": 0,
+      "name": "StatusCircle / Dark",
+      "width": 600,
+      "fill": "$color.neutral-900",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "tq719",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "pKgzn",
+              "name": "Title",
+              "fill": "$color.neutral-200",
+              "content": "StatusCircle",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "Pq2sB",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "content": "Icon badge reflecting a boolean status — true, false, or unknown.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "r61Wm7",
+          "name": "States",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "MMkQn",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "STATES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 0.5
+            },
+            {
+              "type": "frame",
+              "id": "m9qoc",
+              "name": "States Row",
+              "width": "fill_container",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "USn10",
+                  "name": "True Cell",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "r2Mih",
+                      "name": "True Badge",
+                      "fill": "$color.status-success",
+                      "cornerRadius": 6,
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "I1hyO",
+                          "name": "Icon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "check",
+                          "library": "lucide",
+                          "fill": "$color.white"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "uoerV",
+                      "name": "Caption",
+                      "fill": "$color.neutral-400",
+                      "content": "status: true",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "D8IoX",
+                  "name": "False Cell",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "CPCCh",
+                      "name": "False Badge",
+                      "fill": "$color.status-danger",
+                      "cornerRadius": 6,
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "T02WFa",
+                          "name": "Icon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "x",
+                          "library": "lucide",
+                          "fill": "$color.white"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "fyEda",
+                      "name": "Caption",
+                      "fill": "$color.neutral-400",
+                      "content": "status: false",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Z4pXAu",
+                  "name": "Unknown Cell",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "c86Wy",
+                      "name": "Unknown Badge",
+                      "fill": "$color.gray-500",
+                      "cornerRadius": 6,
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "ph0Zn",
+                          "name": "Icon",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "circle-question-mark",
+                          "library": "lucide",
+                          "fill": "$color.white"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "lFi3A",
+                      "name": "Caption",
+                      "fill": "$color.neutral-400",
+                      "content": "status: undefined",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "gray-100": {
+      "type": "color",
+      "value": "#f5f5f5"
+    },
+    "gray-200": {
+      "type": "color",
+      "value": "#e8e8e8"
+    },
+    "gray-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "gray-500": {
+      "type": "color",
+      "value": "#a8a8a8"
+    },
+    "gray-700": {
+      "type": "color",
+      "value": "#8c8c8c"
+    },
+    "gray-900": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "neutral-200": {
+      "type": "color",
+      "value": "#e5e5e5"
+    },
+    "neutral-400": {
+      "type": "color",
+      "value": "#a3a3a3"
+    },
+    "neutral-700": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "neutral-800": {
+      "type": "color",
+      "value": "#262626"
+    },
+    "neutral-900": {
+      "type": "color",
+      "value": "#171717"
+    },
+    "status-danger": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "status-info": {
+      "type": "color",
+      "value": "#3399ff"
+    },
+    "status-success": {
+      "type": "color",
+      "value": "#14b8a6"
+    },
+    "status-warning": {
+      "type": "color",
+      "value": "#eab308"
+    },
+    "white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "color.blue-100": {
+      "type": "color",
+      "value": "#cce5ff"
+    },
+    "color.blue-200": {
+      "type": "color",
+      "value": "#99ccff"
+    },
+    "color.blue-300": {
+      "type": "color",
+      "value": "#66b2ff"
+    },
+    "color.blue-400": {
+      "type": "color",
+      "value": "#3399ff"
+    },
+    "color.blue-50": {
+      "type": "color",
+      "value": "#e6f2ff"
+    },
+    "color.blue-500": {
+      "type": "color",
+      "value": "#0085e6"
+    },
+    "color.blue-600": {
+      "type": "color",
+      "value": "#0073cf"
+    },
+    "color.blue-700": {
+      "type": "color",
+      "value": "#005ba6"
+    },
+    "color.blue-800": {
+      "type": "color",
+      "value": "#004480"
+    },
+    "color.blue-900": {
+      "type": "color",
+      "value": "#002d59"
+    },
+    "color.blue-950": {
+      "type": "color",
+      "value": "#001a33"
+    },
+    "color.gray-100": {
+      "type": "color",
+      "value": "#f5f5f5"
+    },
+    "color.gray-200": {
+      "type": "color",
+      "value": "#e8e8e8"
+    },
+    "color.gray-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.gray-400": {
+      "type": "color",
+      "value": "#c7c7c7"
+    },
+    "color.gray-500": {
+      "type": "color",
+      "value": "#a8a8a8"
+    },
+    "color.gray-600": {
+      "type": "color",
+      "value": "#b4b4b4"
+    },
+    "color.gray-700": {
+      "type": "color",
+      "value": "#8c8c8c"
+    },
+    "color.gray-800": {
+      "type": "color",
+      "value": "#666666"
+    },
+    "color.gray-900": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-200": {
+      "type": "color",
+      "value": "#e5e5e5"
+    },
+    "color.neutral-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.neutral-400": {
+      "type": "color",
+      "value": "#a3a3a3"
+    },
+    "color.neutral-500": {
+      "type": "color",
+      "value": "#737373"
+    },
+    "color.neutral-600": {
+      "type": "color",
+      "value": "#525252"
+    },
+    "color.neutral-700": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-800": {
+      "type": "color",
+      "value": "#262626"
+    },
+    "color.neutral-900": {
+      "type": "color",
+      "value": "#171717"
+    },
+    "color.red-100": {
+      "type": "color",
+      "value": "#fee2e2"
+    },
+    "color.red-400": {
+      "type": "color",
+      "value": "#f87171"
+    },
+    "color.red-500": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "color.red-600": {
+      "type": "color",
+      "value": "#dc2626"
+    },
+    "color.red-800": {
+      "type": "color",
+      "value": "#991b1b"
+    },
+    "color.status-danger": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "color.status-info": {
+      "type": "color",
+      "value": "#3399ff"
+    },
+    "color.status-success": {
+      "type": "color",
+      "value": "#14b8a6"
+    },
+    "color.status-warning": {
+      "type": "color",
+      "value": "#eab308"
+    },
+    "color.transparent": {
+      "type": "color",
+      "value": "#00000000"
+    },
+    "color.white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "color.yellow-100": {
+      "type": "color",
+      "value": "#fef9c3"
+    },
+    "color.yellow-400": {
+      "type": "color",
+      "value": "#facc15"
+    },
+    "color.yellow-500": {
+      "type": "color",
+      "value": "#eab308"
+    },
+    "color.yellow-600": {
+      "type": "color",
+      "value": "#ca8a04"
+    },
+    "color.yellow-800": {
+      "type": "color",
+      "value": "#854d0e"
+    }
+  }
+}

--- a/src/components/Tabs/Tabs.pen
+++ b/src/components/Tabs/Tabs.pen
@@ -1,0 +1,1783 @@
+{
+  "version": "2.13",
+  "children": [
+    {
+      "type": "frame",
+      "id": "LMlS4",
+      "x": 0,
+      "y": 0,
+      "name": "Tabs / Light",
+      "clip": true,
+      "width": 600,
+      "fill": "$color.white",
+      "cornerRadius": 12,
+      "stroke": "$color.gray-200",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "tmGus",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "PXnL7",
+              "name": "Title",
+              "fill": "$color.neutral-900",
+              "content": "Tabs",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "AY21f",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Horizontal tab bar — pill-style triggers. The active tab fills gray-200 with gray-800 text; inactive tabs are transparent with gray-500 text. Medium 14px labels, rounded-lg, gap-x-1, horizontally scrollable when they overflow.",
+              "lineHeight": 1.4,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "oKWyF",
+          "name": "Preview Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "Zokys",
+              "name": "PREVIEW Section Title",
+              "fill": "$color.gray-500",
+              "content": "PREVIEW",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "hYkO3",
+              "name": "Preview Box",
+              "width": "fill_container",
+              "fill": "$color.gray-100",
+              "cornerRadius": 10,
+              "padding": 24,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ad2tA",
+                  "name": "Preview Tab Bar",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "TQY0Y",
+                      "name": "pv-Overview Tab",
+                      "fill": "$color.gray-200",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QLs6t",
+                          "name": "pv-Overview Label",
+                          "fill": "$color.gray-800",
+                          "content": "Overview",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "sR5M9",
+                      "name": "pv-Activity Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jVe9z",
+                          "name": "pv-Activity Label",
+                          "fill": "$color.gray-500",
+                          "content": "Activity",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DVWkt",
+                      "name": "pv-Settings Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "G6nI3",
+                          "name": "pv-Settings Label",
+                          "fill": "$color.gray-500",
+                          "content": "Settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dZ2ll",
+                      "name": "pv-Members Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "uT8jV",
+                          "name": "pv-Members Label",
+                          "fill": "$color.gray-500",
+                          "content": "Members",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "R6Joy",
+          "name": "States Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "z1n7W",
+              "name": "STATES Section Title",
+              "fill": "$color.gray-500",
+              "content": "STATES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "Hi6sS",
+              "name": "States Row",
+              "gap": 28,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "oyQfZ",
+                  "name": "Active Cell",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "sAdnS",
+                      "name": "st-Active Tab",
+                      "fill": "$color.gray-200",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "H1beD",
+                          "name": "st-Active Label",
+                          "fill": "$color.gray-800",
+                          "content": "Active",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "j3rnNL",
+                      "name": "st-Active Caption",
+                      "fill": "$color.gray-500",
+                      "content": "Active",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "l4yCcp",
+                  "name": "Default Cell",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BEwPk",
+                      "name": "st-Default Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Fw4yc",
+                          "name": "st-Default Label",
+                          "fill": "$color.gray-500",
+                          "content": "Default",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "X5xEd4",
+                      "name": "st-Default Caption",
+                      "fill": "$color.gray-500",
+                      "content": "Default",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "i2Y3xA",
+                  "name": "Disabled Cell",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "g82Kao",
+                      "name": "st-Disabled Tab",
+                      "opacity": 0.5,
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vtHbv",
+                          "name": "st-Disabled Label",
+                          "fill": "$color.gray-500",
+                          "content": "Disabled",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "G3Plm1",
+                      "name": "st-Disabled Caption",
+                      "fill": "$color.gray-500",
+                      "content": "Disabled",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Sx3PA",
+          "name": "Icons Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "g4aiok",
+              "name": "WITH ICONS Section Title",
+              "fill": "$color.gray-500",
+              "content": "WITH ICONS",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "ISFS3",
+              "name": "Icon Tab Bar",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "gdnMm",
+                  "name": "ic-Dashboard Tab",
+                  "fill": "$color.gray-200",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    16
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "WaSxv",
+                      "name": "ic-Dashboard Icon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "layout-dashboard",
+                      "library": "lucide",
+                      "fill": "$color.gray-800"
+                    },
+                    {
+                      "type": "text",
+                      "id": "iN9IM",
+                      "name": "ic-Dashboard Label",
+                      "fill": "$color.gray-800",
+                      "content": "Dashboard",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "cvPh5",
+                  "name": "ic-Activity Tab",
+                  "fill": "$color.transparent",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    16
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "LEXiI",
+                      "name": "ic-Activity Icon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "activity",
+                      "library": "lucide",
+                      "fill": "$color.gray-500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "mTcUd",
+                      "name": "ic-Activity Label",
+                      "fill": "$color.gray-500",
+                      "content": "Activity",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MguzF",
+                  "name": "ic-Settings Tab",
+                  "fill": "$color.transparent",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    16
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "jOj1r",
+                      "name": "ic-Settings Icon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "settings",
+                      "library": "lucide",
+                      "fill": "$color.gray-500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xBEAi",
+                      "name": "ic-Settings Label",
+                      "fill": "$color.gray-500",
+                      "content": "Settings",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Ss6N2",
+                  "name": "ic-Members Tab",
+                  "fill": "$color.transparent",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    16
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "R99Ld",
+                      "name": "ic-Members Icon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "users",
+                      "library": "lucide",
+                      "fill": "$color.gray-500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "m6Lfv",
+                      "name": "ic-Members Label",
+                      "fill": "$color.gray-500",
+                      "content": "Members",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "i9yVu",
+          "name": "Scrollable Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "G9wId3",
+              "name": "SCROLLABLE Section Title",
+              "fill": "$color.gray-500",
+              "content": "SCROLLABLE",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "J7JK1a",
+              "name": "Scroll Box",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$color.gray-100",
+              "cornerRadius": 10,
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RLNal",
+                  "name": "Scroll Tab Row",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "N3MyLv",
+                      "name": "sc-Overview Tab",
+                      "fill": "$color.gray-200",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "zDKLc",
+                          "name": "sc-Overview Label",
+                          "fill": "$color.gray-800",
+                          "content": "Overview",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HZtTi",
+                      "name": "sc-Activity Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "wAQQS",
+                          "name": "sc-Activity Label",
+                          "fill": "$color.gray-500",
+                          "content": "Activity",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ig7CN",
+                      "name": "sc-Members Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ap387",
+                          "name": "sc-Members Label",
+                          "fill": "$color.gray-500",
+                          "content": "Members",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "PCT4p",
+                      "name": "sc-Settings Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "u5Vms",
+                          "name": "sc-Settings Label",
+                          "fill": "$color.gray-500",
+                          "content": "Settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "TdccD",
+                      "name": "sc-Billing Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "aFa8e",
+                          "name": "sc-Billing Label",
+                          "fill": "$color.gray-500",
+                          "content": "Billing",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IJ3Os",
+                      "name": "sc-Integrations Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "FAc72",
+                          "name": "sc-Integrations Label",
+                          "fill": "$color.gray-500",
+                          "content": "Integrations",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "L52Okl",
+                      "name": "sc-Security Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "PQfz5",
+                          "name": "sc-Security Label",
+                          "fill": "$color.gray-500",
+                          "content": "Security",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ViXzV",
+                      "name": "sc-AuditLog Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mJX7G",
+                          "name": "sc-AuditLog Label",
+                          "fill": "$color.gray-500",
+                          "content": "Audit Log",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "o8e5Lq",
+                  "name": "Scrollbar Track",
+                  "width": "fill_container",
+                  "height": 6,
+                  "fill": "$color.gray-200",
+                  "cornerRadius": 3,
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 3,
+                      "id": "xR8zh",
+                      "name": "Scrollbar Thumb",
+                      "fill": "$color.gray-400",
+                      "width": 180,
+                      "height": 6
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "qsq2o",
+              "name": "sc Caption",
+              "fill": "$color.gray-500",
+              "content": "Horizontally scrollable when tabs overflow the container (SimpleBar, forceVisible x).",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "nZmkq",
+      "x": 660,
+      "y": 0,
+      "name": "Tabs / Dark",
+      "clip": true,
+      "width": 600,
+      "fill": "$color.neutral-900",
+      "cornerRadius": 12,
+      "stroke": "$color.neutral-700",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "A1mc09",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "BLEh9",
+              "name": "Title",
+              "fill": "$color.neutral-200",
+              "content": "Tabs",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "LzXZJ",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Horizontal tab bar — pill-style triggers. The active tab fills gray-200 with gray-800 text; inactive tabs are transparent with gray-500 text. Medium 14px labels, rounded-lg, gap-x-1, horizontally scrollable when they overflow.",
+              "lineHeight": 1.4,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "c5KnEF",
+          "name": "Preview Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "r2bEld",
+              "name": "PREVIEW Section Title",
+              "fill": "$color.gray-500",
+              "content": "PREVIEW",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "jajs8",
+              "name": "Preview Box",
+              "width": "fill_container",
+              "fill": "$color.neutral-800",
+              "cornerRadius": 10,
+              "padding": 24,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "M6qxP",
+                  "name": "Preview Tab Bar",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "kENsX",
+                      "name": "pv-Overview Tab",
+                      "fill": "$color.neutral-700",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dtw2P",
+                          "name": "pv-Overview Label",
+                          "fill": "$color.white",
+                          "content": "Overview",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gD5gI",
+                      "name": "pv-Activity Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XHjbx",
+                          "name": "pv-Activity Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Activity",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Xsbsg",
+                      "name": "pv-Settings Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "v8OOqf",
+                          "name": "pv-Settings Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "z0LUzb",
+                      "name": "pv-Members Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "c9aCwS",
+                          "name": "pv-Members Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Members",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "xJzCU",
+          "name": "States Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "JXEv9",
+              "name": "STATES Section Title",
+              "fill": "$color.gray-500",
+              "content": "STATES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "IN5O0",
+              "name": "States Row",
+              "gap": 28,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RLRQA",
+                  "name": "Active Cell",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ZfHZL",
+                      "name": "st-Active Tab",
+                      "fill": "$color.neutral-700",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "V5tPYZ",
+                          "name": "st-Active Label",
+                          "fill": "$color.white",
+                          "content": "Active",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "I5AbK",
+                      "name": "st-Active Caption",
+                      "fill": "$color.gray-500",
+                      "content": "Active",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RnJn5",
+                  "name": "Default Cell",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Tqewd",
+                      "name": "st-Default Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mQRyk",
+                          "name": "st-Default Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Default",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "qypAv",
+                      "name": "st-Default Caption",
+                      "fill": "$color.gray-500",
+                      "content": "Default",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "zvqzl",
+                  "name": "Disabled Cell",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "KgjM1",
+                      "name": "st-Disabled Tab",
+                      "opacity": 0.5,
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vD1sR",
+                          "name": "st-Disabled Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Disabled",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "OpNZa",
+                      "name": "st-Disabled Caption",
+                      "fill": "$color.gray-500",
+                      "content": "Disabled",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "k0SV31",
+          "name": "Icons Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "OVrPs",
+              "name": "WITH ICONS Section Title",
+              "fill": "$color.gray-500",
+              "content": "WITH ICONS",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "Y6OKW",
+              "name": "Icon Tab Bar",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "hkRHx",
+                  "name": "ic-Dashboard Tab",
+                  "fill": "$color.neutral-700",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    16
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "CLrYt",
+                      "name": "ic-Dashboard Icon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "layout-dashboard",
+                      "library": "lucide",
+                      "fill": "$color.white"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ciXLO",
+                      "name": "ic-Dashboard Label",
+                      "fill": "$color.white",
+                      "content": "Dashboard",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "w7zjYx",
+                  "name": "ic-Activity Tab",
+                  "fill": "$color.transparent",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    16
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "FTPJy",
+                      "name": "ic-Activity Icon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "activity",
+                      "library": "lucide",
+                      "fill": "$color.neutral-500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "J89arb",
+                      "name": "ic-Activity Label",
+                      "fill": "$color.neutral-500",
+                      "content": "Activity",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jCDim",
+                  "name": "ic-Settings Tab",
+                  "fill": "$color.transparent",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    16
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "sdEvv",
+                      "name": "ic-Settings Icon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "settings",
+                      "library": "lucide",
+                      "fill": "$color.neutral-500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "NpSPa",
+                      "name": "ic-Settings Label",
+                      "fill": "$color.neutral-500",
+                      "content": "Settings",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Lmzzy",
+                  "name": "ic-Members Tab",
+                  "fill": "$color.transparent",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    12,
+                    16
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "Q5Rhf",
+                      "name": "ic-Members Icon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "users",
+                      "library": "lucide",
+                      "fill": "$color.neutral-500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "kKVGQ",
+                      "name": "ic-Members Label",
+                      "fill": "$color.neutral-500",
+                      "content": "Members",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "D4TcJ",
+          "name": "Scrollable Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "QNb0q",
+              "name": "SCROLLABLE Section Title",
+              "fill": "$color.gray-500",
+              "content": "SCROLLABLE",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "a6thQz",
+              "name": "Scroll Box",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$color.neutral-800",
+              "cornerRadius": 10,
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Nr12M",
+                  "name": "Scroll Tab Row",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "yEn8h",
+                      "name": "sc-Overview Tab",
+                      "fill": "$color.neutral-700",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "V3Hqd",
+                          "name": "sc-Overview Label",
+                          "fill": "$color.white",
+                          "content": "Overview",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rYO52",
+                      "name": "sc-Activity Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Wv35T",
+                          "name": "sc-Activity Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Activity",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cQpJN",
+                      "name": "sc-Members Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "B2R7BJ",
+                          "name": "sc-Members Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Members",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "TcsFu",
+                      "name": "sc-Settings Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "tuhbP",
+                          "name": "sc-Settings Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Settings",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RyDGI",
+                      "name": "sc-Billing Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Y4Hvf",
+                          "name": "sc-Billing Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Billing",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FT0Em",
+                      "name": "sc-Integrations Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "IjXrN",
+                          "name": "sc-Integrations Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Integrations",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "EaKxj",
+                      "name": "sc-Security Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SHbQ6",
+                          "name": "sc-Security Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Security",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "SpADe",
+                      "name": "sc-AuditLog Tab",
+                      "fill": "$color.transparent",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": [
+                        12,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "LqgkK",
+                          "name": "sc-AuditLog Label",
+                          "fill": "$color.neutral-500",
+                          "content": "Audit Log",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "b1xpX7",
+                  "name": "Scrollbar Track",
+                  "width": "fill_container",
+                  "height": 6,
+                  "fill": "$color.neutral-700",
+                  "cornerRadius": 3,
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 3,
+                      "id": "QwWqT",
+                      "name": "Scrollbar Thumb",
+                      "fill": "$color.neutral-600",
+                      "width": 180,
+                      "height": 6
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "RU5ee",
+              "name": "sc Caption",
+              "fill": "$color.gray-500",
+              "content": "Horizontally scrollable when tabs overflow the container (SimpleBar, forceVisible x).",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "color.blue-100": {
+      "type": "color",
+      "value": "#cce5ff"
+    },
+    "color.blue-200": {
+      "type": "color",
+      "value": "#99ccff"
+    },
+    "color.blue-300": {
+      "type": "color",
+      "value": "#66b2ff"
+    },
+    "color.blue-400": {
+      "type": "color",
+      "value": "#3399ff"
+    },
+    "color.blue-50": {
+      "type": "color",
+      "value": "#e6f2ff"
+    },
+    "color.blue-500": {
+      "type": "color",
+      "value": "#0085e6"
+    },
+    "color.blue-600": {
+      "type": "color",
+      "value": "#0073cf"
+    },
+    "color.blue-700": {
+      "type": "color",
+      "value": "#005ba6"
+    },
+    "color.blue-800": {
+      "type": "color",
+      "value": "#004480"
+    },
+    "color.blue-900": {
+      "type": "color",
+      "value": "#002d59"
+    },
+    "color.blue-950": {
+      "type": "color",
+      "value": "#001a33"
+    },
+    "color.gray-100": {
+      "type": "color",
+      "value": "#f5f5f5"
+    },
+    "color.gray-200": {
+      "type": "color",
+      "value": "#e8e8e8"
+    },
+    "color.gray-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.gray-400": {
+      "type": "color",
+      "value": "#c7c7c7"
+    },
+    "color.gray-500": {
+      "type": "color",
+      "value": "#a8a8a8"
+    },
+    "color.gray-600": {
+      "type": "color",
+      "value": "#b4b4b4"
+    },
+    "color.gray-700": {
+      "type": "color",
+      "value": "#8c8c8c"
+    },
+    "color.gray-800": {
+      "type": "color",
+      "value": "#666666"
+    },
+    "color.gray-900": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-200": {
+      "type": "color",
+      "value": "#e5e5e5"
+    },
+    "color.neutral-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.neutral-400": {
+      "type": "color",
+      "value": "#a3a3a3"
+    },
+    "color.neutral-500": {
+      "type": "color",
+      "value": "#737373"
+    },
+    "color.neutral-600": {
+      "type": "color",
+      "value": "#525252"
+    },
+    "color.neutral-700": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-800": {
+      "type": "color",
+      "value": "#262626"
+    },
+    "color.neutral-900": {
+      "type": "color",
+      "value": "#171717"
+    },
+    "color.red-100": {
+      "type": "color",
+      "value": "#fee2e2"
+    },
+    "color.red-400": {
+      "type": "color",
+      "value": "#f87171"
+    },
+    "color.red-500": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "color.red-600": {
+      "type": "color",
+      "value": "#dc2626"
+    },
+    "color.red-800": {
+      "type": "color",
+      "value": "#991b1b"
+    },
+    "color.red-800-30": {
+      "type": "color",
+      "value": "#991b1b4d"
+    },
+    "color.transparent": {
+      "type": "color",
+      "value": "#00000000"
+    },
+    "color.white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "color.white-10": {
+      "type": "color",
+      "value": "#ffffff1a"
+    },
+    "color.white-20": {
+      "type": "color",
+      "value": "#ffffff33"
+    },
+    "color.yellow-100": {
+      "type": "color",
+      "value": "#fef9c3"
+    },
+    "color.yellow-400": {
+      "type": "color",
+      "value": "#facc15"
+    },
+    "color.yellow-500": {
+      "type": "color",
+      "value": "#eab308"
+    },
+    "color.yellow-600": {
+      "type": "color",
+      "value": "#ca8a04"
+    },
+    "color.yellow-800": {
+      "type": "color",
+      "value": "#854d0e"
+    },
+    "color.yellow-800-30": {
+      "type": "color",
+      "value": "#854d0e4d"
+    }
+  }
+}

--- a/src/components/Tooltip/Tooltip.pen
+++ b/src/components/Tooltip/Tooltip.pen
@@ -1,0 +1,1131 @@
+{
+  "version": "2.13",
+  "children": [
+    {
+      "type": "frame",
+      "id": "Moki7",
+      "x": 0,
+      "y": 0,
+      "name": "Tooltip / Light",
+      "clip": true,
+      "width": 600,
+      "fill": "$color.white",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "aurud",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "Yj20l",
+              "name": "Title",
+              "fill": "$color.neutral-900",
+              "content": "Tooltip",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "vHPpH",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Hover hint — a small dark popover anchored below the trigger with a pointer arrow. White text on a dark surface, appears on hover. Placement: bottom.",
+              "lineHeight": 1.4,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "n2lUk",
+          "name": "Preview",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "HuGYU",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "PREVIEW",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "CEohn",
+              "name": "Preview Box",
+              "width": "fill_container",
+              "height": 160,
+              "fill": "$color.gray-100",
+              "cornerRadius": 10,
+              "layout": "vertical",
+              "gap": 8,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "aWR2v",
+                  "name": "Trigger",
+                  "width": 32,
+                  "height": 32,
+                  "fill": "$color.white",
+                  "cornerRadius": 6,
+                  "stroke": "$color.gray-300",
+                  "strokeWidth": 1,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "Uf3Ok",
+                      "name": "Icon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "circle-question-mark",
+                      "library": "lucide",
+                      "fill": "$color.neutral-600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "x1St1",
+                  "name": "Tooltip",
+                  "layout": "vertical",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "path",
+                      "id": "hLEF2",
+                      "name": "Arrow",
+                      "geometry": "M0 6l6-6 6 6z",
+                      "viewBox": [
+                        0,
+                        0,
+                        12,
+                        6
+                      ],
+                      "fill": "$color.tooltip-bg",
+                      "width": 12,
+                      "height": 6
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Rc6IY",
+                      "name": "Bubble",
+                      "fill": "$color.tooltip-bg",
+                      "cornerRadius": 6,
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000001f",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 3
+                      },
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "iVNmZ",
+                          "name": "Label",
+                          "fill": "$color.white",
+                          "content": "More information",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "V5hS4V",
+          "name": "Content",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "SjUaq",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "CONTENT",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "BFJtp",
+              "name": "Content Row",
+              "width": "fill_container",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RaNrf",
+                  "name": "Cell Short",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "tC9VN",
+                      "name": "Short",
+                      "layout": "vertical",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "path",
+                          "id": "f066pw",
+                          "name": "Arrow",
+                          "geometry": "M0 6l6-6 6 6z",
+                          "viewBox": [
+                            0,
+                            0,
+                            12,
+                            6
+                          ],
+                          "fill": "$color.tooltip-bg",
+                          "width": 12,
+                          "height": 6
+                        },
+                        {
+                          "type": "frame",
+                          "id": "j8Bk5",
+                          "name": "Bubble",
+                          "fill": "$color.tooltip-bg",
+                          "cornerRadius": 6,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001f",
+                            "offset": {
+                              "x": 0,
+                              "y": 1
+                            },
+                            "blur": 3
+                          },
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "EEAMf",
+                              "name": "Label",
+                              "fill": "$color.white",
+                              "content": "Copy to clipboard",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "FquEe",
+                      "name": "Caption",
+                      "fill": "$color.gray-500",
+                      "content": "short label",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "GX3aM",
+                  "name": "Cell Long",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "t0THIz",
+                      "name": "Long",
+                      "layout": "vertical",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "path",
+                          "id": "JQvrV",
+                          "name": "Arrow",
+                          "geometry": "M0 6l6-6 6 6z",
+                          "viewBox": [
+                            0,
+                            0,
+                            12,
+                            6
+                          ],
+                          "fill": "$color.tooltip-bg",
+                          "width": 12,
+                          "height": 6
+                        },
+                        {
+                          "type": "frame",
+                          "id": "r3fr2q",
+                          "name": "Bubble",
+                          "fill": "$color.tooltip-bg",
+                          "cornerRadius": 6,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001f",
+                            "offset": {
+                              "x": 0,
+                              "y": 1
+                            },
+                            "blur": 3
+                          },
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "deHUk",
+                              "name": "Label",
+                              "fill": "$color.white",
+                              "textGrowth": "fixed-width",
+                              "width": 220,
+                              "content": "This action permanently deletes the selected items and cannot be undone.",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "wySGB",
+                      "name": "Caption",
+                      "fill": "$color.gray-500",
+                      "content": "long — wraps (max width)",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "WSeLW",
+          "name": "States",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "cULPe",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "STATES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "M6JUb4",
+              "name": "States Row",
+              "width": "fill_container",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "PKuYL",
+                  "name": "Enabled",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "HGLhu",
+                      "name": "Trigger",
+                      "width": 32,
+                      "height": 32,
+                      "fill": "$color.white",
+                      "cornerRadius": 6,
+                      "stroke": "$color.gray-300",
+                      "strokeWidth": 1,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "e4boEt",
+                          "name": "Icon",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "circle-question-mark",
+                          "library": "lucide",
+                          "fill": "$color.neutral-600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "rw0Rf",
+                      "name": "Caption",
+                      "fill": "$color.gray-500",
+                      "content": "enabled (hover shows tip)",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "lt5bu",
+                  "name": "Disabled",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Gts4y",
+                      "name": "Trigger",
+                      "opacity": 0.4,
+                      "width": 32,
+                      "height": 32,
+                      "fill": "$color.white",
+                      "cornerRadius": 6,
+                      "stroke": "$color.gray-300",
+                      "strokeWidth": 1,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "Hfpgf",
+                          "name": "Icon",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "circle-question-mark",
+                          "library": "lucide",
+                          "fill": "$color.neutral-600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "zRxLk",
+                      "name": "Caption",
+                      "fill": "$color.gray-500",
+                      "content": "disabled (no tip)",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "oOJEv",
+      "x": 660,
+      "y": 0,
+      "name": "Tooltip / Dark",
+      "clip": true,
+      "width": 600,
+      "fill": "$color.neutral-900",
+      "layout": "vertical",
+      "gap": 36,
+      "padding": 40,
+      "children": [
+        {
+          "type": "frame",
+          "id": "Kn9oD",
+          "name": "Header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "oc8hZ",
+              "name": "Title",
+              "fill": "$color.neutral-200",
+              "content": "Tooltip",
+              "fontFamily": "Inter",
+              "fontSize": 28,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "WMs4t",
+              "name": "Subtitle",
+              "fill": "$color.neutral-400",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Hover hint — a small dark popover anchored below the trigger with a pointer arrow. White text on a dark surface, appears on hover. Placement: bottom.",
+              "lineHeight": 1.4,
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "y2FYQ",
+          "name": "Preview",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "jgnVF",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "PREVIEW",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "G6J716",
+              "name": "Preview Box",
+              "width": "fill_container",
+              "height": 160,
+              "fill": "$color.neutral-800",
+              "cornerRadius": 10,
+              "layout": "vertical",
+              "gap": 8,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "S7MEmc",
+                  "name": "Trigger",
+                  "width": 32,
+                  "height": 32,
+                  "fill": "$color.neutral-800",
+                  "cornerRadius": 6,
+                  "stroke": "$color.neutral-700",
+                  "strokeWidth": 1,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "b9FtW",
+                      "name": "Icon",
+                      "width": 18,
+                      "height": 18,
+                      "icon": "circle-question-mark",
+                      "library": "lucide",
+                      "fill": "$color.neutral-400"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "S4KOq",
+                  "name": "Tooltip",
+                  "layout": "vertical",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "path",
+                      "id": "VSncD",
+                      "name": "Arrow",
+                      "geometry": "M0 6l6-6 6 6z",
+                      "viewBox": [
+                        0,
+                        0,
+                        12,
+                        6
+                      ],
+                      "fill": "$color.neutral-700",
+                      "width": 12,
+                      "height": 6
+                    },
+                    {
+                      "type": "frame",
+                      "id": "mS4Bj",
+                      "name": "Bubble",
+                      "fill": "$color.neutral-700",
+                      "cornerRadius": 6,
+                      "effect": {
+                        "type": "shadow",
+                        "shadowType": "outer",
+                        "color": "#0000001f",
+                        "offset": {
+                          "x": 0,
+                          "y": 1
+                        },
+                        "blur": 3
+                      },
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "NYUkA",
+                          "name": "Label",
+                          "fill": "$color.white",
+                          "content": "More information",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ssWd1",
+          "name": "Content",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "owuG6",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "CONTENT",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "NSJmj",
+              "name": "Content Row",
+              "width": "fill_container",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "n5Nz3Z",
+                  "name": "Cell Short",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hRXCz",
+                      "name": "Short",
+                      "layout": "vertical",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "path",
+                          "id": "OWz9a",
+                          "name": "Arrow",
+                          "geometry": "M0 6l6-6 6 6z",
+                          "viewBox": [
+                            0,
+                            0,
+                            12,
+                            6
+                          ],
+                          "fill": "$color.neutral-700",
+                          "width": 12,
+                          "height": 6
+                        },
+                        {
+                          "type": "frame",
+                          "id": "I5MzFg",
+                          "name": "Bubble",
+                          "fill": "$color.neutral-700",
+                          "cornerRadius": 6,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001f",
+                            "offset": {
+                              "x": 0,
+                              "y": 1
+                            },
+                            "blur": 3
+                          },
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "hNf2z",
+                              "name": "Label",
+                              "fill": "$color.white",
+                              "content": "Copy to clipboard",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "ycwgt",
+                      "name": "Caption",
+                      "fill": "$color.gray-500",
+                      "content": "short label",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "y3iVPk",
+                  "name": "Cell Long",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ME8E1",
+                      "name": "Long",
+                      "layout": "vertical",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "path",
+                          "id": "fobMq",
+                          "name": "Arrow",
+                          "geometry": "M0 6l6-6 6 6z",
+                          "viewBox": [
+                            0,
+                            0,
+                            12,
+                            6
+                          ],
+                          "fill": "$color.neutral-700",
+                          "width": 12,
+                          "height": 6
+                        },
+                        {
+                          "type": "frame",
+                          "id": "cbbNJ",
+                          "name": "Bubble",
+                          "fill": "$color.neutral-700",
+                          "cornerRadius": 6,
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#0000001f",
+                            "offset": {
+                              "x": 0,
+                              "y": 1
+                            },
+                            "blur": 3
+                          },
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "mHeVp",
+                              "name": "Label",
+                              "fill": "$color.white",
+                              "textGrowth": "fixed-width",
+                              "width": 220,
+                              "content": "This action permanently deletes the selected items and cannot be undone.",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "klLmg",
+                      "name": "Caption",
+                      "fill": "$color.gray-500",
+                      "content": "long — wraps (max width)",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "q13eUN",
+          "name": "States",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "jFheq",
+              "name": "Section Title",
+              "fill": "$color.gray-500",
+              "content": "STATES",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "r1Vr0C",
+              "name": "States Row",
+              "width": "fill_container",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rQO1q",
+                  "name": "Enabled",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "vFrJJ",
+                      "name": "Trigger",
+                      "width": 32,
+                      "height": 32,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 6,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "OBh1C",
+                          "name": "Icon",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "circle-question-mark",
+                          "library": "lucide",
+                          "fill": "$color.neutral-400"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Aa5SN",
+                      "name": "Caption",
+                      "fill": "$color.gray-500",
+                      "content": "enabled (hover shows tip)",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "IjTMK",
+                  "name": "Disabled",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "t3lxQ",
+                      "name": "Trigger",
+                      "opacity": 0.4,
+                      "width": 32,
+                      "height": 32,
+                      "fill": "$color.neutral-800",
+                      "cornerRadius": 6,
+                      "stroke": "$color.neutral-700",
+                      "strokeWidth": 1,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "eng9x",
+                          "name": "Icon",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "circle-question-mark",
+                          "library": "lucide",
+                          "fill": "$color.neutral-400"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "SF3Hd",
+                      "name": "Caption",
+                      "fill": "$color.gray-500",
+                      "content": "disabled (no tip)",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "color.blue-100": {
+      "type": "color",
+      "value": "#cce5ff"
+    },
+    "color.blue-200": {
+      "type": "color",
+      "value": "#99ccff"
+    },
+    "color.blue-300": {
+      "type": "color",
+      "value": "#66b2ff"
+    },
+    "color.blue-400": {
+      "type": "color",
+      "value": "#3399ff"
+    },
+    "color.blue-50": {
+      "type": "color",
+      "value": "#e6f2ff"
+    },
+    "color.blue-500": {
+      "type": "color",
+      "value": "#0085e6"
+    },
+    "color.blue-600": {
+      "type": "color",
+      "value": "#0073cf"
+    },
+    "color.blue-700": {
+      "type": "color",
+      "value": "#005ba6"
+    },
+    "color.blue-800": {
+      "type": "color",
+      "value": "#004480"
+    },
+    "color.blue-900": {
+      "type": "color",
+      "value": "#002d59"
+    },
+    "color.blue-950": {
+      "type": "color",
+      "value": "#001a33"
+    },
+    "color.gray-100": {
+      "type": "color",
+      "value": "#f5f5f5"
+    },
+    "color.gray-200": {
+      "type": "color",
+      "value": "#e8e8e8"
+    },
+    "color.gray-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.gray-400": {
+      "type": "color",
+      "value": "#c7c7c7"
+    },
+    "color.gray-500": {
+      "type": "color",
+      "value": "#a8a8a8"
+    },
+    "color.gray-600": {
+      "type": "color",
+      "value": "#b4b4b4"
+    },
+    "color.gray-700": {
+      "type": "color",
+      "value": "#8c8c8c"
+    },
+    "color.gray-800": {
+      "type": "color",
+      "value": "#666666"
+    },
+    "color.gray-900": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-200": {
+      "type": "color",
+      "value": "#e5e5e5"
+    },
+    "color.neutral-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "color.neutral-400": {
+      "type": "color",
+      "value": "#a3a3a3"
+    },
+    "color.neutral-500": {
+      "type": "color",
+      "value": "#737373"
+    },
+    "color.neutral-600": {
+      "type": "color",
+      "value": "#525252"
+    },
+    "color.neutral-700": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "color.neutral-800": {
+      "type": "color",
+      "value": "#262626"
+    },
+    "color.neutral-900": {
+      "type": "color",
+      "value": "#171717"
+    },
+    "color.red-100": {
+      "type": "color",
+      "value": "#fee2e2"
+    },
+    "color.red-400": {
+      "type": "color",
+      "value": "#f87171"
+    },
+    "color.red-500": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "color.red-600": {
+      "type": "color",
+      "value": "#dc2626"
+    },
+    "color.red-800": {
+      "type": "color",
+      "value": "#991b1b"
+    },
+    "color.red-800-30": {
+      "type": "color",
+      "value": "#991b1b4d"
+    },
+    "color.tooltip-bg": {
+      "type": "color",
+      "value": "#111827"
+    },
+    "color.transparent": {
+      "type": "color",
+      "value": "#00000000"
+    },
+    "color.white": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "color.white-10": {
+      "type": "color",
+      "value": "#ffffff1a"
+    },
+    "color.white-20": {
+      "type": "color",
+      "value": "#ffffff33"
+    },
+    "color.yellow-100": {
+      "type": "color",
+      "value": "#fef9c3"
+    },
+    "color.yellow-400": {
+      "type": "color",
+      "value": "#facc15"
+    },
+    "color.yellow-500": {
+      "type": "color",
+      "value": "#eab308"
+    },
+    "color.yellow-600": {
+      "type": "color",
+      "value": "#ca8a04"
+    },
+    "color.yellow-800": {
+      "type": "color",
+      "value": "#854d0e"
+    },
+    "color.yellow-800-30": {
+      "type": "color",
+      "value": "#854d0e4d"
+    }
+  }
+}

--- a/src/design-system/Design.pen
+++ b/src/design-system/Design.pen
@@ -2199,6 +2199,153 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ORF1S",
+                  "name": "Status Circle Group",
+                  "width": 200,
+                  "layout": "vertical",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "VJfui",
+                      "name": "Group Header",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "BFeDx",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "STATUS CIRCLE",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.5
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "CMKR3",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "a5XLVG",
+                      "name": "Items",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 20,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Q2377g",
+                          "name": "Status",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "xvFPA",
+                              "name": "Badges",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "id": "F6czea",
+                                  "type": "ref",
+                                  "ref": "xz3Ab",
+                                  "name": "True",
+                                  "fill": "$color.status-success",
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "descendants": {
+                                    "e7K7wr": {
+                                      "type": "icon",
+                                      "id": "cNYkZ",
+                                      "name": "Icon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "icon": "check",
+                                      "library": "lucide",
+                                      "fill": "$color.white"
+                                    }
+                                  }
+                                },
+                                {
+                                  "id": "JCRIl",
+                                  "type": "ref",
+                                  "ref": "xz3Ab",
+                                  "name": "False",
+                                  "fill": "$color.status-danger",
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "descendants": {
+                                    "e7K7wr": {
+                                      "type": "icon",
+                                      "id": "J3Zqh",
+                                      "name": "Icon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "icon": "x",
+                                      "library": "lucide",
+                                      "fill": "$color.white"
+                                    }
+                                  }
+                                },
+                                {
+                                  "id": "s99jP",
+                                  "type": "ref",
+                                  "ref": "xz3Ab",
+                                  "name": "Unknown",
+                                  "fill": "$color.gray-500",
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "descendants": {
+                                    "e7K7wr": {
+                                      "type": "icon",
+                                      "id": "P2FCEQ",
+                                      "name": "Icon",
+                                      "width": 16,
+                                      "height": 16,
+                                      "icon": "circle-question-mark",
+                                      "library": "lucide",
+                                      "fill": "$color.white"
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "Mc5h8",
+                              "name": "Caption",
+                              "fill": "$color.gray-500",
+                              "content": "status: true / false / —",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }

--- a/src/design-system/Design.pen
+++ b/src/design-system/Design.pen
@@ -2346,6 +2346,805 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "type": "frame",
+                  "id": "zpqX3",
+                  "name": "Label Group",
+                  "width": 200,
+                  "layout": "vertical",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "JjhDm",
+                      "name": "Group Header",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SdBxL",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "LABEL",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.5
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "lPWRo",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Ij1cD",
+                      "name": "Items",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 20,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "XZQUi",
+                          "name": "Default",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "dBRG5",
+                              "name": "Label",
+                              "fill": "$color.neutral-700",
+                              "content": "Field label",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "KYyJk",
+                              "name": "Caption",
+                              "fill": "$color.gray-500",
+                              "content": "default",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "G8Q7FI",
+                          "name": "Required",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "m4FKQ",
+                              "name": "Label",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "cVKuV",
+                                  "name": "Text",
+                                  "fill": "$color.neutral-700",
+                                  "content": "Field label",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "GGh6i",
+                                  "name": "Asterisk",
+                                  "fill": "$color.red-500",
+                                  "content": " *",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "DyYnE",
+                              "name": "Caption",
+                              "fill": "$color.gray-500",
+                              "content": "required",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZlsMR",
+                  "name": "Spinner Group",
+                  "width": 200,
+                  "layout": "vertical",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "kek4r",
+                      "name": "Group Header",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "A1JyzJ",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "SPINNER",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.5
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "P3heN9",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BKvdA",
+                      "name": "Items",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 20,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "l9Mhmo",
+                          "name": "Sizes",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ovUzq",
+                              "name": "Ring Row",
+                              "gap": 20,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "KdriR",
+                                  "name": "Spinner sm",
+                                  "innerRadius": 0.625,
+                                  "startAngle": 135,
+                                  "sweepAngle": 270,
+                                  "fill": "$color.blue-600",
+                                  "width": 16,
+                                  "height": 16
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "QmBBm",
+                                  "name": "Spinner md",
+                                  "innerRadius": 0.75,
+                                  "startAngle": 135,
+                                  "sweepAngle": 270,
+                                  "fill": "$color.blue-600",
+                                  "width": 24,
+                                  "height": 24
+                                },
+                                {
+                                  "type": "ellipse",
+                                  "id": "wYQoN",
+                                  "name": "Spinner lg",
+                                  "innerRadius": 0.8125,
+                                  "startAngle": 135,
+                                  "sweepAngle": 270,
+                                  "fill": "$color.blue-600",
+                                  "width": 32,
+                                  "height": 32
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "C00xm0",
+                              "name": "Caption",
+                              "fill": "$color.gray-500",
+                              "content": "primary — sm / md / lg",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "If0fe",
+                          "name": "Light",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "D1fomn",
+                              "name": "Chip",
+                              "width": 48,
+                              "height": 48,
+                              "fill": "$color.neutral-900",
+                              "cornerRadius": 8,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "O1QrZK",
+                                  "name": "Spinner light",
+                                  "innerRadius": 0.75,
+                                  "startAngle": 135,
+                                  "sweepAngle": 270,
+                                  "fill": "$color.white",
+                                  "width": 24,
+                                  "height": 24
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "ErrOZ",
+                              "name": "Caption",
+                              "fill": "$color.gray-500",
+                              "content": "light (on dark)",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xUA7E",
+                  "name": "Tooltip Group",
+                  "width": 240,
+                  "layout": "vertical",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "r47pv",
+                      "name": "Group Header",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "LyYk9",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "TOOLTIP",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.5
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "eVUGH",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "inuJ8",
+                      "name": "Items",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "a8FChc",
+                          "name": "Preview",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Jmrty",
+                              "name": "Trigger",
+                              "width": 28,
+                              "height": 28,
+                              "fill": "$color.white",
+                              "cornerRadius": 6,
+                              "stroke": "$color.gray-300",
+                              "strokeWidth": 1,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "nZku0",
+                                  "name": "Icon",
+                                  "width": 16,
+                                  "height": 16,
+                                  "icon": "circle-question-mark",
+                                  "library": "lucide",
+                                  "fill": "$color.neutral-600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "g45eX",
+                              "name": "Tooltip",
+                              "layout": "vertical",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "path",
+                                  "id": "w66hw",
+                                  "name": "Arrow",
+                                  "geometry": "M0 6l6-6 6 6z",
+                                  "viewBox": [
+                                    0,
+                                    0,
+                                    12,
+                                    6
+                                  ],
+                                  "fill": "$color.tooltip-bg",
+                                  "width": 12,
+                                  "height": 6
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "GtdvX",
+                                  "name": "Bubble",
+                                  "fill": "$color.tooltip-bg",
+                                  "cornerRadius": 6,
+                                  "effect": {
+                                    "type": "shadow",
+                                    "shadowType": "outer",
+                                    "color": "#0000001f",
+                                    "offset": {
+                                      "x": 0,
+                                      "y": 1
+                                    },
+                                    "blur": 3
+                                  },
+                                  "padding": [
+                                    4,
+                                    8
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Y92Y3Y",
+                                      "name": "Label",
+                                      "fill": "$color.white",
+                                      "content": "More information",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "ejcNN",
+                          "name": "Caption",
+                          "fill": "$color.gray-500",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "hover hint · arrow · bottom",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ZxqYx",
+              "name": "Row 5",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "b5ItZy",
+                  "name": "Tabs Group",
+                  "width": 300,
+                  "layout": "vertical",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "V13SzF",
+                      "name": "Group Header",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "fyeJP",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "TABS",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.5
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "M76F9R",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "B6p4c",
+                      "name": "Items",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "C7frKm",
+                          "name": "Preview",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "QqYHY",
+                              "name": "Tab Bar",
+                              "gap": 4,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "JvPbi",
+                                  "name": "Overview Tab",
+                                  "fill": "$color.gray-200",
+                                  "cornerRadius": 8,
+                                  "gap": 6,
+                                  "padding": [
+                                    8,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "B6oHc",
+                                      "name": "Overview Label",
+                                      "fill": "$color.gray-800",
+                                      "content": "Overview",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "mrDW0",
+                                  "name": "Activity Tab",
+                                  "fill": "$color.transparent",
+                                  "cornerRadius": 8,
+                                  "gap": 6,
+                                  "padding": [
+                                    8,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "AXi6h",
+                                      "name": "Activity Label",
+                                      "fill": "$color.gray-500",
+                                      "content": "Activity",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "XwPdA",
+                                  "name": "Settings Tab",
+                                  "fill": "$color.transparent",
+                                  "cornerRadius": 8,
+                                  "gap": 6,
+                                  "padding": [
+                                    8,
+                                    12
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "JIBHj",
+                                      "name": "Settings Label",
+                                      "fill": "$color.gray-500",
+                                      "content": "Settings",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "V7mwU6",
+                          "name": "Caption",
+                          "fill": "$color.gray-500",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "active pill · ghost inactive · scrollable",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "X0z74W",
+                  "name": "Dialog Group",
+                  "width": 300,
+                  "layout": "vertical",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hfa5K",
+                      "name": "Group Header",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "g7gixW",
+                          "name": "Group Title",
+                          "fill": "$color.gray-500",
+                          "content": "DIALOG",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.5
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "htqdQ",
+                          "name": "Divider",
+                          "fill": "$color.gray-300",
+                          "width": "fill_container",
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "x8YCk4",
+                      "name": "Items",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Elcrf",
+                          "name": "Preview",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "y7NKsv",
+                              "name": "Dialog Card",
+                              "width": "fill_container",
+                              "fill": "$color.white",
+                              "cornerRadius": 10,
+                              "stroke": "$color.gray-200",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "effect": {
+                                "type": "shadow",
+                                "shadowType": "outer",
+                                "color": "#00000026",
+                                "offset": {
+                                  "x": 0,
+                                  "y": 6
+                                },
+                                "blur": 18,
+                                "spread": -5
+                              },
+                              "layout": "vertical",
+                              "padding": [
+                                14,
+                                14,
+                                10,
+                                14
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "tRNlu",
+                                  "name": "Caption",
+                                  "fill": "$color.neutral-900",
+                                  "content": "Delete profile?",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "pK4je",
+                                  "name": "BodyWrap",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "padding": [
+                                    6,
+                                    0,
+                                    10,
+                                    0
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "SdUax",
+                                      "name": "Body",
+                                      "fill": "$color.gray-500",
+                                      "textGrowth": "fixed-width",
+                                      "width": "fill_container",
+                                      "content": "This action can't be undone.",
+                                      "lineHeight": 1.4,
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "NfeKD",
+                                  "name": "Footer",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "justifyContent": "end",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "fdbYf",
+                                      "name": "Cancel Btn",
+                                      "fill": "$color.gray-100",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "aWKYQ",
+                                          "name": "Cancel Lbl",
+                                          "fill": "$color.gray-800",
+                                          "content": "Cancel",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "Rjour",
+                                      "name": "Delete Btn",
+                                      "fill": "$color.red-500",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        6,
+                                        10
+                                      ],
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "Mg2gk",
+                                          "name": "Delete Lbl",
+                                          "fill": "$color.white",
+                                          "content": "Delete",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "WQikz",
+                          "name": "Caption",
+                          "fill": "$color.gray-500",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "icon · caption · body · footer · sizes sm–xxl",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -6801,6 +7600,10 @@
     "color.status-warning": {
       "type": "color",
       "value": "#eab308"
+    },
+    "color.tooltip-bg": {
+      "type": "color",
+      "value": "#111827"
     }
   }
 }

--- a/src/design-system/PENCIL.md
+++ b/src/design-system/PENCIL.md
@@ -224,6 +224,11 @@ Always set `name` on every node. Use descriptive, hierarchical names:
 | BooleanBadge | `src/components/BooleanBadge/BooleanBadge.pen` |
 | StatusBadge | `src/components/StatusBadge/StatusBadge.pen` |
 | StatusCircle | `src/components/StatusCircle/StatusCircle.pen` |
+| Label | `src/components/Label/Label.pen` |
+| Spinner | `src/components/Spinner/Spinner.pen` |
+| Tooltip | `src/components/Tooltip/Tooltip.pen` |
+| Tabs | `src/components/Tabs/Tabs.pen` |
+| Dialog | `src/components/Dialog/Dialog.pen` |
 
 Button.pen is the most complete reference — it has 6 pages (Light/Dark × Solid/Outline/Transparent) showing all 5 color variants across 4 states.
 
@@ -257,6 +262,11 @@ Switch.pen has the richest single-page structure: States Table + Sizes + Example
 | BooleanBadge visual (Yes/No label, success/danger color, `invertColor`) | reuses `Badge/Solid` (override fill + Label; no dedicated reusable) |
 | StatusBadge visual (enabled flag → Enabled/Disabled/Unknown; `textStatus` → Approved/Rejected/Pending/Expired; success/danger/secondary color) | reuses `Badge/Solid` (override `padding:[2,6]` for small size + fill + Label; no dedicated reusable) |
 | StatusCircle visual (`status` true → success/check, false → danger/x, undefined → gray-500/circle-question-mark; small icon badge) | reuses `Badge/Solid` (override `padding:[2,6]` + fill, and **replace** the `e7K7wr` Label descendant with a 16×16 white lucide `icon`; no dedicated reusable) |
+| Label visual (form field label text 14/500 `neutral-700`; optional required `*` in `red-500`; clickable variant renders as button, same visual) | plain text — no reusable; showcase `Label Group` shows default + required (`Field label` + red ` *`) |
+| Spinner visual (animated ring, `border-3` + `border-t-transparent` → C-shaped arc; sizes sm/md/lg/xl = 16/24/32/40px; primary `blue-600` (dark `blue-500`), light `white`) | plain `ellipse` (`innerRadius:(d-6)/d`, `startAngle:135`, `sweepAngle:270`) — no reusable; showcase `Spinner Group` shows primary sm/md/lg + light-on-dark |
+| Tooltip visual (dark hover popover below trigger; `bg #111827` (dark `neutral-700`), white `text-xs`/500, `rounded-md`, `py-1 px-2`, up-pointing arrow, `sideOffset 8`; placement `bottom` only; long content wraps at `max-w-xs`) | bubble = `frame` (`fill $color.tooltip-bg`, `cornerRadius 6`, `padding [4,8]`) + arrow `path` (`M0 6 L6 0 L12 6 Z`) in a centered vertical unit — no reusable; needs `color.tooltip-bg` (#111827) token in Design.pen; showcase `Tooltip Group` shows trigger + bubble + arrow |
+| Tabs visual (horizontal pill tab bar; active tab `bg gray-200`/`text gray-800` (dark `neutral-700`/`white`), inactive `transparent`/`gray-500` (dark `neutral-500`), `text-sm`/500, `rounded-lg`, `py-3 px-4`, `gap-x-1` between tabs + `gap-x-2` for icon+label; disabled = `opacity-50`; horizontally scrollable via SimpleBar `forceVisible="x"` when tabs overflow) | tab = `frame` (`fill gray-200`/`transparent`, `cornerRadius 8`, `padding [12,16]`, optional leading lucide `icon` + `text` 14/500) — no reusable; showcase `Tabs Group` shows a 3-tab bar with the first active |
+| Dialog visual (Radix modal: white card `rounded-xl` (`p-8 !pb-0`), `border gray-200` + shadow (dark `bg neutral-800`/`border neutral-700`), over a `black/50` overlay scrim; optional 48px circular icon (`bg-current/12` + 64px `bg-current/6` ring behind) — delete/destroy/warning `red-800`, check `teal-800`/`teal-100` bg, default `#6b7280`; `caption` h3 24/700, `body` `text-gray-500` (dark `white`), footer button row `justify-end gap-4`; delete/destroy are centered + borderless; sizes sm/md/lg/xl/xxl = `max-w-sm/lg/xl/4xl/6xl`) | dialog = `frame` (`fill white`/`neutral-800`, `cornerRadius 12`, outer shadow), icon circle = 2 stacked `ellipse` (outer 6%, inner 12%) + lucide `icon`, footer buttons reuse the `btn` pattern (`padding [9,13]`, `cornerRadius 8`) — no reusable; needs `teal-100`/`teal-800`/`dialog-scrim`/tint tokens; showcase `Dialog Group` shows a compact card with caption + body + Cancel/Delete footer |
 | NumberInput visual (container, stepper buttons, value) | `NumberInput` |
 | Input sub-component visual (any of the 6 types) | `Input/DurationInput`, `Input/HostnameListInput`, `Input/FileUpload`, `Input/MultipleValueTextInput`, `Input/CodeEditor`, `Input/DynamicContent` |
 | New component `.pen` created | Add new reusable components + a new component group to the showcase grid (see layout note below) |
@@ -264,7 +274,7 @@ Switch.pen has the richest single-page structure: States Table + Sizes + Example
 
 ### Showcase layout (Component Library frame `VLhPh`)
 
-The primitives **Body** (`W3Yt2`, vertical, gap 40) is a **grid of rows**, not a single strip. Each row (`Row 1`/`Row 2`/`Row 3`/`Row 4`, horizontal, gap 40, `alignItems:start`) holds ~4 component groups. (`Row 4` currently holds the `Status Badge Group` + `Status Circle Group` — append the next components there before starting `Row 5`.) A component group = vertical frame (Group Header with title + divider, then an Items frame). The frame is intentionally kept ~3200 wide as **headroom**: new component groups fill the blank space — append to the shortest/last row, then start a new row once a row reaches ~4–5 groups. Below the primitives is the full-width **Input Section** (`jMZl6`) with composite form examples.
+The primitives **Body** (`W3Yt2`, vertical, gap 40) is a **grid of rows**, not a single strip. Each row (`Row 1`/`Row 2`/`Row 3`/`Row 4`/`Row 5`, horizontal, gap 40, `alignItems:start`) holds ~4 component groups. (`Row 4` is full with 5 groups — `Status Badge Group` + `Status Circle Group` + `Label Group` + `Spinner Group` + `Tooltip Group`. `Row 5` now holds the `Tabs Group` + `Dialog Group`; append the next component to `Row 5` until it reaches ~5 groups, then start `Row 6`.) A component group = vertical frame (Group Header with title + divider, then an Items frame). The frame is intentionally kept ~3200 wide as **headroom**: new component groups fill the blank space — append to the shortest/last row, then start a new row once a row reaches ~4–5 groups. Below the primitives is the full-width **Input Section** (`jMZl6`) with composite form examples.
 
 ### How to update a component in Design.pen
 

--- a/src/design-system/PENCIL.md
+++ b/src/design-system/PENCIL.md
@@ -223,6 +223,7 @@ Always set `name` on every node. Use descriptive, hierarchical names:
 | Badge | `src/components/Badge/Badge.pen` |
 | BooleanBadge | `src/components/BooleanBadge/BooleanBadge.pen` |
 | StatusBadge | `src/components/StatusBadge/StatusBadge.pen` |
+| StatusCircle | `src/components/StatusCircle/StatusCircle.pen` |
 
 Button.pen is the most complete reference — it has 6 pages (Light/Dark × Solid/Outline/Transparent) showing all 5 color variants across 4 states.
 
@@ -255,6 +256,7 @@ Switch.pen has the richest single-page structure: States Table + Sizes + Example
 | Badge visual (pill radius, padding/size, colors, remove button) | `Badge/Solid`, `Badge/Removable` |
 | BooleanBadge visual (Yes/No label, success/danger color, `invertColor`) | reuses `Badge/Solid` (override fill + Label; no dedicated reusable) |
 | StatusBadge visual (enabled flag → Enabled/Disabled/Unknown; `textStatus` → Approved/Rejected/Pending/Expired; success/danger/secondary color) | reuses `Badge/Solid` (override `padding:[2,6]` for small size + fill + Label; no dedicated reusable) |
+| StatusCircle visual (`status` true → success/check, false → danger/x, undefined → gray-500/circle-question-mark; small icon badge) | reuses `Badge/Solid` (override `padding:[2,6]` + fill, and **replace** the `e7K7wr` Label descendant with a 16×16 white lucide `icon`; no dedicated reusable) |
 | NumberInput visual (container, stepper buttons, value) | `NumberInput` |
 | Input sub-component visual (any of the 6 types) | `Input/DurationInput`, `Input/HostnameListInput`, `Input/FileUpload`, `Input/MultipleValueTextInput`, `Input/CodeEditor`, `Input/DynamicContent` |
 | New component `.pen` created | Add new reusable components + a new component group to the showcase grid (see layout note below) |
@@ -262,7 +264,7 @@ Switch.pen has the richest single-page structure: States Table + Sizes + Example
 
 ### Showcase layout (Component Library frame `VLhPh`)
 
-The primitives **Body** (`W3Yt2`, vertical, gap 40) is a **grid of rows**, not a single strip. Each row (`Row 1`/`Row 2`/`Row 3`/`Row 4`, horizontal, gap 40, `alignItems:start`) holds ~4 component groups. (`Row 4` currently holds just the `Status Badge Group` — append the next components there before starting `Row 5`.) A component group = vertical frame (Group Header with title + divider, then an Items frame). The frame is intentionally kept ~3200 wide as **headroom**: new component groups fill the blank space — append to the shortest/last row, then start a new row once a row reaches ~4–5 groups. Below the primitives is the full-width **Input Section** (`jMZl6`) with composite form examples.
+The primitives **Body** (`W3Yt2`, vertical, gap 40) is a **grid of rows**, not a single strip. Each row (`Row 1`/`Row 2`/`Row 3`/`Row 4`, horizontal, gap 40, `alignItems:start`) holds ~4 component groups. (`Row 4` currently holds the `Status Badge Group` + `Status Circle Group` — append the next components there before starting `Row 5`.) A component group = vertical frame (Group Header with title + divider, then an Items frame). The frame is intentionally kept ~3200 wide as **headroom**: new component groups fill the blank space — append to the shortest/last row, then start a new row once a row reaches ~4–5 groups. Below the primitives is the full-width **Input Section** (`jMZl6`) with composite form examples.
 
 ### How to update a component in Design.pen
 


### PR DESCRIPTION
Closes #1714

Adds the **StatusCircle** design-system Pencil file and syncs it into the showcase.

- `src/components/StatusCircle/StatusCircle.pen` — Light + Dark pages, **STATES** section with the three icon-badge states:
  - `status: true` → success `#14b8a6` / `check`
  - `status: false` → danger `#ef4444` / `x`
  - `status: undefined` → gray-500 `#a8a8a8` / `circle-question-mark`
  - Small icon badge: `padding:[2,6]`, `cornerRadius:6`, white 16×16 lucide icon centered.
- `src/design-system/Design.pen` — added **Status Circle Group** to Row 4 (reuses `Badge/Solid` with the Label replaced by an icon).
- `src/design-system/PENCIL.md` — §8 file table, §9 sync map, Row 4 layout note.

Stacked on `pencil-statusbadge-component` (PR #1787).

🤖 Generated with [Claude Code](https://claude.com/claude-code)