### PR TITLE
Send null instead of empty string for blank email on user update

### DIFF
--- a/src/ducks/transform/auth.spec.ts
+++ b/src/ducks/transform/auth.spec.ts
@@ -94,4 +94,13 @@ describe('auth transforms', () => {
         const result = transformUserUpdateRequestModelToDto(model);
         expect(result.customAttributes).toHaveLength(1);
     });
+
+    test('transformUserUpdateRequestModelToDto sends null for a blank email (issue #1800)', () => {
+        expect(transformUserUpdateRequestModelToDto({ email: '' } as any).email).toBeNull();
+        expect(transformUserUpdateRequestModelToDto({ email: undefined } as any).email).toBeNull();
+    });
+
+    test('transformUserUpdateRequestModelToDto keeps a provided email', () => {
+        expect(transformUserUpdateRequestModelToDto({ email: 'a@b.com' } as any).email).toBe('a@b.com');
+    });
 });

--- a/src/ducks/transform/auth.ts
+++ b/src/ducks/transform/auth.ts
@@ -45,6 +45,7 @@ export function transformRoleResponseDtoToModel(role: RoleResponseDto): RoleResp
 export function transformUserUpdateRequestModelToDto(user: UserUpdateRequestModel): UserUpdateRequestDto {
     return {
         ...user,
+        email: user.email || null,
         customAttributes: user.customAttributes?.map(transformAttributeRequestModelToDto),
-    };
+    } as UserUpdateRequestDto;
 }


### PR DESCRIPTION
Fixes #1800 