### PR TITLE
fix: always send recordPolicy in signing profile request (#1810)

### DIFF
--- a/src/components/_pages/signing-profiles/form/SigningProfileForm.tsx
+++ b/src/components/_pages/signing-profiles/form/SigningProfileForm.tsx
@@ -511,7 +511,6 @@ export default function SigningProfileForm() {
                 recordSignedDocument: recordSignedDocumentAllowed ? values.recordSignedDocument : false,
                 recordDtbs: signatureAndDtbsRecordable ? values.recordDtbs : false,
                 retentionDays: values.retentionIndefinite ? undefined : Number(values.retentionDays),
-                deleteAfterRetrieval: values.deleteAfterRetrieval,
                 persistenceMode: values.persistenceMode,
             };
 

--- a/src/components/_pages/signing-profiles/form/SigningProfileForm.tsx
+++ b/src/components/_pages/signing-profiles/form/SigningProfileForm.tsx
@@ -502,21 +502,18 @@ export default function SigningProfileForm() {
                 signingOperationAttributes: signingOpAttrs,
             };
 
-            // When recording is disabled, omit recordPolicy entirely so the API applies its
-            // default (no signing record) rather than persisting an explicit disabled policy.
-            const recordPolicy: SigningRecordPolicyRequestDto | undefined = values.recordingEnabled
-                ? {
-                      recordingEnabled: true,
-                      recordRequestMetadata: values.recordRequestMetadata,
-                      // Not stored for the timestamping workflow; force false when the toggle is hidden.
-                      recordSignature: signatureAndDtbsRecordable ? values.recordSignature : false,
-                      // Only valid for CONTENT_SIGNING / TIMESTAMPING; force false otherwise.
-                      recordSignedDocument: recordSignedDocumentAllowed ? values.recordSignedDocument : false,
-                      recordDtbs: signatureAndDtbsRecordable ? values.recordDtbs : false,
-                      retentionDays: values.retentionIndefinite ? undefined : Number(values.retentionDays),
-                      persistenceMode: values.persistenceMode,
-                  }
-                : undefined;
+            const recordPolicy: SigningRecordPolicyRequestDto = {
+                recordingEnabled: values.recordingEnabled,
+                recordRequestMetadata: values.recordRequestMetadata,
+                // Not stored for the timestamping workflow; force false when the toggle is hidden.
+                recordSignature: signatureAndDtbsRecordable ? values.recordSignature : false,
+                // Only valid for CONTENT_SIGNING / TIMESTAMPING; force false otherwise.
+                recordSignedDocument: recordSignedDocumentAllowed ? values.recordSignedDocument : false,
+                recordDtbs: signatureAndDtbsRecordable ? values.recordDtbs : false,
+                retentionDays: values.retentionIndefinite ? undefined : Number(values.retentionDays),
+                deleteAfterRetrieval: values.deleteAfterRetrieval,
+                persistenceMode: values.persistenceMode,
+            };
 
             const requestDto = {
                 name: values.name,


### PR DESCRIPTION
Previously, when recording was disabled the form omitted recordPolicy entirely (undefined → absent from JSON), so the backend received no instruction to disable recording and left the existing policy unchanged.

Now the full policy object is always sent with recordingEnabled reflecting the toggle value. This ensures:
- disabling recording is explicitly persisted on update
- persistenceMode and all other content-policy fields round-trip correctly, preserving settings for when recording is later re-enabled