### PR TITLE
Add the time-quality configuration association widget

### DIFF
--- a/src/components/_pages/time-quality-configurations/detail/TimeQualityConfigurationDetail.tsx
+++ b/src/components/_pages/time-quality-configurations/detail/TimeQualityConfigurationDetail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 
 import Breadcrumb from 'components/Breadcrumb';
 import Container from 'components/Container';
@@ -9,6 +9,7 @@ import Dialog from 'components/Dialog';
 import Widget from 'components/Widget';
 import type { WidgetButtonProps } from 'components/WidgetButtons';
 import CustomAttributeWidget from 'components/Attributes/CustomAttributeWidget';
+import StatusBadge from 'components/StatusBadge';
 
 import { actions, selectors } from 'ducks/time-quality-configurations';
 import { Resource } from 'types/openapi';
@@ -26,6 +27,9 @@ export const TimeQualityConfigurationDetail = () => {
     const isFetchingDetail = useSelector(selectors.isFetchingDetail);
     const isDeleting = useSelector(selectors.isDeleting);
     const deleteErrorMessage = useSelector(selectors.deleteErrorMessage);
+    const associatedSigningProfiles = useSelector(selectors.associatedSigningProfiles);
+    const isFetchingAssociatedSigningProfiles = useSelector(selectors.isFetchingAssociatedSigningProfiles);
+
     const [confirmDelete, setConfirmDelete] = useState<boolean>(false);
 
     const isBusy = useMemo(() => isFetchingDetail || isDeleting, [isFetchingDetail, isDeleting]);
@@ -33,6 +37,7 @@ export const TimeQualityConfigurationDetail = () => {
     const getFreshData = useCallback(() => {
         if (!id) return;
         dispatch(actions.getTimeQualityConfiguration({ uuid: id }));
+        dispatch(actions.listAssociatedSigningProfiles({ uuid: id }));
     }, [dispatch, id]);
 
     useEffect(() => {
@@ -71,6 +76,28 @@ export const TimeQualityConfigurationDetail = () => {
     );
 
     const tableHeader: TableHeader[] = useMemo(() => createWidgetDetailHeaders(), []);
+
+    const signingProfilesTableHeaders: TableHeader[] = useMemo(
+        () => [
+            { id: 'name', content: 'Name', sortable: true },
+            { id: 'enabled', content: 'Enabled' },
+        ],
+        [],
+    );
+
+    const signingProfilesTableData: TableDataRow[] = useMemo(
+        () =>
+            associatedSigningProfiles.map((sp) => ({
+                id: sp.uuid,
+                columns: [
+                    <Link key="name" to={`/${Resource.SigningProfiles.toLowerCase()}/detail/${sp.uuid}`}>
+                        {sp.name}
+                    </Link>,
+                    <StatusBadge key="enabled" enabled={sp.enabled} />,
+                ],
+            })),
+        [associatedSigningProfiles],
+    );
 
     const generalData: TableDataRow[] = useMemo(
         () =>
@@ -214,6 +241,17 @@ export const TimeQualityConfigurationDetail = () => {
 
                     <Widget title="NTP Settings" titleSize="large">
                         {ntpData.length > 0 && <CustomTable headers={tableHeader} data={ntpData} />}
+                    </Widget>
+                    <Widget title="Used by Signing Profiles" titleSize="large" busy={isFetchingAssociatedSigningProfiles}>
+                        {associatedSigningProfiles.length > 0 ? (
+                            <CustomTable headers={signingProfilesTableHeaders} data={signingProfilesTableData} />
+                        ) : (
+                            !isFetchingAssociatedSigningProfiles && (
+                                <p className="text-sm text-gray-400">
+                                    No Signing Profiles are currently using this Time Quality Configuration.
+                                </p>
+                            )
+                        )}
                     </Widget>
                 </Container>
             </Widget>

--- a/src/components/_pages/tsp-profiles/form/TspProfileForm.tsx
+++ b/src/components/_pages/tsp-profiles/form/TspProfileForm.tsx
@@ -162,7 +162,7 @@ export const TspProfileForm = () => {
     const lastResetIdRef = useRef<string | undefined>(undefined);
 
     const valuesToReset = useMemo<FormValues | undefined>(() => {
-        if (!editMode || !id || !tspProfile || tspProfile.uuid !== id || isFetchingDetail) return undefined;
+        if (!editMode || !id || tspProfile?.uuid !== id || isFetchingDetail) return undefined;
 
         const attributeInitialValues = mapProfileAttribute(
             tspProfile,

--- a/src/components/_pages/tsp-profiles/form/TspProfileForm.tsx
+++ b/src/components/_pages/tsp-profiles/form/TspProfileForm.tsx
@@ -162,7 +162,7 @@ export const TspProfileForm = () => {
     const lastResetIdRef = useRef<string | undefined>(undefined);
 
     const valuesToReset = useMemo<FormValues | undefined>(() => {
-        if (!editMode || !id || tspProfile?.uuid !== id || isFetchingDetail) return undefined;
+        if (!editMode || !id || !tspProfile || tspProfile.uuid !== id || isFetchingDetail) return undefined;
 
         const attributeInitialValues = mapProfileAttribute(
             tspProfile,

--- a/src/ducks/time-quality-configurations-epics.spec.ts
+++ b/src/ducks/time-quality-configurations-epics.spec.ts
@@ -335,7 +335,7 @@ describe('timeQualityConfigurations epics', () => {
         );
     });
 
-    test('listAssociatedSigningProfiles failure emits listAssociatedSigningProfilesFailure', async () => {
+    test('listAssociatedSigningProfiles failure emits listAssociatedSigningProfilesFailure and fetchError', async () => {
         const err = new Error('fetch failed');
         const emitted = await runEpic(
             TimeQualityConfigurationsEpicIndex.ListAssociatedSigningProfiles,
@@ -345,9 +345,10 @@ describe('timeQualityConfigurations epics', () => {
                     listSigningProfilesForTimeQualityConfiguration: () => throwError(() => err),
                 } as any,
             },
-            1,
+            2,
         );
 
         expect(emitted[0].type).toBe(timeQualityConfigurationActions.listAssociatedSigningProfilesFailure.type);
+        expect(emitted[1]).toEqual(appRedirectActions.fetchError({ error: err, message: 'Failed to get associated Signing Profiles' }));
     });
 });

--- a/src/ducks/time-quality-configurations-epics.spec.ts
+++ b/src/ducks/time-quality-configurations-epics.spec.ts
@@ -34,6 +34,7 @@ enum TimeQualityConfigurationsEpicIndex {
     Update = 4,
     Delete = 5,
     BulkDelete = 6,
+    ListAssociatedSigningProfiles = 7,
 }
 
 vi.mock('../App', () => ({
@@ -314,5 +315,39 @@ describe('timeQualityConfigurations epics', () => {
 
         expect(emitted[0].type).toBe(timeQualityConfigurationActions.bulkDeleteTimeQualityConfigurationsFailure.type);
         expect(emitted[1]).toEqual(appRedirectActions.fetchError({ error: err, message: 'Failed to delete Time Quality Configurations' }));
+    });
+
+    test('listAssociatedSigningProfiles success emits listAssociatedSigningProfilesSuccess', async () => {
+        const profiles = [{ uuid: 'sp-1', name: 'Signing Profile 1' }];
+        const emitted = await runEpic(
+            TimeQualityConfigurationsEpicIndex.ListAssociatedSigningProfiles,
+            timeQualityConfigurationActions.listAssociatedSigningProfiles({ uuid: 'c-1' }),
+            {
+                timeQualityConfigurations: {
+                    listSigningProfilesForTimeQualityConfiguration: () => of(profiles),
+                } as any,
+            },
+            1,
+        );
+
+        expect(emitted[0]).toEqual(
+            timeQualityConfigurationActions.listAssociatedSigningProfilesSuccess({ signingProfiles: profiles as any }),
+        );
+    });
+
+    test('listAssociatedSigningProfiles failure emits listAssociatedSigningProfilesFailure', async () => {
+        const err = new Error('fetch failed');
+        const emitted = await runEpic(
+            TimeQualityConfigurationsEpicIndex.ListAssociatedSigningProfiles,
+            timeQualityConfigurationActions.listAssociatedSigningProfiles({ uuid: 'c-1' }),
+            {
+                timeQualityConfigurations: {
+                    listSigningProfilesForTimeQualityConfiguration: () => throwError(() => err),
+                } as any,
+            },
+            1,
+        );
+
+        expect(emitted[0].type).toBe(timeQualityConfigurationActions.listAssociatedSigningProfilesFailure.type);
     });
 });

--- a/src/ducks/time-quality-configurations-epics.ts
+++ b/src/ducks/time-quality-configurations-epics.ts
@@ -200,6 +200,24 @@ const bulkDeleteTimeQualityConfigurations: AppEpic = (action$, state$, deps) => 
     );
 };
 
+const listAssociatedSigningProfiles: AppEpic = (action$, state$, deps) => {
+    return action$.pipe(
+        filter(slice.actions.listAssociatedSigningProfiles.match),
+        switchMap((action) =>
+            deps.apiClients.timeQualityConfigurations.listSigningProfilesForTimeQualityConfiguration({ uuid: action.payload.uuid }).pipe(
+                switchMap((profiles) => of(slice.actions.listAssociatedSigningProfilesSuccess({ signingProfiles: profiles }))),
+                catchError((error) =>
+                    of(
+                        slice.actions.listAssociatedSigningProfilesFailure({
+                            error: extractError(error, 'Failed to get associated Signing Profiles'),
+                        }),
+                    ),
+                ),
+            ),
+        ),
+    );
+};
+
 const epics = [
     listTimeQualityConfigurations,
     getTimeQualityConfiguration,
@@ -208,6 +226,7 @@ const epics = [
     updateTimeQualityConfiguration,
     deleteTimeQualityConfiguration,
     bulkDeleteTimeQualityConfigurations,
+    listAssociatedSigningProfiles,
 ];
 
 export default epics;

--- a/src/ducks/time-quality-configurations-epics.ts
+++ b/src/ducks/time-quality-configurations-epics.ts
@@ -211,6 +211,7 @@ const listAssociatedSigningProfiles: AppEpic = (action$, state$, deps) => {
                         slice.actions.listAssociatedSigningProfilesFailure({
                             error: extractError(error, 'Failed to get associated Signing Profiles'),
                         }),
+                        appRedirectActions.fetchError({ error, message: 'Failed to get associated Signing Profiles' }),
                     ),
                 ),
             ),

--- a/src/ducks/time-quality-configurations.spec.ts
+++ b/src/ducks/time-quality-configurations.spec.ts
@@ -191,6 +191,31 @@ describe('timeQualityConfigurations slice', () => {
         expect(next.bulkDeleteErrorMessages).toEqual(errors);
         expect(next.timeQualityConfigurations).toHaveLength(1);
     });
+
+    test('listAssociatedSigningProfiles sets isFetchingAssociatedSigningProfiles and clears list', () => {
+        const state = { ...initialState, associatedSigningProfiles: [{ uuid: 'sp-1' }] as any[] };
+        const next = reducer(state, actions.listAssociatedSigningProfiles({ uuid: 'c-1' }));
+        expect(next.isFetchingAssociatedSigningProfiles).toBe(true);
+        expect(next.associatedSigningProfiles).toEqual([]);
+    });
+
+    test('listAssociatedSigningProfilesSuccess sets profiles and clears flag', () => {
+        const profiles = [{ uuid: 'sp-1' }] as any[];
+        const next = reducer(
+            { ...initialState, isFetchingAssociatedSigningProfiles: true },
+            actions.listAssociatedSigningProfilesSuccess({ signingProfiles: profiles }),
+        );
+        expect(next.isFetchingAssociatedSigningProfiles).toBe(false);
+        expect(next.associatedSigningProfiles).toEqual(profiles);
+    });
+
+    test('listAssociatedSigningProfilesFailure clears isFetchingAssociatedSigningProfiles', () => {
+        const next = reducer(
+            { ...initialState, isFetchingAssociatedSigningProfiles: true },
+            actions.listAssociatedSigningProfilesFailure({ error: 'err' }),
+        );
+        expect(next.isFetchingAssociatedSigningProfiles).toBe(false);
+    });
 });
 
 describe('timeQualityConfigurations selectors', () => {
@@ -199,6 +224,8 @@ describe('timeQualityConfigurations selectors', () => {
         const configs = [config];
         const fields = [{ searchGroupEnum: 'g-1' }] as any[];
         const bulkErrors = [{ message: 'err' }] as any[];
+
+        const profiles = [{ uuid: 'sp-1' }] as any[];
 
         const featureState = {
             ...initialState,
@@ -215,6 +242,8 @@ describe('timeQualityConfigurations selectors', () => {
             isDeleting: true,
             isUpdating: true,
             isBulkDeleting: true,
+            associatedSigningProfiles: profiles,
+            isFetchingAssociatedSigningProfiles: true,
         };
 
         const state = { timeQualityConfigurations: featureState } as any;
@@ -232,5 +261,7 @@ describe('timeQualityConfigurations selectors', () => {
         expect(selectors.isDeleting(state)).toBe(true);
         expect(selectors.isUpdating(state)).toBe(true);
         expect(selectors.isBulkDeleting(state)).toBe(true);
+        expect(selectors.associatedSigningProfiles(state)).toEqual(profiles);
+        expect(selectors.isFetchingAssociatedSigningProfiles(state)).toBe(true);
     });
 });

--- a/src/ducks/time-quality-configurations.ts
+++ b/src/ducks/time-quality-configurations.ts
@@ -1,6 +1,7 @@
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type {
     SearchFieldDataByGroupDto,
+    SimplifiedSigningProfileDto,
     TimeQualityConfigurationDto,
     TimeQualityConfigurationListDto,
     TimeQualityConfigurationRequestDto,
@@ -26,6 +27,9 @@ export type State = {
     isDeleting: boolean;
     isUpdating: boolean;
     isBulkDeleting: boolean;
+
+    associatedSigningProfiles: SimplifiedSigningProfileDto[];
+    isFetchingAssociatedSigningProfiles: boolean;
 };
 
 export const initialState: State = {
@@ -43,6 +47,9 @@ export const initialState: State = {
     isDeleting: false,
     isUpdating: false,
     isBulkDeleting: false,
+
+    associatedSigningProfiles: [],
+    isFetchingAssociatedSigningProfiles: false,
 };
 
 export const slice = createSlice({
@@ -99,6 +106,20 @@ export const slice = createSlice({
 
         getTimeQualityConfigurationFailure: (state, action: PayloadAction<{ error: string | undefined }>) => {
             state.isFetchingDetail = false;
+        },
+
+        listAssociatedSigningProfiles: (state, action: PayloadAction<{ uuid: string }>) => {
+            state.isFetchingAssociatedSigningProfiles = true;
+            state.associatedSigningProfiles = [];
+        },
+
+        listAssociatedSigningProfilesSuccess: (state, action: PayloadAction<{ signingProfiles: SimplifiedSigningProfileDto[] }>) => {
+            state.isFetchingAssociatedSigningProfiles = false;
+            state.associatedSigningProfiles = action.payload.signingProfiles;
+        },
+
+        listAssociatedSigningProfilesFailure: (state, action: PayloadAction<{ error: string | undefined }>) => {
+            state.isFetchingAssociatedSigningProfiles = false;
         },
 
         listTimeQualityConfigurationSearchableFields: (state, action: PayloadAction<void>) => {
@@ -228,6 +249,8 @@ const isCreating = createSelector(state, (state) => state.isCreating);
 const isDeleting = createSelector(state, (state) => state.isDeleting);
 const isUpdating = createSelector(state, (state) => state.isUpdating);
 const isBulkDeleting = createSelector(state, (state) => state.isBulkDeleting);
+const associatedSigningProfiles = createSelector(state, (state) => state.associatedSigningProfiles);
+const isFetchingAssociatedSigningProfiles = createSelector(state, (state) => state.isFetchingAssociatedSigningProfiles);
 
 export const selectors = {
     state,
@@ -244,6 +267,8 @@ export const selectors = {
     isDeleting,
     isUpdating,
     isBulkDeleting,
+    associatedSigningProfiles,
+    isFetchingAssociatedSigningProfiles,
 };
 
 export const actions = slice.actions;

--- a/src/ducks/tsp-profiles-epics.spec.ts
+++ b/src/ducks/tsp-profiles-epics.spec.ts
@@ -59,17 +59,21 @@ async function runEpic(
     const { default: epics } = await import('./tsp-profiles-epics');
 
     const defaultClient = {
-        listTspProfiles: () => of({ items: [{ uuid: 'p-1', name: 'TSP Profile 1', enabled: true }], totalItems: 1 }),
-        getTspProfile: () => of({ uuid: 'p-1', name: 'TSP Profile 1', enabled: true }),
+        listTspProfiles: () =>
+            of({
+                items: [{ uuid: 'profile-1', name: 'TSP Profile 1', enabled: true }],
+                totalItems: 1,
+            }),
+        getTspProfile: () => of({ uuid: 'profile-1', name: 'TSP Profile 1', enabled: true }),
         listTspProfileSearchableFields: () => of([{ searchGroupEnum: 'g-1' }]),
-        createTspProfile: () => of({ uuid: 'p-new', name: 'New TSP Profile', enabled: true }),
-        updateTspProfile: () => of({ uuid: 'p-1', name: 'Updated TSP Profile', enabled: true }),
+        createTspProfile: () => of({ uuid: 'c-new', name: 'New TSP Profile' }),
+        updateTspProfile: () => of({ uuid: 'profile-1', name: 'Updated TSP Profile' }),
         deleteTspProfile: () => of(null),
-        enableTspProfile: () => of(null),
-        disableTspProfile: () => of(null),
+        enableTspProfile: () => of(undefined),
+        disableTspProfile: () => of(undefined),
         bulkDeleteTspProfiles: () => of([]),
-        bulkEnableTspProfiles: () => of(null),
-        bulkDisableTspProfiles: () => of(null),
+        bulkEnableTspProfiles: () => of(undefined),
+        bulkDisableTspProfiles: () => of(undefined),
     };
 
     const deps: EpicDeps = {
@@ -84,24 +88,28 @@ async function runEpic(
 }
 
 describe('tspProfiles epics', () => {
-    test('listTspProfiles success emits listSuccess, pagingListSuccess and removeWidgetLock', async () => {
+    test('listTspProfiles success emits listSuccess and removeWidgetLock', async () => {
         const emitted = await runEpic(TspProfilesEpicIndex.List, tspProfileActions.listTspProfiles(), {}, 3);
 
         expect(emitted[0]).toEqual(
             tspProfileActions.listTspProfilesSuccess({
-                tspProfiles: [{ uuid: 'p-1', name: 'TSP Profile 1', enabled: true }] as any,
+                tspProfiles: [{ uuid: 'profile-1', name: 'TSP Profile 1', enabled: true }] as any,
             }),
         );
         expect(emitted[1]).toEqual(pagingActions.listSuccess({ entity: EntityType.TSP_PROFILE, totalItems: 1 }));
         expect(emitted[2]).toEqual(userInterfaceActions.removeWidgetLock(LockWidgetNameEnum.ListOfTspProfiles));
     });
 
-    test('listTspProfiles failure emits listFailure, pagingListFailure and insertWidgetLock', async () => {
+    test('listTspProfiles failure emits listFailure and insertWidgetLock', async () => {
         const err = new Error('failed');
         const emitted = await runEpic(
             TspProfilesEpicIndex.List,
             tspProfileActions.listTspProfiles(),
-            { tspProfiles: { listTspProfiles: () => throwError(() => err) } as any },
+            {
+                tspProfiles: {
+                    listTspProfiles: () => throwError(() => err),
+                } as any,
+            },
             3,
         );
 
@@ -111,11 +119,15 @@ describe('tspProfiles epics', () => {
     });
 
     test('getTspProfile success emits getSuccess and removeWidgetLock', async () => {
-        const profile = { uuid: 'p-1', name: 'TSP Profile 1', enabled: true };
+        const profile = { uuid: 'profile-1', name: 'TSP Profile 1', enabled: true };
         const emitted = await runEpic(
             TspProfilesEpicIndex.Detail,
-            tspProfileActions.getTspProfile({ uuid: 'p-1' }),
-            { tspProfiles: { getTspProfile: () => of(profile) } as any },
+            tspProfileActions.getTspProfile({ uuid: 'profile-1' }),
+            {
+                tspProfiles: {
+                    getTspProfile: () => of(profile),
+                } as any,
+            },
             2,
         );
 
@@ -127,8 +139,12 @@ describe('tspProfiles epics', () => {
         const err = new Error('failed');
         const emitted = await runEpic(
             TspProfilesEpicIndex.Detail,
-            tspProfileActions.getTspProfile({ uuid: 'p-1' }),
-            { tspProfiles: { getTspProfile: () => throwError(() => err) } as any },
+            tspProfileActions.getTspProfile({ uuid: 'profile-1' }),
+            {
+                tspProfiles: {
+                    getTspProfile: () => throwError(() => err),
+                } as any,
+            },
             3,
         );
 
@@ -142,7 +158,11 @@ describe('tspProfiles epics', () => {
         const emitted = await runEpic(
             TspProfilesEpicIndex.SearchableFields,
             tspProfileActions.listTspProfileSearchableFields(),
-            { tspProfiles: { listTspProfileSearchableFields: () => of(fields) } as any },
+            {
+                tspProfiles: {
+                    listTspProfileSearchableFields: () => of(fields),
+                } as any,
+            },
             1,
         );
 
@@ -154,7 +174,11 @@ describe('tspProfiles epics', () => {
         const emitted = await runEpic(
             TspProfilesEpicIndex.SearchableFields,
             tspProfileActions.listTspProfileSearchableFields(),
-            { tspProfiles: { listTspProfileSearchableFields: () => throwError(() => err) } as any },
+            {
+                tspProfiles: {
+                    listTspProfileSearchableFields: () => throwError(() => err),
+                } as any,
+            },
             1,
         );
 
@@ -170,7 +194,7 @@ describe('tspProfiles epics', () => {
         );
 
         expect(emitted[0].type).toBe(tspProfileActions.createTspProfileSuccess.type);
-        expect(emitted[1]).toEqual(appRedirectActions.redirect({ url: '../tspprofiles/detail/p-new' }));
+        expect(emitted[1]).toEqual(appRedirectActions.redirect({ url: '../tspprofiles/detail/c-new' }));
     });
 
     test('createTspProfile failure emits createFailure and fetchError', async () => {
@@ -178,7 +202,11 @@ describe('tspProfiles epics', () => {
         const emitted = await runEpic(
             TspProfilesEpicIndex.Create,
             tspProfileActions.createTspProfile({ tspProfileRequestDto: {} as any }),
-            { tspProfiles: { createTspProfile: () => throwError(() => err) } as any },
+            {
+                tspProfiles: {
+                    createTspProfile: () => throwError(() => err),
+                } as any,
+            },
             2,
         );
 
@@ -189,21 +217,25 @@ describe('tspProfiles epics', () => {
     test('updateTspProfile success emits updateSuccess and redirect', async () => {
         const emitted = await runEpic(
             TspProfilesEpicIndex.Update,
-            tspProfileActions.updateTspProfile({ uuid: 'p-1', tspProfileRequestDto: {} as any }),
+            tspProfileActions.updateTspProfile({ uuid: 'profile-1', tspProfileRequestDto: {} as any }),
             {},
             2,
         );
 
         expect(emitted[0].type).toBe(tspProfileActions.updateTspProfileSuccess.type);
-        expect(emitted[1]).toEqual(appRedirectActions.redirect({ url: '../../tspprofiles/detail/p-1' }));
+        expect(emitted[1]).toEqual(appRedirectActions.redirect({ url: '../../tspprofiles/detail/profile-1' }));
     });
 
     test('updateTspProfile failure emits updateFailure and fetchError', async () => {
         const err = new Error('update failed');
         const emitted = await runEpic(
             TspProfilesEpicIndex.Update,
-            tspProfileActions.updateTspProfile({ uuid: 'p-1', tspProfileRequestDto: {} as any }),
-            { tspProfiles: { updateTspProfile: () => throwError(() => err) } as any },
+            tspProfileActions.updateTspProfile({ uuid: 'profile-1', tspProfileRequestDto: {} as any }),
+            {
+                tspProfiles: {
+                    updateTspProfile: () => throwError(() => err),
+                } as any,
+            },
             2,
         );
 
@@ -212,9 +244,9 @@ describe('tspProfiles epics', () => {
     });
 
     test('deleteTspProfile success emits deleteSuccess and redirect', async () => {
-        const emitted = await runEpic(TspProfilesEpicIndex.Delete, tspProfileActions.deleteTspProfile({ uuid: 'p-1' }), {}, 2);
+        const emitted = await runEpic(TspProfilesEpicIndex.Delete, tspProfileActions.deleteTspProfile({ uuid: 'profile-1' }), {}, 2);
 
-        expect(emitted[0]).toEqual(tspProfileActions.deleteTspProfileSuccess({ uuid: 'p-1' }));
+        expect(emitted[0]).toEqual(tspProfileActions.deleteTspProfileSuccess({ uuid: 'profile-1' }));
         expect(emitted[1]).toEqual(appRedirectActions.redirect({ url: '../../tspprofiles' }));
     });
 
@@ -222,8 +254,12 @@ describe('tspProfiles epics', () => {
         const err = new Error('delete failed');
         const emitted = await runEpic(
             TspProfilesEpicIndex.Delete,
-            tspProfileActions.deleteTspProfile({ uuid: 'p-1' }),
-            { tspProfiles: { deleteTspProfile: () => throwError(() => err) } as any },
+            tspProfileActions.deleteTspProfile({ uuid: 'profile-1' }),
+            {
+                tspProfiles: {
+                    deleteTspProfile: () => throwError(() => err),
+                } as any,
+            },
             2,
         );
 
@@ -232,17 +268,21 @@ describe('tspProfiles epics', () => {
     });
 
     test('enableTspProfile success emits enableSuccess', async () => {
-        const emitted = await runEpic(TspProfilesEpicIndex.Enable, tspProfileActions.enableTspProfile({ uuid: 'p-1' }), {}, 1);
+        const emitted = await runEpic(TspProfilesEpicIndex.Enable, tspProfileActions.enableTspProfile({ uuid: 'profile-1' }), {}, 1);
 
-        expect(emitted[0]).toEqual(tspProfileActions.enableTspProfileSuccess({ uuid: 'p-1' }));
+        expect(emitted[0]).toEqual(tspProfileActions.enableTspProfileSuccess({ uuid: 'profile-1' }));
     });
 
     test('enableTspProfile failure emits enableFailure and fetchError', async () => {
         const err = new Error('enable failed');
         const emitted = await runEpic(
             TspProfilesEpicIndex.Enable,
-            tspProfileActions.enableTspProfile({ uuid: 'p-1' }),
-            { tspProfiles: { enableTspProfile: () => throwError(() => err) } as any },
+            tspProfileActions.enableTspProfile({ uuid: 'profile-1' }),
+            {
+                tspProfiles: {
+                    enableTspProfile: () => throwError(() => err),
+                } as any,
+            },
             2,
         );
 
@@ -251,17 +291,21 @@ describe('tspProfiles epics', () => {
     });
 
     test('disableTspProfile success emits disableSuccess', async () => {
-        const emitted = await runEpic(TspProfilesEpicIndex.Disable, tspProfileActions.disableTspProfile({ uuid: 'p-1' }), {}, 1);
+        const emitted = await runEpic(TspProfilesEpicIndex.Disable, tspProfileActions.disableTspProfile({ uuid: 'profile-1' }), {}, 1);
 
-        expect(emitted[0]).toEqual(tspProfileActions.disableTspProfileSuccess({ uuid: 'p-1' }));
+        expect(emitted[0]).toEqual(tspProfileActions.disableTspProfileSuccess({ uuid: 'profile-1' }));
     });
 
     test('disableTspProfile failure emits disableFailure and fetchError', async () => {
         const err = new Error('disable failed');
         const emitted = await runEpic(
             TspProfilesEpicIndex.Disable,
-            tspProfileActions.disableTspProfile({ uuid: 'p-1' }),
-            { tspProfiles: { disableTspProfile: () => throwError(() => err) } as any },
+            tspProfileActions.disableTspProfile({ uuid: 'profile-1' }),
+            {
+                tspProfiles: {
+                    disableTspProfile: () => throwError(() => err),
+                } as any,
+            },
             2,
         );
 
@@ -269,15 +313,15 @@ describe('tspProfiles epics', () => {
         expect(emitted[1]).toEqual(appRedirectActions.fetchError({ error: err, message: 'Failed to disable TSP Profile' }));
     });
 
-    test('bulkDeleteTspProfiles success (no errors) emits bulkDeleteSuccess and alert', async () => {
+    test('bulkDeleteTspProfiles success emits bulkDeleteSuccess and alert', async () => {
         const emitted = await runEpic(
             TspProfilesEpicIndex.BulkDelete,
-            tspProfileActions.bulkDeleteTspProfiles({ uuids: ['p-1', 'p-2'] }),
+            tspProfileActions.bulkDeleteTspProfiles({ uuids: ['profile-1', 'c-2'] }),
             {},
             2,
         );
 
-        expect(emitted[0]).toEqual(tspProfileActions.bulkDeleteTspProfilesSuccess({ uuids: ['p-1', 'p-2'], errors: [] }));
+        expect(emitted[0]).toEqual(tspProfileActions.bulkDeleteTspProfilesSuccess({ uuids: ['profile-1', 'c-2'], errors: [] }));
         expect(emitted[1]).toEqual(alertActions.success('Selected TSP Profiles successfully deleted.'));
     });
 
@@ -285,8 +329,12 @@ describe('tspProfiles epics', () => {
         const err = new Error('bulk delete failed');
         const emitted = await runEpic(
             TspProfilesEpicIndex.BulkDelete,
-            tspProfileActions.bulkDeleteTspProfiles({ uuids: ['p-1'] }),
-            { tspProfiles: { bulkDeleteTspProfiles: () => throwError(() => err) } as any },
+            tspProfileActions.bulkDeleteTspProfiles({ uuids: ['profile-1'] }),
+            {
+                tspProfiles: {
+                    bulkDeleteTspProfiles: () => throwError(() => err),
+                } as any,
+            },
             2,
         );
 
@@ -295,17 +343,26 @@ describe('tspProfiles epics', () => {
     });
 
     test('bulkEnableTspProfiles success emits bulkEnableSuccess', async () => {
-        const emitted = await runEpic(TspProfilesEpicIndex.BulkEnable, tspProfileActions.bulkEnableTspProfiles({ uuids: ['p-1'] }), {}, 1);
+        const emitted = await runEpic(
+            TspProfilesEpicIndex.BulkEnable,
+            tspProfileActions.bulkEnableTspProfiles({ uuids: ['profile-1', 'c-2'] }),
+            {},
+            1,
+        );
 
-        expect(emitted[0]).toEqual(tspProfileActions.bulkEnableTspProfilesSuccess({ uuids: ['p-1'] }));
+        expect(emitted[0]).toEqual(tspProfileActions.bulkEnableTspProfilesSuccess({ uuids: ['profile-1', 'c-2'] }));
     });
 
     test('bulkEnableTspProfiles failure emits bulkEnableFailure and fetchError', async () => {
         const err = new Error('bulk enable failed');
         const emitted = await runEpic(
             TspProfilesEpicIndex.BulkEnable,
-            tspProfileActions.bulkEnableTspProfiles({ uuids: ['p-1'] }),
-            { tspProfiles: { bulkEnableTspProfiles: () => throwError(() => err) } as any },
+            tspProfileActions.bulkEnableTspProfiles({ uuids: ['profile-1'] }),
+            {
+                tspProfiles: {
+                    bulkEnableTspProfiles: () => throwError(() => err),
+                } as any,
+            },
             2,
         );
 
@@ -316,20 +373,24 @@ describe('tspProfiles epics', () => {
     test('bulkDisableTspProfiles success emits bulkDisableSuccess', async () => {
         const emitted = await runEpic(
             TspProfilesEpicIndex.BulkDisable,
-            tspProfileActions.bulkDisableTspProfiles({ uuids: ['p-1'] }),
+            tspProfileActions.bulkDisableTspProfiles({ uuids: ['profile-1', 'c-2'] }),
             {},
             1,
         );
 
-        expect(emitted[0]).toEqual(tspProfileActions.bulkDisableTspProfilesSuccess({ uuids: ['p-1'] }));
+        expect(emitted[0]).toEqual(tspProfileActions.bulkDisableTspProfilesSuccess({ uuids: ['profile-1', 'c-2'] }));
     });
 
     test('bulkDisableTspProfiles failure emits bulkDisableFailure and fetchError', async () => {
         const err = new Error('bulk disable failed');
         const emitted = await runEpic(
             TspProfilesEpicIndex.BulkDisable,
-            tspProfileActions.bulkDisableTspProfiles({ uuids: ['p-1'] }),
-            { tspProfiles: { bulkDisableTspProfiles: () => throwError(() => err) } as any },
+            tspProfileActions.bulkDisableTspProfiles({ uuids: ['profile-1'] }),
+            {
+                tspProfiles: {
+                    bulkDisableTspProfiles: () => throwError(() => err),
+                } as any,
+            },
             2,
         );
 

--- a/src/ducks/tsp-profiles.spec.ts
+++ b/src/ducks/tsp-profiles.spec.ts
@@ -7,16 +7,11 @@ describe('tspProfiles slice', () => {
         expect(reducer(undefined, { type: 'unknown' })).toEqual(initialState);
     });
 
-    test('setCheckedRows updates checkedRows', () => {
-        const next = reducer(initialState, actions.setCheckedRows({ checkedRows: ['p-1', 'p-2'] }));
-        expect(next.checkedRows).toEqual(['p-1', 'p-2']);
-    });
-
     test('resetState restores initial values', () => {
         const dirty = {
             ...initialState,
-            tspProfile: { uuid: 'p-1' } as any,
-            tspProfiles: [{ uuid: 'p-1' } as any],
+            tspProfile: { uuid: 'profile-1' } as any,
+            tspProfiles: [{ uuid: 'profile-1' } as any],
             isFetchingList: true,
             tempKey: 'gone',
         } as any;
@@ -25,6 +20,11 @@ describe('tspProfiles slice', () => {
 
         expect(next).toEqual(initialState);
         expect((next as any).tempKey).toBeUndefined();
+    });
+
+    test('setCheckedRows updates checkedRows', () => {
+        const next = reducer(initialState, actions.setCheckedRows({ checkedRows: ['profile-1', 'profile-2'] }));
+        expect(next.checkedRows).toEqual(['profile-1', 'profile-2']);
     });
 
     test('clearDeleteErrorMessages clears error fields', () => {
@@ -42,7 +42,7 @@ describe('tspProfiles slice', () => {
     });
 
     test('listTspProfilesSuccess updates list', () => {
-        const profiles = [{ uuid: 'p-1', enabled: true }] as any[];
+        const profiles = [{ uuid: 'profile-1' }] as any[];
         const next = reducer({ ...initialState, isFetchingList: true }, actions.listTspProfilesSuccess({ tspProfiles: profiles }));
         expect(next.isFetchingList).toBe(false);
         expect(next.tspProfiles).toEqual(profiles);
@@ -54,13 +54,13 @@ describe('tspProfiles slice', () => {
     });
 
     test('getTspProfile sets isFetchingDetail', () => {
-        const next = reducer(initialState, actions.getTspProfile({ uuid: 'p-1' }));
+        const next = reducer(initialState, actions.getTspProfile({ uuid: 'profile-1' }));
         expect(next.isFetchingDetail).toBe(true);
     });
 
     test('getTspProfileSuccess sets detail and updates list entry', () => {
-        const existing = { uuid: 'p-1', name: 'Old', enabled: true } as any;
-        const updated = { uuid: 'p-1', name: 'New', enabled: true } as any;
+        const existing = { uuid: 'profile-1', name: 'Old' } as any;
+        const updated = { uuid: 'profile-1', name: 'New' } as any;
         const state = { ...initialState, isFetchingDetail: true, tspProfiles: [existing] };
         const next = reducer(state, actions.getTspProfileSuccess({ tspProfile: updated }));
         expect(next.isFetchingDetail).toBe(false);
@@ -104,7 +104,7 @@ describe('tspProfiles slice', () => {
     test('createTspProfileSuccess clears isCreating', () => {
         const next = reducer(
             { ...initialState, isCreating: true },
-            actions.createTspProfileSuccess({ tspProfile: { uuid: 'p-1' } as any }),
+            actions.createTspProfileSuccess({ tspProfile: { uuid: 'profile-1' } as any }),
         );
         expect(next.isCreating).toBe(false);
     });
@@ -115,13 +115,13 @@ describe('tspProfiles slice', () => {
     });
 
     test('updateTspProfile sets isUpdating', () => {
-        const next = reducer(initialState, actions.updateTspProfile({ uuid: 'p-1', tspProfileRequestDto: {} as any }));
+        const next = reducer(initialState, actions.updateTspProfile({ uuid: 'profile-1', tspProfileRequestDto: {} as any }));
         expect(next.isUpdating).toBe(true);
     });
 
     test('updateTspProfileSuccess updates detail and list', () => {
-        const existing = { uuid: 'p-1', name: 'Old', enabled: true } as any;
-        const updated = { uuid: 'p-1', name: 'Updated', enabled: true } as any;
+        const existing = { uuid: 'profile-1', name: 'Old' } as any;
+        const updated = { uuid: 'profile-1', name: 'Updated' } as any;
         const state = { ...initialState, isUpdating: true, tspProfile: existing, tspProfiles: [existing] };
         const next = reducer(state, actions.updateTspProfileSuccess({ tspProfile: updated }));
         expect(next.isUpdating).toBe(false);
@@ -135,15 +135,15 @@ describe('tspProfiles slice', () => {
     });
 
     test('deleteTspProfile sets isDeleting and clears deleteErrorMessage', () => {
-        const next = reducer({ ...initialState, deleteErrorMessage: 'old error' }, actions.deleteTspProfile({ uuid: 'p-1' }));
+        const next = reducer({ ...initialState, deleteErrorMessage: 'old error' }, actions.deleteTspProfile({ uuid: 'profile-1' }));
         expect(next.isDeleting).toBe(true);
         expect(next.deleteErrorMessage).toBe('');
     });
 
     test('deleteTspProfileSuccess removes from list and clears detail', () => {
-        const profile = { uuid: 'p-1', enabled: true } as any;
+        const profile = { uuid: 'profile-1' } as any;
         const state = { ...initialState, isDeleting: true, tspProfile: profile, tspProfiles: [profile] };
-        const next = reducer(state, actions.deleteTspProfileSuccess({ uuid: 'p-1' }));
+        const next = reducer(state, actions.deleteTspProfileSuccess({ uuid: 'profile-1' }));
         expect(next.isDeleting).toBe(false);
         expect(next.tspProfiles).toHaveLength(0);
         expect(next.tspProfile).toBeUndefined();
@@ -156,14 +156,19 @@ describe('tspProfiles slice', () => {
     });
 
     test('enableTspProfile sets isEnabling', () => {
-        const next = reducer(initialState, actions.enableTspProfile({ uuid: 'p-1' }));
+        const next = reducer(initialState, actions.enableTspProfile({ uuid: 'profile-1' }));
         expect(next.isEnabling).toBe(true);
     });
 
-    test('enableTspProfileSuccess enables list entry and detail', () => {
-        const profile = { uuid: 'p-1', enabled: false } as any;
-        const state = { ...initialState, isEnabling: true, tspProfile: profile, tspProfiles: [profile] };
-        const next = reducer(state, actions.enableTspProfileSuccess({ uuid: 'p-1' }));
+    test('enableTspProfileSuccess sets enabled=true in list and detail', () => {
+        const profile = { uuid: 'profile-1', enabled: false } as any;
+        const state = {
+            ...initialState,
+            isEnabling: true,
+            tspProfile: profile,
+            tspProfiles: [{ ...profile }],
+        };
+        const next = reducer(state, actions.enableTspProfileSuccess({ uuid: 'profile-1' }));
         expect(next.isEnabling).toBe(false);
         expect(next.tspProfiles[0].enabled).toBe(true);
         expect(next.tspProfile?.enabled).toBe(true);
@@ -175,14 +180,19 @@ describe('tspProfiles slice', () => {
     });
 
     test('disableTspProfile sets isDisabling', () => {
-        const next = reducer(initialState, actions.disableTspProfile({ uuid: 'p-1' }));
+        const next = reducer(initialState, actions.disableTspProfile({ uuid: 'profile-1' }));
         expect(next.isDisabling).toBe(true);
     });
 
-    test('disableTspProfileSuccess disables list entry and detail', () => {
-        const profile = { uuid: 'p-1', enabled: true } as any;
-        const state = { ...initialState, isDisabling: true, tspProfile: profile, tspProfiles: [profile] };
-        const next = reducer(state, actions.disableTspProfileSuccess({ uuid: 'p-1' }));
+    test('disableTspProfileSuccess sets enabled=false in list and detail', () => {
+        const profile = { uuid: 'profile-1', enabled: true } as any;
+        const state = {
+            ...initialState,
+            isDisabling: true,
+            tspProfile: profile,
+            tspProfiles: [{ ...profile }],
+        };
+        const next = reducer(state, actions.disableTspProfileSuccess({ uuid: 'profile-1' }));
         expect(next.isDisabling).toBe(false);
         expect(next.tspProfiles[0].enabled).toBe(false);
         expect(next.tspProfile?.enabled).toBe(false);
@@ -196,29 +206,26 @@ describe('tspProfiles slice', () => {
     test('bulkDeleteTspProfiles sets isBulkDeleting and clears errors', () => {
         const next = reducer(
             { ...initialState, bulkDeleteErrorMessages: [{ message: 'err' } as any] },
-            actions.bulkDeleteTspProfiles({ uuids: ['p-1'] }),
+            actions.bulkDeleteTspProfiles({ uuids: ['profile-1'] }),
         );
         expect(next.isBulkDeleting).toBe(true);
         expect(next.bulkDeleteErrorMessages).toEqual([]);
     });
 
     test('bulkDeleteTspProfilesSuccess removes items from list', () => {
-        const profiles = [
-            { uuid: 'p-1', enabled: true },
-            { uuid: 'p-2', enabled: true },
-        ] as any[];
+        const profiles = [{ uuid: 'profile-1' }, { uuid: 'profile-2' }] as any[];
         const state = { ...initialState, isBulkDeleting: true, tspProfiles: profiles };
-        const next = reducer(state, actions.bulkDeleteTspProfilesSuccess({ uuids: ['p-1'], errors: [] }));
+        const next = reducer(state, actions.bulkDeleteTspProfilesSuccess({ uuids: ['profile-1'], errors: [] }));
         expect(next.isBulkDeleting).toBe(false);
         expect(next.tspProfiles).toHaveLength(1);
-        expect(next.tspProfiles[0].uuid).toBe('p-2');
+        expect(next.tspProfiles[0].uuid).toBe('profile-2');
     });
 
     test('bulkDeleteTspProfilesSuccess with errors sets bulkDeleteErrorMessages', () => {
-        const errors = [{ message: 'err', uuid: 'p-1', name: 'TSP Profile 1' }] as any[];
-        const profiles = [{ uuid: 'p-1', enabled: true }] as any[];
+        const errors = [{ message: 'err', uuid: 'profile-1', name: 'TSP Profile 1' }] as any[];
+        const profiles = [{ uuid: 'profile-1' }] as any[];
         const state = { ...initialState, isBulkDeleting: true, tspProfiles: profiles };
-        const next = reducer(state, actions.bulkDeleteTspProfilesSuccess({ uuids: ['p-1'], errors }));
+        const next = reducer(state, actions.bulkDeleteTspProfilesSuccess({ uuids: ['profile-1'], errors }));
         expect(next.isBulkDeleting).toBe(false);
         expect(next.bulkDeleteErrorMessages).toEqual(errors);
         expect(next.tspProfiles).toHaveLength(1);
@@ -230,17 +237,20 @@ describe('tspProfiles slice', () => {
     });
 
     test('bulkEnableTspProfiles sets isBulkEnabling', () => {
-        const next = reducer(initialState, actions.bulkEnableTspProfiles({ uuids: ['p-1'] }));
+        const next = reducer(initialState, actions.bulkEnableTspProfiles({ uuids: ['profile-1'] }));
         expect(next.isBulkEnabling).toBe(true);
     });
 
-    test('bulkEnableTspProfilesSuccess enables list entries', () => {
-        const profiles = [{ uuid: 'p-1', enabled: false }] as any[];
-        const state = { ...initialState, isBulkEnabling: true, tspProfiles: profiles, tspProfile: profiles[0] };
-        const next = reducer(state, actions.bulkEnableTspProfilesSuccess({ uuids: ['p-1'] }));
+    test('bulkEnableTspProfilesSuccess sets enabled=true for matching uuids', () => {
+        const profiles = [
+            { uuid: 'profile-1', enabled: false },
+            { uuid: 'profile-2', enabled: false },
+        ] as any[];
+        const state = { ...initialState, isBulkEnabling: true, tspProfiles: profiles };
+        const next = reducer(state, actions.bulkEnableTspProfilesSuccess({ uuids: ['profile-1'] }));
         expect(next.isBulkEnabling).toBe(false);
         expect(next.tspProfiles[0].enabled).toBe(true);
-        expect(next.tspProfile?.enabled).toBe(true);
+        expect(next.tspProfiles[1].enabled).toBe(false);
     });
 
     test('bulkEnableTspProfilesFailure clears isBulkEnabling', () => {
@@ -249,17 +259,20 @@ describe('tspProfiles slice', () => {
     });
 
     test('bulkDisableTspProfiles sets isBulkDisabling', () => {
-        const next = reducer(initialState, actions.bulkDisableTspProfiles({ uuids: ['p-1'] }));
+        const next = reducer(initialState, actions.bulkDisableTspProfiles({ uuids: ['profile-1'] }));
         expect(next.isBulkDisabling).toBe(true);
     });
 
-    test('bulkDisableTspProfilesSuccess disables list entries', () => {
-        const profiles = [{ uuid: 'p-1', enabled: true }] as any[];
-        const state = { ...initialState, isBulkDisabling: true, tspProfiles: profiles, tspProfile: profiles[0] };
-        const next = reducer(state, actions.bulkDisableTspProfilesSuccess({ uuids: ['p-1'] }));
+    test('bulkDisableTspProfilesSuccess sets enabled=false for matching uuids', () => {
+        const profiles = [
+            { uuid: 'profile-1', enabled: true },
+            { uuid: 'profile-2', enabled: true },
+        ] as any[];
+        const state = { ...initialState, isBulkDisabling: true, tspProfiles: profiles };
+        const next = reducer(state, actions.bulkDisableTspProfilesSuccess({ uuids: ['profile-1'] }));
         expect(next.isBulkDisabling).toBe(false);
         expect(next.tspProfiles[0].enabled).toBe(false);
-        expect(next.tspProfile?.enabled).toBe(false);
+        expect(next.tspProfiles[1].enabled).toBe(true);
     });
 
     test('bulkDisableTspProfilesFailure clears isBulkDisabling', () => {
@@ -270,7 +283,7 @@ describe('tspProfiles slice', () => {
 
 describe('tspProfiles selectors', () => {
     test('selectors read all values from state', () => {
-        const profile = { uuid: 'p-1', enabled: true } as any;
+        const profile = { uuid: 'profile-1' } as any;
         const profiles = [profile];
         const fields = [{ searchGroupEnum: 'g-1' }] as any[];
         const bulkErrors = [{ message: 'err' }] as any[];
@@ -280,7 +293,7 @@ describe('tspProfiles selectors', () => {
             tspProfile: profile,
             tspProfiles: profiles,
             searchableFields: fields,
-            checkedRows: ['p-1'],
+            checkedRows: ['profile-1'],
             deleteErrorMessage: 'del err',
             bulkDeleteErrorMessages: bulkErrors,
             isFetchingList: true,
@@ -298,20 +311,20 @@ describe('tspProfiles selectors', () => {
 
         const state = { tspProfiles: featureState } as any;
 
-        expect(selectors.searchableFields(state)).toEqual(fields);
         expect(selectors.tspProfile(state)).toEqual(profile);
         expect(selectors.tspProfiles(state)).toEqual(profiles);
+        expect(selectors.searchableFields(state)).toEqual(fields);
+        expect(selectors.checkedRows(state)).toEqual(['profile-1']);
         expect(selectors.deleteErrorMessage(state)).toBe('del err');
-        expect(selectors.checkedRows(state)).toEqual(['p-1']);
+        expect(selectors.bulkDeleteErrorMessages(state)).toEqual(bulkErrors);
         expect(selectors.isFetchingList(state)).toBe(true);
         expect(selectors.isFetchingDetail(state)).toBe(true);
         expect(selectors.isFetchingSearchableFields(state)).toBe(true);
         expect(selectors.isCreating(state)).toBe(true);
-        expect(selectors.isUpdating(state)).toBe(true);
         expect(selectors.isDeleting(state)).toBe(true);
+        expect(selectors.isUpdating(state)).toBe(true);
         expect(selectors.isEnabling(state)).toBe(true);
         expect(selectors.isDisabling(state)).toBe(true);
-        expect(selectors.bulkDeleteErrorMessages(state)).toEqual(bulkErrors);
         expect(selectors.isBulkDeleting(state)).toBe(true);
         expect(selectors.isBulkEnabling(state)).toBe(true);
         expect(selectors.isBulkDisabling(state)).toBe(true);

--- a/src/types/user-interface.tsx
+++ b/src/types/user-interface.tsx
@@ -111,10 +111,12 @@ export enum LockWidgetNameEnum {
     VaultProfileDetails,
     ListOfTrustedCertificates,
     TrustedCertificateDetails,
-    ListOfTimeQualityConfigurations,
-    TimeQualityConfigurationDetails,
     ListOfTspProfiles,
     TspProfileDetails,
+    ListOfTimeQualityConfigurations,
+    TimeQualityConfigurationDetails,
+    ListOfSigningProfiles,
+    SigningProfileDetails,
 }
 
 export interface WidgetLockModel {

--- a/src/utils/type-guards.spec.ts
+++ b/src/utils/type-guards.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+import { isTimestampingWorkflow, isContentSigningWorkflow, isRawSigningWorkflow, isStaticKeyManagedSigning } from './type-guards';
+import { ManagedSigningType, SigningScheme, SigningWorkflowType } from '../types/openapi';
+
+describe('type-guards', () => {
+    describe('Workflow Type Guards', () => {
+        test('isTimestampingWorkflow should return true for Timestamping type', () => {
+            const wf: any = { type: SigningWorkflowType.Timestamping };
+            expect(isTimestampingWorkflow(wf)).toBe(true);
+        });
+
+        test('isTimestampingWorkflow should return false for other types', () => {
+            const wf: any = { type: SigningWorkflowType.ContentSigning };
+            expect(isTimestampingWorkflow(wf)).toBe(false);
+        });
+
+        test('isContentSigningWorkflow should return true for ContentSigning type', () => {
+            const wf: any = { type: SigningWorkflowType.ContentSigning };
+            expect(isContentSigningWorkflow(wf)).toBe(true);
+        });
+
+        test('isContentSigningWorkflow should return false for other types', () => {
+            const wf: any = { type: SigningWorkflowType.Timestamping };
+            expect(isContentSigningWorkflow(wf)).toBe(false);
+        });
+
+        test('isRawSigningWorkflow should return true for RawSigning type', () => {
+            const wf: any = { type: SigningWorkflowType.RawSigning };
+            expect(isRawSigningWorkflow(wf)).toBe(true);
+        });
+
+        test('isRawSigningWorkflow should return false for other types', () => {
+            const wf: any = { type: SigningWorkflowType.Timestamping };
+            expect(isRawSigningWorkflow(wf)).toBe(false);
+        });
+    });
+
+    describe('Signing Scheme Type Guards', () => {
+        test('isStaticKeyManagedSigning should return true for Managed StaticKey', () => {
+            const sc: any = {
+                signingScheme: SigningScheme.Managed,
+                managedSigningType: ManagedSigningType.StaticKey,
+            };
+            expect(isStaticKeyManagedSigning(sc)).toBe(true);
+        });
+
+        test('isStaticKeyManagedSigning should return false for other schemes', () => {
+            const sc: any = {
+                signingScheme: SigningScheme.Delegated,
+                managedSigningType: ManagedSigningType.StaticKey,
+            };
+            expect(isStaticKeyManagedSigning(sc)).toBe(false);
+        });
+
+        test('isStaticKeyManagedSigning should return false for other managed types', () => {
+            const sc: any = {
+                signingScheme: SigningScheme.Managed,
+                managedSigningType: 'Other' as any,
+            };
+            expect(isStaticKeyManagedSigning(sc)).toBe(false);
+        });
+    });
+});

--- a/src/utils/validators.spec.ts
+++ b/src/utils/validators.spec.ts
@@ -620,4 +620,43 @@ describe('validators', () => {
             );
         });
     });
+
+    describe('validateIso8601Duration', () => {
+        test('should accept valid ISO 8601 durations', () => {
+            expect(validateIso8601Duration()('PT1H')).toBeUndefined();
+            expect(validateIso8601Duration()('P1DT12H')).toBeUndefined();
+            expect(validateIso8601Duration()('PT10M30S')).toBeUndefined();
+        });
+
+        test('should accept empty value', () => {
+            expect(validateIso8601Duration()('')).toBeUndefined();
+            expect(validateIso8601Duration()(undefined)).toBeUndefined();
+        });
+
+        test('should reject invalid ISO 8601 durations', () => {
+            expect(validateIso8601Duration()('1H')).toBe('Value must be a valid ISO 8601 duration (e.g., PT1H)');
+            expect(validateIso8601Duration()('abc')).toBe('Value must be a valid ISO 8601 duration (e.g., PT1H)');
+        });
+    });
+
+    describe('validateNtpServers', () => {
+        test('should accept valid NTP servers list', () => {
+            expect(validateNtpServers()('pool.ntp.org')).toBeUndefined();
+            expect(validateNtpServers()('pool.ntp.org, 127.0.0.1, time.google.com')).toBeUndefined();
+        });
+
+        test('should accept empty value', () => {
+            expect(validateNtpServers()('')).toBeUndefined();
+            expect(validateNtpServers()(undefined)).toBeUndefined();
+        });
+
+        test('should reject invalid NTP servers', () => {
+            expect(validateNtpServers()('invalid@host')).toBe(
+                'Value must be a comma-separated list of valid NTP server addresses (IP or hostname)',
+            );
+            expect(validateNtpServers()('pool.ntp.org, invalid space')).toBe(
+                'Value must be a comma-separated list of valid NTP server addresses (IP or hostname)',
+            );
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Ports the self-contained, dependency-complete subset of `feat/signing` that applies cleanly to `main`. Most of the signing feature is already in `main`; this fills the remaining gaps. The branch-specific version bump (`2.18.0-signing`) and the `feat/signing` docker workflow are intentionally **excluded**.

### Changes
- **Widget-lock enum fix (latent bug):** adds the missing `LockWidgetNameEnum` members `ListOfSigningProfiles` and `SigningProfileDetails`. `main`'s existing signing-profiles pages (`SigningProfileDetail.tsx`, `SigningProfilesList.tsx`, `signing-profiles-epics.ts`) already reference these, so without them the widget locks resolve to `undefined` at runtime. Vite/esbuild does not type-check, so the build never caught it.
- **TQC "Used by Signing Profiles" widget:** Time Quality Configuration detail now lists the signing profiles that reference it, backed by a new `listAssociatedSigningProfiles` epic + slice state. The API (`listSigningProfilesForTimeQualityConfiguration`) and type (`SimplifiedSigningProfileDto`) already exist in `main`.
- **TspProfileForm guard:** form reset now guards against an `undefined` tspProfile.
- **Tests:** accompanying unit tests for TQC, TSP, type-guards, and validators.

## Verification (baseline `main` → this branch)

| Gate | `main` | This branch |
|---|---|---|
| `vite build` | ✅ exit 0 | ✅ exit 0 |
| `biome check` | ✅ 0 errors (289 warn) | ✅ 0 errors (289 warn) |
| `vitest` | ✅ 2613 passed | ✅ 2633 passed (+20) |
| `tsc --noEmit` (not a CI gate) | 222 errors | 214 errors (−8 signing-enum) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1813
