### PR TITLE
Add Attributes v2 callback support in attribute editor

### DIFF
--- a/src/components/Attributes/AttributeEditor/AttributeEditor.callbacks.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/AttributeEditor.callbacks.spec.tsx
@@ -1,0 +1,234 @@
+import { test, expect } from '../../../../playwright/ct-test';
+import { AttributeEditorCallbackHarness } from './AttributeEditorCallbackHarness';
+import type { DataAttributeModel, GroupAttributeModel, AttributeDescriptorModel } from 'types/attributes';
+import { AttributeContentType, AttributeType } from 'types/openapi';
+
+const ID = 'cb';
+
+function data(name: string, overrides: Partial<DataAttributeModel> = {}): DataAttributeModel {
+    return {
+        type: AttributeType.Data,
+        name,
+        uuid: `uuid-${name}`,
+        contentType: AttributeContentType.String,
+        properties: { label: name, required: false, readOnly: false, visible: true, list: false, multiSelect: false },
+        ...overrides,
+    } as DataAttributeModel;
+}
+
+/** A Data descriptor whose NG callback depends on the named attributes. */
+function ng(name: string, dependsOn: string[], overrides: Partial<DataAttributeModel> = {}): DataAttributeModel {
+    return data(name, { attributeCallback: { mappings: [], dependsOn } as any, ...overrides });
+}
+
+/** A Data descriptor with a legacy mapping callback. */
+function legacy(name: string, from: string): DataAttributeModel {
+    return data(name, {
+        attributeCallback: { callbackContext: 'core/cb', callbackMethod: 'GET', mappings: [{ from, to: 'p', targets: [] }] } as any,
+    });
+}
+
+test.describe('AttributeEditor NG dependsOn callbacks', () => {
+    test('fires when all named attrs get values, and re-fires on change (AC-1)', async ({ mount, page }) => {
+        const descriptors: AttributeDescriptorModel[] = [data('a'), ng('dep', ['a'])];
+        const c = await mount(
+            <AttributeEditorCallbackHarness
+                id={ID}
+                attributeDescriptors={descriptors}
+                connectorUuid="conn-1"
+                functionGroupCode="authorityProvider"
+                kind="k"
+                actions={[
+                    { label: 'setA1', sets: [{ name: 'a', value: { label: 'A1', value: { data: 'a1' } } }] },
+                    { label: 'setA2', sets: [{ name: 'a', value: { label: 'A2', value: { data: 'a2' } } }] },
+                ]}
+            />,
+        );
+        await c.getByTestId('set-setA1').click();
+        await expect(page.getByTestId('callback')).toHaveCount(1, { timeout: 4000 });
+        await expect(page.getByTestId('callback').first()).toHaveAttribute('data-callback-id', `__attributes__${ID}__.dep`);
+
+        // release the in-flight gate, then change the dependency -> re-fire
+        await c.getByTestId('resolve-all').click();
+        await c.getByTestId('set-setA2').click();
+        await expect(page.getByTestId('callback')).toHaveCount(2, { timeout: 4000 });
+    });
+
+    test('payload carries only dependsOn-named raw content (AC-2)', async ({ mount, page }) => {
+        const descriptors: AttributeDescriptorModel[] = [data('a'), data('other'), ng('dep', ['a'])];
+        const c = await mount(
+            <AttributeEditorCallbackHarness
+                id={ID}
+                attributeDescriptors={descriptors}
+                connectorUuid="conn-1"
+                functionGroupCode="authorityProvider"
+                kind="k"
+                actions={[
+                    {
+                        label: 'fill',
+                        sets: [
+                            { name: 'a', value: { label: 'A', value: { reference: 'r', data: 'a-val' } } },
+                            { name: 'other', value: { label: 'O', value: { data: 'secret-other' } } },
+                        ],
+                    },
+                ]}
+            />,
+        );
+        await c.getByTestId('set-fill').click();
+        await expect(page.getByTestId('callback')).toHaveCount(1, { timeout: 4000 });
+        const payloadText = await page.getByTestId('callback').first().textContent();
+        expect(payloadText).toContain('a-val');
+        expect(payloadText).not.toContain('secret-other');
+        expect(payloadText).not.toContain('pathVariable');
+    });
+
+    test('dependsOn:[] fires once on mount (AC-1 mount path)', async ({ mount, page }) => {
+        const descriptors: AttributeDescriptorModel[] = [ng('dep', [])];
+        await mount(
+            <AttributeEditorCallbackHarness
+                id={ID}
+                attributeDescriptors={descriptors}
+                connectorUuid="conn-1"
+                functionGroupCode="authorityProvider"
+                kind="k"
+            />,
+        );
+        await expect(page.getByTestId('callback')).toHaveCount(1, { timeout: 4000 });
+        // give the debounce a beat to confirm it does not fire a second time
+        await page.waitForTimeout(900);
+        await expect(page.getByTestId('callback')).toHaveCount(1);
+    });
+
+    test('cleared dependency does not fire and resets the dependent (AC-1)', async ({ mount, page }) => {
+        const descriptors: AttributeDescriptorModel[] = [data('a'), ng('dep', ['a'])];
+        const c = await mount(
+            <AttributeEditorCallbackHarness
+                id={ID}
+                attributeDescriptors={descriptors}
+                connectorUuid="conn-1"
+                functionGroupCode="authorityProvider"
+                kind="k"
+                watchField="dep"
+                actions={[
+                    { label: 'setA', sets: [{ name: 'a', value: { label: 'A', value: { data: 'a1' } } }] },
+                    // Give the dependent its own content (as a prior callback result would).
+                    { label: 'setDep', sets: [{ name: 'dep', value: { label: 'D', value: { data: 'dep-value' } } }] },
+                    { label: 'clearA', sets: [{ name: 'a', value: '' }] },
+                ]}
+            />,
+        );
+        await c.getByTestId('set-setA').click();
+        await expect(page.getByTestId('callback')).toHaveCount(1, { timeout: 4000 });
+        await c.getByTestId('resolve-all').click();
+
+        // Populate the dependent's content, then confirm it is held.
+        await c.getByTestId('set-setDep').click();
+        await expect(page.getByTestId('watched')).toHaveAttribute('data-empty', 'false', { timeout: 4000 });
+
+        await c.getByTestId('set-clearA').click();
+        // (a) No new callback fires on a cleared dependency.
+        await page.waitForTimeout(900);
+        await expect(page.getByTestId('callback')).toHaveCount(1);
+        // (b) The dependent's own content is reset locally (load-bearing: fails if the
+        // setValue('<dep>', undefined) reset line is removed from production).
+        await expect(page.getByTestId('watched')).toHaveAttribute('data-empty', 'true');
+    });
+
+    test('cascade: callback A drives B (B dependsOn:[A]) is NOT suppressed by isRunningCb (AC-7)', async ({ mount, page }) => {
+        // a is a plain input; b depends on a (control B). When a callback is in flight on
+        // control "depA" (b's own id), the OLD whole-gate bypass would have dropped B's fire
+        // if any callback were running. With per-callbackId gating, B fires.
+        const descriptors: AttributeDescriptorModel[] = [
+            data('a'),
+            ng('depA', ['a']), // control A's NG callback, keyed __..depA
+            ng('depB', ['a']), // control B's NG callback, keyed __..depB
+        ];
+        const c = await mount(
+            <AttributeEditorCallbackHarness
+                id={ID}
+                attributeDescriptors={descriptors}
+                connectorUuid="conn-1"
+                functionGroupCode="authorityProvider"
+                kind="k"
+                actions={[{ label: 'setA', sets: [{ name: 'a', value: { label: 'A', value: { data: 'a1' } } }] }]}
+            />,
+        );
+        await c.getByTestId('set-setA').click();
+        // Both depA and depB must fire from the single change to 'a' — neither suppresses the other.
+        await expect(page.getByTestId('callback')).toHaveCount(2, { timeout: 4000 });
+        const ids = await page.getByTestId('callback').evaluateAll((nodes) => nodes.map((n) => n.getAttribute('data-callback-id')));
+        expect(ids).toContain(`__attributes__${ID}__.depA`);
+        expect(ids).toContain(`__attributes__${ID}__.depB`);
+    });
+
+    test('both-present tiebreak: descriptor with mappings AND dependsOn dispatches NG only (AC-3 tiebreak)', async ({ mount, page }) => {
+        const both = data('dep', {
+            attributeCallback: {
+                callbackContext: 'core/legacy',
+                callbackMethod: 'GET',
+                mappings: [{ from: 'a', to: 'p', targets: [] }],
+                dependsOn: ['a'],
+            } as any,
+        });
+        const descriptors: AttributeDescriptorModel[] = [data('a'), both];
+        const c = await mount(
+            <AttributeEditorCallbackHarness
+                id={ID}
+                attributeDescriptors={descriptors}
+                connectorUuid="conn-1"
+                functionGroupCode="authorityProvider"
+                kind="k"
+                actions={[{ label: 'setA', sets: [{ name: 'a', value: { label: 'A', value: { data: 'a1' } } }] }]}
+            />,
+        );
+        await c.getByTestId('set-setA').click();
+        // Exactly one dispatch (NG), never two; payload carries attributes, not maps.
+        await expect(page.getByTestId('callback')).toHaveCount(1, { timeout: 4000 });
+        const payloadText = await page.getByTestId('callback').first().textContent();
+        expect(payloadText).toContain('"attributes"');
+        expect(payloadText).not.toContain('pathVariable');
+    });
+
+    test('legacy mapping callback still fires via the old path (AC-3 regression)', async ({ mount, page }) => {
+        const descriptors: AttributeDescriptorModel[] = [data('a'), legacy('dep', 'a')];
+        const c = await mount(
+            <AttributeEditorCallbackHarness
+                id={ID}
+                attributeDescriptors={descriptors}
+                connectorUuid="conn-1"
+                functionGroupCode="authorityProvider"
+                kind="k"
+                actions={[{ label: 'setA', sets: [{ name: 'a', value: { label: 'A', value: { data: 'a1' } } }] }]}
+            />,
+        );
+        await c.getByTestId('set-setA').click();
+        await expect(page.getByTestId('callback')).toHaveCount(1, { timeout: 4000 });
+        const payloadText = await page.getByTestId('callback').first().textContent();
+        // legacy path builds the map-shaped DTO, not the NG attributes array.
+        expect(payloadText).toContain('pathVariable');
+        expect(payloadText).not.toContain('"attributes"');
+    });
+
+    test('runtime-injected GROUP child with already-satisfied dependsOn fires once on injection (AC-7 initial)', async ({
+        mount,
+        page,
+    }) => {
+        // 'a' has a value from mount; the dependent NG descriptor is injected via
+        // groupAttributesCallbackAttributes (a runtime-injected GROUP child).
+        const injected = ng('depGroup', ['a']);
+        const descriptors: AttributeDescriptorModel[] = [data('a')];
+        await mount(
+            <AttributeEditorCallbackHarness
+                id={ID}
+                attributeDescriptors={descriptors}
+                groupAttributesCallbackAttributes={[injected as unknown as GroupAttributeModel]}
+                connectorUuid="conn-1"
+                functionGroupCode="authorityProvider"
+                kind="k"
+                initialValues={{ a: { label: 'A', value: { data: 'a1' } } }}
+            />,
+        );
+        await expect(page.getByTestId('callback')).toHaveCount(1, { timeout: 4000 });
+        await expect(page.getByTestId('callback').first()).toHaveAttribute('data-callback-id', `__attributes__${ID}__.depGroup`);
+    });
+});

--- a/src/components/Attributes/AttributeEditor/AttributeEditorCallbackHarness.tsx
+++ b/src/components/Attributes/AttributeEditor/AttributeEditorCallbackHarness.tsx
@@ -1,0 +1,170 @@
+import { type Middleware, configureStore } from '@reduxjs/toolkit';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import * as ReactHookForm from 'react-hook-form';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { testReducers, testInitialState } from 'ducks/test-reducers';
+import type { AttributeDescriptorModel } from 'types/attributes';
+import AttributeEditor from './index';
+
+/**
+ * Test harness for the NG (dependsOn) callback behaviour of AttributeEditor.
+ *
+ * It builds a real Redux store with a recording middleware that captures every
+ * `connectors/callbackConnector` and `connectors/callbackResource` action and
+ * renders them into the DOM (one node per dispatch, plus a serialised payload),
+ * so Playwright can assert exactly which callbacks fired, in what order, and
+ * with what payload. A small control panel drives form values via setValue to
+ * simulate dependency changes, clears and cascades without going through slow,
+ * flaky real inputs.
+ *
+ * `simulateSuccess` lets a test flip a callback's in-flight flag back off (as the
+ * epic's callbackSuccess would), to exercise the per-callbackId gate releasing.
+ */
+
+type FormSetter = { name: string; value: unknown };
+
+export type AttributeEditorCallbackHarnessProps = {
+    id: string;
+    attributeDescriptors: AttributeDescriptorModel[];
+    groupAttributesCallbackAttributes?: AttributeDescriptorModel[];
+    connectorUuid?: string;
+    functionGroupCode?: string;
+    kind?: string;
+    /** Buttons that, when clicked, apply these form values via setValue. */
+    actions?: { label: string; sets: FormSetter[] }[];
+    /** Initial form values, under `__attributes__<id>__`. */
+    initialValues?: Record<string, unknown>;
+    /** Attribute name whose live form value is rendered into a probe node (for reset assertions). */
+    watchField?: string;
+};
+
+function isCallbackAction(type: string): boolean {
+    return type === 'connectors/callbackConnector' || type === 'connectors/callbackResource';
+}
+
+function HarnessInner({
+    id,
+    attributeDescriptors,
+    groupAttributesCallbackAttributes = [],
+    connectorUuid,
+    functionGroupCode,
+    kind,
+    actions = [],
+    watchField,
+    recorded,
+    onSimulateSuccess,
+    bump,
+}: Readonly<
+    AttributeEditorCallbackHarnessProps & {
+        recorded: { type: string; callbackId: string; payload: any }[];
+        onSimulateSuccess: (callbackId: string) => void;
+        bump: number;
+    }
+>) {
+    const { setValue, control } = ReactHookForm.useFormContext<Record<string, any>>();
+    void bump; // re-render is driven by the store subscription in the parent
+    // Live value of an optional dependent control, surfaced to the DOM for reset assertions.
+    const watchedValue = ReactHookForm.useWatch({ control, name: watchField ? `__attributes__${id}__.${watchField}` : '__noop__' });
+
+    return (
+        <>
+            <div data-testid="controls">
+                {actions.map((a) => (
+                    <button
+                        key={a.label}
+                        type="button"
+                        data-testid={`set-${a.label}`}
+                        onClick={() => {
+                            a.sets.forEach(({ name, value }) => {
+                                setValue(`__attributes__${id}__.${name}`, value, { shouldValidate: true, shouldDirty: true });
+                            });
+                        }}
+                    >
+                        {a.label}
+                    </button>
+                ))}
+                <button
+                    type="button"
+                    data-testid="resolve-all"
+                    onClick={() => {
+                        // Release every in-flight callback id (simulates callbackSuccess from the epic).
+                        recorded.forEach((r) => {
+                            onSimulateSuccess(r.callbackId);
+                        });
+                    }}
+                >
+                    resolve-all
+                </button>
+            </div>
+            <div data-testid="callbacks">
+                {recorded.map((r, i) => (
+                    // append-only record; index is a stable key here
+                    <div key={`${r.callbackId}:${i}`} data-testid="callback" data-callback-id={r.callbackId} data-type={r.type}>
+                        {JSON.stringify(r.payload)}
+                    </div>
+                ))}
+            </div>
+            {watchField !== undefined && (
+                <div data-testid="watched" data-empty={watchedValue === undefined || watchedValue === '' ? 'true' : 'false'}>
+                    {watchedValue === undefined ? '<undefined>' : JSON.stringify(watchedValue)}
+                </div>
+            )}
+            <AttributeEditor
+                id={id}
+                attributeDescriptors={attributeDescriptors}
+                groupAttributesCallbackAttributes={groupAttributesCallbackAttributes}
+                setGroupAttributesCallbackAttributes={() => {}}
+                connectorUuid={connectorUuid}
+                functionGroupCode={functionGroupCode as any}
+                kind={kind}
+            />
+        </>
+    );
+}
+
+export function AttributeEditorCallbackHarness(props: Readonly<AttributeEditorCallbackHarnessProps>) {
+    const { id, initialValues } = props;
+
+    const recordedRef = useRef<{ type: string; callbackId: string; payload: any }[]>([]);
+    const [bump, setBump] = useState(0);
+
+    const store = useMemo(() => {
+        const recorder: Middleware = () => (next) => (action: any) => {
+            if (action?.type && isCallbackAction(action.type)) {
+                const callbackId = action.payload?.callbackId;
+                recordedRef.current.push({ type: action.type, callbackId, payload: action.payload });
+            }
+            return next(action);
+        };
+        return configureStore({
+            reducer: testReducers,
+            preloadedState: testInitialState as any,
+            middleware: (getDefault) => getDefault({ serializableCheck: false }).concat(recorder),
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // Re-render whenever the store changes (every callback dispatch flips an
+    // isRunningCallback flag), so the recorded list reflects late, debounced fires.
+    useEffect(() => store.subscribe(() => setBump((n) => n + 1)), [store]);
+
+    const methods = ReactHookForm.useForm({
+        defaultValues: initialValues ? ({ [`__attributes__${id}__`]: initialValues } as Record<string, any>) : {},
+    });
+
+    const onSimulateSuccess = (callbackId: string) => {
+        // Drive the slice as the epic's callbackSuccess would: clear the in-flight flag.
+        store.dispatch({ type: 'connectors/callbackSuccess', payload: { callbackId, data: [] } });
+    };
+
+    return (
+        <Provider store={store}>
+            <MemoryRouter>
+                <ReactHookForm.FormProvider {...methods}>
+                    <HarnessInner {...props} recorded={recordedRef.current} onSimulateSuccess={onSimulateSuccess} bump={bump} />
+                </ReactHookForm.FormProvider>
+            </MemoryRouter>
+        </Provider>
+    );
+}

--- a/src/components/Attributes/AttributeEditor/collectDependsOnValues.ts
+++ b/src/components/Attributes/AttributeEditor/collectDependsOnValues.ts
@@ -1,0 +1,93 @@
+import { type AttributeDescriptorModel, isDataAttributeModel, isGroupAttributeModel } from 'types/attributes';
+import { AttributeVersion, type BaseAttributeContentDtoV2, type RequestAttribute } from 'types/openapi';
+
+/**
+ * Extracts the raw attribute content array from a stored react-hook-form value.
+ *
+ * The AttributeEditor stores form values in several shapes depending on the
+ * descriptor:
+ *  - list / RESOURCE (single select): the option object `{ label, value }`,
+ *    where `value` is the raw content object (e.g. `{ reference, data }`);
+ *  - list multiSelect: an array of such option objects;
+ *  - scalar (non-list): the primitive value directly (string / number / boolean);
+ *  - File: `{ content, fileName, mimeType }`.
+ *
+ * For the NG (Attributes v2) `dependsOn` callback we forward the *raw content*
+ * with no dot-path resolution and no scalar flattening of objects — exactly the
+ * content the connector expects to receive back. Returns `undefined` when the
+ * value is absent (empty string, null, undefined, empty array).
+ */
+function extractRawContent(formValue: unknown): Array<BaseAttributeContentDtoV2> | undefined {
+    if (formValue === undefined || formValue === null || formValue === '') return undefined;
+
+    // list multiSelect → array of { label, value }
+    if (Array.isArray(formValue)) {
+        if (formValue.length === 0) return undefined;
+        const content = formValue
+            .map((option) => (isOptionObject(option) ? option.value : option))
+            .filter((c): c is BaseAttributeContentDtoV2 => c !== undefined && c !== null);
+        return content.length > 0 ? content : undefined;
+    }
+
+    // single list / RESOURCE select → { label, value }
+    if (isOptionObject(formValue)) {
+        return formValue.value === undefined || formValue.value === null ? undefined : [formValue.value as BaseAttributeContentDtoV2];
+    }
+
+    // scalar (string / number / boolean) → wrap as a content object
+    return [{ data: formValue } as BaseAttributeContentDtoV2];
+}
+
+function isOptionObject(value: unknown): value is { label?: unknown; value: unknown } {
+    return typeof value === 'object' && value !== null && 'value' in value && 'label' in value;
+}
+
+/**
+ * Builds the `RequestAttribute[]` payload for an NG (`dependsOn`) callback.
+ *
+ * For each name in the triggering descriptor's `attributeCallback.dependsOn`,
+ * finds the matching descriptor among all descriptors and reads the *raw current
+ * content* of that attribute from the form values. Sends only the `dependsOn`-named
+ * attributes (never the whole form) as raw content objects — no `from`/`to`
+ * mapping, no dot-path resolution.
+ *
+ * Returns `undefined` (the all-present gate) when ANY named dependency has no
+ * value, so the caller does not fire the callback.
+ */
+export function collectDependsOnValues(
+    callbackDescriptor: AttributeDescriptorModel,
+    allDescriptors: AttributeDescriptorModel[],
+    formValues: Record<string, any>,
+    id: string,
+): RequestAttribute[] | undefined {
+    if (!isDataAttributeModel(callbackDescriptor) && !isGroupAttributeModel(callbackDescriptor)) return undefined;
+
+    const dependsOn = callbackDescriptor.attributeCallback?.dependsOn;
+    if (!dependsOn) return undefined;
+
+    // dependsOn: [] fires with an empty payload (the caller drives the once-on-mount semantics).
+    if (dependsOn.length === 0) return [];
+
+    const formAttributes = (formValues?.[`__attributes__${id}__`] ?? {}) as Record<string, any>;
+    const result: RequestAttribute[] = [];
+
+    for (const name of dependsOn) {
+        const descriptor = allDescriptors.find((d) => d.name === name);
+        // A named dependency without a resolvable Data descriptor cannot be serialised — treat as missing.
+        if (!descriptor || !isDataAttributeModel(descriptor)) return undefined;
+
+        const content = extractRawContent(formAttributes[name]);
+        // All-present gate: any missing dependency suppresses the callback.
+        if (content === undefined) return undefined;
+
+        result.push({
+            uuid: descriptor.uuid,
+            name: descriptor.name,
+            contentType: descriptor.contentType,
+            version: AttributeVersion.V2,
+            content,
+        });
+    }
+
+    return result;
+}

--- a/src/components/Attributes/AttributeEditor/collectDependsOnValues.unit.spec.ts
+++ b/src/components/Attributes/AttributeEditor/collectDependsOnValues.unit.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'vitest';
+import { collectDependsOnValues } from './collectDependsOnValues';
+import { AttributeContentType, AttributeType, AttributeVersion } from 'types/openapi';
+import type { AttributeDescriptorModel, DataAttributeModel } from 'types/attributes';
+
+const EDITOR_ID = 'ed1';
+
+function dataDescriptor(overrides: Partial<DataAttributeModel> = {}): DataAttributeModel {
+    return {
+        type: AttributeType.Data,
+        name: 'field',
+        uuid: 'uuid-field',
+        contentType: AttributeContentType.String,
+        properties: { label: 'Field', required: false, readOnly: false, visible: true, list: false, multiSelect: false },
+        ...overrides,
+    } as DataAttributeModel;
+}
+
+/** A descriptor whose NG callback depends on the named attributes. */
+function ngDescriptor(dependsOn: string[], overrides: Partial<DataAttributeModel> = {}): DataAttributeModel {
+    return dataDescriptor({
+        name: 'dependent',
+        uuid: 'uuid-dependent',
+        attributeCallback: { mappings: [], dependsOn } as any,
+        ...overrides,
+    });
+}
+
+function formValues(inner: Record<string, unknown>): Record<string, any> {
+    return { [`__attributes__${EDITOR_ID}__`]: inner };
+}
+
+describe('collectDependsOnValues', () => {
+    test('builds a RequestAttribute per dependsOn name when all values present (raw content, version stamped)', () => {
+        const depA = dataDescriptor({ name: 'a', uuid: 'uuid-a', contentType: AttributeContentType.String });
+        const depB = dataDescriptor({ name: 'b', uuid: 'uuid-b', contentType: AttributeContentType.Integer });
+        const trigger = ngDescriptor(['a', 'b']);
+        const descriptors: AttributeDescriptorModel[] = [depA, depB, trigger];
+
+        const result = collectDependsOnValues(
+            trigger,
+            descriptors,
+            formValues({
+                // single-select list shape: { label, value: rawContent }
+                a: { label: 'Alpha', value: { reference: 'alpha-ref', data: 'alpha' } },
+                // scalar shape: primitive
+                b: 7,
+            }),
+            EDITOR_ID,
+        );
+
+        expect(result).toEqual([
+            {
+                uuid: 'uuid-a',
+                name: 'a',
+                contentType: AttributeContentType.String,
+                version: AttributeVersion.V2,
+                content: [{ reference: 'alpha-ref', data: 'alpha' }],
+            },
+            {
+                uuid: 'uuid-b',
+                name: 'b',
+                contentType: AttributeContentType.Integer,
+                version: AttributeVersion.V2,
+                content: [{ data: 7 }],
+            },
+        ]);
+    });
+
+    test('preserves raw content without flattening to a scalar (AC-2, distinguishes from getCurrentFromMappingValue)', () => {
+        const depA = dataDescriptor({ name: 'a', uuid: 'uuid-a' });
+        const trigger = ngDescriptor(['a']);
+        const result = collectDependsOnValues(
+            trigger,
+            [depA, trigger],
+            formValues({ a: { label: 'X', value: { reference: 'r', data: { nested: 'object', id: 'keep-me' } } } }),
+            EDITOR_ID,
+        );
+        // The whole content object is preserved — NOT reduced to value.uuid / value.data.
+        expect(result?.[0].content).toEqual([{ reference: 'r', data: { nested: 'object', id: 'keep-me' } }]);
+    });
+
+    test('returns undefined when any dependsOn value is missing (all-present gate)', () => {
+        const depA = dataDescriptor({ name: 'a', uuid: 'uuid-a' });
+        const depB = dataDescriptor({ name: 'b', uuid: 'uuid-b' });
+        const trigger = ngDescriptor(['a', 'b']);
+        const result = collectDependsOnValues(
+            trigger,
+            [depA, depB, trigger],
+            formValues({ a: { label: 'Alpha', value: { data: 'alpha' } } }), // b absent
+            EDITOR_ID,
+        );
+        expect(result).toBeUndefined();
+    });
+
+    test('treats empty string / null / empty array as missing', () => {
+        const depA = dataDescriptor({ name: 'a', uuid: 'uuid-a' });
+        const trigger = ngDescriptor(['a']);
+        for (const empty of ['', null, []]) {
+            expect(collectDependsOnValues(trigger, [depA, trigger], formValues({ a: empty }), EDITOR_ID)).toBeUndefined();
+        }
+    });
+
+    test('sends ONLY the dependsOn-named attributes, never the whole form (R7 secret-scope)', () => {
+        const depA = dataDescriptor({ name: 'a', uuid: 'uuid-a' });
+        const secret = dataDescriptor({ name: 'secret', uuid: 'uuid-secret', contentType: AttributeContentType.Secret });
+        const trigger = ngDescriptor(['a']);
+        const result = collectDependsOnValues(
+            trigger,
+            [depA, secret, trigger],
+            formValues({
+                a: { label: 'Alpha', value: { data: 'alpha' } },
+                secret: { label: 'hidden', value: { data: 'super-secret' } },
+            }),
+            EDITOR_ID,
+        );
+        expect(result).toHaveLength(1);
+        expect(result?.[0].name).toBe('a');
+        expect(JSON.stringify(result)).not.toContain('super-secret');
+    });
+
+    test('builds no pathVariable / body / requestParameter fields (D4 — only RequestAttribute fields)', () => {
+        const depA = dataDescriptor({ name: 'a', uuid: 'uuid-a' });
+        const trigger = ngDescriptor(['a']);
+        const result = collectDependsOnValues(
+            trigger,
+            [depA, trigger],
+            formValues({ a: { label: 'Alpha', value: { data: 'alpha' } } }),
+            EDITOR_ID,
+        );
+        const keys = Object.keys(result![0]).sort();
+        expect(keys).toEqual(['content', 'contentType', 'name', 'uuid', 'version']);
+    });
+
+    test('dependsOn: [] returns an empty array (fires once on mount with no payload)', () => {
+        const trigger = ngDescriptor([]);
+        expect(collectDependsOnValues(trigger, [trigger], formValues({}), EDITOR_ID)).toEqual([]);
+    });
+
+    test('returns undefined for a descriptor without dependsOn (legacy mappings only)', () => {
+        const legacy = dataDescriptor({ name: 'legacy', attributeCallback: { mappings: [{ from: 'x', to: 'y', targets: [] }] } as any });
+        expect(collectDependsOnValues(legacy, [legacy], formValues({}), EDITOR_ID)).toBeUndefined();
+    });
+
+    test('handles list multiSelect content (array of option objects)', () => {
+        const depA = dataDescriptor({
+            name: 'a',
+            uuid: 'uuid-a',
+            properties: { label: 'A', required: false, list: true, multiSelect: true } as any,
+        });
+        const trigger = ngDescriptor(['a']);
+        const result = collectDependsOnValues(
+            trigger,
+            [depA, trigger],
+            formValues({
+                a: [
+                    { label: 'One', value: { reference: 'r1', data: '1' } },
+                    { label: 'Two', value: { reference: 'r2', data: '2' } },
+                ],
+            }),
+            EDITOR_ID,
+        );
+        expect(result?.[0].content).toEqual([
+            { reference: 'r1', data: '1' },
+            { reference: 'r2', data: '2' },
+        ]);
+    });
+});

--- a/src/components/Attributes/AttributeEditor/index.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/index.spec.tsx
@@ -268,6 +268,29 @@ test.describe('AttributeEditor', () => {
         await expect(input).toHaveValue('defaultValue');
     });
 
+    test('RESOURCE attribute renders Core-sourced options unchanged (AC-5 rendering)', async ({ mount, page }) => {
+        // A RESOURCE attribute renders like a list, sourced from the static `content`
+        // Core pre-populates. This asserts the rendering path is unchanged by #1764.
+        // NOTE: the secret-free `{resource, uuid, name}` *serialisation* half of AC-5
+        // is Core-dependent ("reference-typed values expanded inline by Core" per the
+        // OpenAPI spec) and is intentionally NOT emitted by the FE here.
+        const descriptors: AttributeDescriptorModel[] = [
+            dataDescriptor({
+                name: 'resourceField',
+                uuid: 'resource-uuid',
+                contentType: AttributeContentType.Resource,
+                properties: { label: 'Resource Field', required: false, list: false, multiSelect: false } as any,
+                content: [
+                    { reference: 'Authority One', data: { uuid: 'auth-1', name: 'Authority One' } },
+                    { reference: 'Authority Two', data: { uuid: 'auth-2', name: 'Authority Two' } },
+                ] as any,
+            }),
+        ];
+        await mount(<AttributeEditorTestWrapper id={editorId} attributeDescriptors={descriptors} />);
+        await expect(page.getByText('Resource Field')).toBeVisible({ timeout: 10000 });
+        await expect(page.getByTestId('select-__attributes__testEditor__.resourceFieldSelect')).toBeAttached({ timeout: 5000 });
+    });
+
     test('Boolean required with no value shows false', async ({ mount, page }) => {
         const descriptors: AttributeDescriptorModel[] = [
             dataDescriptor({

--- a/src/components/Attributes/AttributeEditor/index.tsx
+++ b/src/components/Attributes/AttributeEditor/index.tsx
@@ -23,9 +23,10 @@ import {
     isInfoAttributeModel,
 } from 'types/attributes';
 import type { CallbackAttributeModel } from 'types/connectors';
-import { AttributeContentType, AttributeValueTarget, type FunctionGroupCode, type Resource } from 'types/openapi';
+import { AttributeContentType, AttributeValueTarget, type FunctionGroupCode, type RequestAttribute, type Resource } from 'types/openapi';
 import { base64ToUtf8 } from 'utils/common-utils';
 import { Attribute } from './Attribute';
+import { collectDependsOnValues } from './collectDependsOnValues';
 import CustomAttributeAddSelect from 'components/Attributes/AttributeEditor/CustomAttributeAddSelect';
 import { mapAttributeContentToOptionValue } from 'utils/attributes/attributes';
 import { deepEqual } from 'utils/deep-equal';
@@ -349,6 +350,45 @@ function AttributeEditorInner({
     );
     /* c8 ignore stop */
 
+    /**
+     * Dispatches an NG (Attributes v2 / `dependsOn`) callback. Unlike the legacy
+     * mapping path, the request carries ONLY the `dependsOn`-named attributes'
+     * raw content in `attributes` — no `pathVariable`/`requestParameter`/`body`/
+     * `filter` maps (D4). Routes through the same resource/connector dispatch as
+     * the legacy path so stale-discard keying (per `callbackId`) is shared.
+     */
+    const executeNgCallback = useCallback(
+        (descriptor: AttributeDescriptorModel, attributes: RequestAttribute[], formAttributeName: string) => {
+            const requestAttributeCallback: CallbackAttributeModel = {
+                name: descriptor.name,
+                uuid: descriptor.uuid,
+                attributes,
+            };
+
+            dispatch(
+                callbackParentUuid && callbackResource
+                    ? connectorActions.callbackResource({
+                          callbackId: formAttributeName,
+                          callbackResource: {
+                              parentObjectUuid: callbackParentUuid,
+                              resource: callbackResource,
+                              requestAttributeCallback,
+                          },
+                      })
+                    : connectorActions.callbackConnector({
+                          callbackId: formAttributeName,
+                          callbackConnector: {
+                              uuid: connectorUuid!,
+                              kind: kind!,
+                              functionGroup: functionGroupCode!,
+                              requestAttributeCallback,
+                          },
+                      }),
+            );
+        },
+        [callbackParentUuid, callbackResource, connectorUuid, dispatch, functionGroupCode, kind],
+    );
+
     /*
      * Get non-required custom attributes, without a value assigned
      */
@@ -636,21 +676,43 @@ function AttributeEditorInner({
             }
 
             if (isDataAttributeModel(descriptor) || isGroupAttributeModel(descriptor)) {
-                // Perform initial callbacks based on "static" mappings only once per descriptor
+                // Perform initial callbacks only once per descriptor
                 if (descriptor.attributeCallback) {
                     const key = `${connectorUuid ?? 'global'}:${descriptor.uuid}:${formAttributeName}`;
                     if (!initialCallbackRunRef.current.has(key)) {
-                        const mappings = buildCallbackMappings(descriptor);
-                        if (mappings) {
-                            executeCallback(mappings, descriptor, formAttributeName);
-                            initialCallbackRunRef.current.add(key);
+                        if (descriptor.attributeCallback.dependsOn != null) {
+                            // NG (Attributes v2) initial fire: covers the no-change-event cases —
+                            // dependsOn:[] fires once on mount, and a runtime-injected GROUP child
+                            // whose dependencies already have values fires once on injection (AC-7).
+                            const allDescriptors = [...attributeDescriptors, ...groupAttributesCallbackAttributes];
+                            const attributesPayload = collectDependsOnValues(descriptor, allDescriptors, formValues, id);
+                            if (attributesPayload) {
+                                executeNgCallback(descriptor, attributesPayload, formAttributeName);
+                                initialCallbackRunRef.current.add(key);
+                            }
+                        } else {
+                            // Legacy mapping path — unchanged.
+                            const mappings = buildCallbackMappings(descriptor);
+                            if (mappings) {
+                                executeCallback(mappings, descriptor, formAttributeName);
+                                initialCallbackRunRef.current.add(key);
+                            }
                         }
                     }
                 }
             }
             return newOptions;
         },
-        [buildCallbackMappings, executeCallback, connectorUuid],
+        [
+            buildCallbackMappings,
+            executeCallback,
+            executeNgCallback,
+            connectorUuid,
+            attributeDescriptors,
+            groupAttributesCallbackAttributes,
+            formValues,
+            id,
+        ],
     );
     /* c8 ignore stop */
     /**
@@ -805,10 +867,6 @@ function AttributeEditorInner({
 
         previousAttributesRef.current = cloneForCompare(currentAttributes);
 
-        // I am not really sure about this. It is currently preventing other callbacks when the form is open in "edit" mode and data loaded to it
-        // It works, but this state should be managed in a different way
-        if (isRunningCb) return;
-
         const changedAttributes: { [name: string]: { previous: any; current: any } } = {};
 
         // get changed attributes and their current values
@@ -821,9 +879,56 @@ function AttributeEditorInner({
             }
         });
 
+        const allDescriptors = [...attributeDescriptors, ...groupAttributesCallbackAttributes];
+
+        // --- NG (Attributes v2 / dependsOn) path ---------------------------------
+        // Evaluated BEFORE the global isRunningCb gate so cascading dependsOn
+        // callbacks (control A's result feeding control B) are not dropped. Each NG
+        // callback is gated PER its own callbackId (not the OR-reduced isRunningCb),
+        // so an in-flight callback on one control cannot suppress a different
+        // control's cascade; same-control supersession is handled by the epic's
+        // switchMap. The legacy mapping path below keeps the global gate.
+        allDescriptors.forEach((descriptor) => {
+            if (!isDataAttributeModel(descriptor) && !isGroupAttributeModel(descriptor)) return;
+            const dependsOn = descriptor.attributeCallback?.dependsOn;
+            if (dependsOn == null) return;
+
+            const formAttributeName = `__attributes__${id}__.${descriptor.name}`;
+            // Per-callbackId gating: skip only while THIS callback is in flight.
+            if (isRunningCallback[formAttributeName]) return;
+
+            const dependencyChanged = dependsOn.some((name) => changedAttributes[name]);
+            if (!dependencyChanged) return;
+
+            // Cleared-dependency reset (AC-1): if any named dependency went empty,
+            // reset the dependent's own value locally and do not fire.
+            const aDependencyCleared = dependsOn.some((name) => {
+                const change = changedAttributes[name];
+                if (!change) return false;
+                const cur = change.current;
+                return cur === undefined || cur === null || cur === '' || (Array.isArray(cur) && cur.length === 0);
+            });
+            if (aDependencyCleared) {
+                setValue(formAttributeName, undefined, { shouldValidate: true });
+                return;
+            }
+
+            const attributesPayload = collectDependsOnValues(descriptor, allDescriptors, formValues, id);
+            if (attributesPayload) {
+                executeNgCallback(descriptor, attributesPayload, formAttributeName);
+            }
+        });
+
+        // I am not really sure about this. It is currently preventing other callbacks when the form is open in "edit" mode and data loaded to it
+        // It works, but this state should be managed in a different way
+        if (isRunningCb) return;
+
         // for each changed attribute check if there are mappings depending on it and if so perform the callback
-        [...attributeDescriptors, ...groupAttributesCallbackAttributes].forEach((descriptor) => {
+        allDescriptors.forEach((descriptor) => {
             if (isDataAttributeModel(descriptor) || isGroupAttributeModel(descriptor)) {
+                // Tiebreak (Q3): a descriptor carrying dependsOn is an NG callback and
+                // is handled exclusively by the NG path above — never also via mappings.
+                if (descriptor.attributeCallback?.dependsOn != null) return;
                 // list all 'from' mappings (get attribute names from the descriptor)
                 const fromNames: string[] = [];
                 descriptor.attributeCallback?.mappings?.forEach((mapping) => {
@@ -850,7 +955,18 @@ function AttributeEditorInner({
                 }
             }
         });
-    }, [attributeDescriptors, groupAttributesCallbackAttributes, buildCallbackMappings, formValues, id, isRunningCb, executeCallback]);
+    }, [
+        attributeDescriptors,
+        groupAttributesCallbackAttributes,
+        buildCallbackMappings,
+        formValues,
+        id,
+        isRunningCb,
+        isRunningCallback,
+        executeCallback,
+        executeNgCallback,
+        setValue,
+    ]);
 
     const doCallbacksLatestRef = useRef(doCallbacks);
     /* istanbul ignore next */

--- a/src/components/_pages/certificates/form/index.tsx
+++ b/src/components/_pages/certificates/form/index.tsx
@@ -476,8 +476,8 @@ export default function CertificateForm({ onCancel }: CertificateFormProps = {})
                                             <AttributeEditor
                                                 id="issuance_attributes"
                                                 attributeDescriptors={issuanceAttributeDescriptors[selectedRaProfileUuid || ''] || []}
-                                                callbackParentUuid={selectedRaProfile?.authorityInstanceUuid}
-                                                callbackResource={Resource.RaProfiles}
+                                                callbackParentUuid={selectedRaProfile?.uuid}
+                                                callbackResource={Resource.Certificates}
                                                 groupAttributesCallbackAttributes={groupAttributesCallbackAttributes}
                                                 setGroupAttributesCallbackAttributes={setGroupAttributesCallbackAttributes}
                                             />

--- a/src/ducks/connectors-epic.spec.ts
+++ b/src/ducks/connectors-epic.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test, vi } from 'vitest';
-import { firstValueFrom, of, throwError } from 'rxjs';
-import { take, toArray } from 'rxjs/operators';
+import { Subject, firstValueFrom, of, throwError } from 'rxjs';
+import { delay, take, toArray } from 'rxjs/operators';
 
-import connectorsEpics from './connectors-epic';
+import connectorsEpics, { callbackConnectorEpic, callbackResourceEpic } from './connectors-epic';
 import { slice } from './connectors';
 import { actions as userInterfaceActions } from './user-interface';
 import { actions as appRedirectActions } from './app-redirect';
@@ -970,5 +970,113 @@ describe('connectors epics', () => {
         expect(basicCalled).toBe(false);
         expect(certificateCalled).toBe(false);
         expect(emitted[0]).toEqual(slice.actions.getConnectorAuthAttributesDescriptorsSuccess({ attributes: [] }));
+    });
+
+    // --- AC-6: per-callbackId stale-response discard ---------------------------
+
+    test('callbackResource drain-all stale-race: superseded callbackId-A success is ABSENT', async () => {
+        const deps = createDeps({
+            callback: {
+                // First request for cb-A is SLOW; second (newer) request for the SAME cb-A is FAST.
+                // switchMap within the cb-A group must cancel the slow first request, so its success
+                // never emits.
+                resourceCallback: (() => {
+                    let call = 0;
+                    return () => {
+                        call += 1;
+                        return call === 1 ? of({ which: 'A-stale' }).pipe(delay(50)) : of({ which: 'A-fresh' });
+                    };
+                })(),
+            } as any,
+        });
+        const epic = callbackResourceEpic as any;
+        const action$ = new Subject<any>();
+        const state$ = of({}) as any;
+        state$.value = {};
+        const collected = firstValueFrom(epic(action$, state$, deps).pipe(toArray())) as Promise<any[]>;
+
+        const mk = () =>
+            slice.actions.callbackResource({
+                callbackId: 'cb-A',
+                callbackResource: { uuid: 'c-1', requestAttributeCallback: { mappings: [] } } as any,
+            });
+        action$.next(mk()); // slow (stale) request
+        action$.next(mk()); // newer request supersedes it
+        action$.complete();
+
+        const emitted = await collected;
+        const successes = emitted.filter((a: any) => a.type === slice.actions.callbackSuccess.type);
+        // Only the fresh result emits; the stale (superseded) success is absent.
+        expect(successes).toHaveLength(1);
+        expect(successes[0].payload.data).toEqual({ which: 'A-fresh' });
+        expect(emitted.some((a: any) => a?.payload?.data?.which === 'A-stale')).toBe(false);
+    });
+
+    test('callbackResource: distinct callbackIds run concurrently (cascade not dropped)', async () => {
+        const deps = createDeps({
+            callback: {
+                resourceCallback: (({ parentObjectUuid }: any) => of({ for: parentObjectUuid })) as any,
+            } as any,
+        });
+        const epic = callbackResourceEpic as any;
+        const action$ = new Subject<any>();
+        const state$ = of({}) as any;
+        state$.value = {};
+        const collected = firstValueFrom(epic(action$, state$, deps).pipe(toArray())) as Promise<any[]>;
+
+        action$.next(
+            slice.actions.callbackResource({
+                callbackId: 'cb-A',
+                callbackResource: { parentObjectUuid: 'A', requestAttributeCallback: { mappings: [] } } as any,
+            }),
+        );
+        action$.next(
+            slice.actions.callbackResource({
+                callbackId: 'cb-B',
+                callbackResource: { parentObjectUuid: 'B', requestAttributeCallback: { mappings: [] } } as any,
+            }),
+        );
+        action$.complete();
+
+        const emitted = await collected;
+        const successIds = emitted.filter((a: any) => a.type === slice.actions.callbackSuccess.type).map((a: any) => a.payload.callbackId);
+        // Both controls' callbacks complete — neither is dropped.
+        expect(successIds).toContain('cb-A');
+        expect(successIds).toContain('cb-B');
+    });
+
+    test('callbackConnector drain-all stale-race: superseded callbackId success is ABSENT (V2 selection preserved)', async () => {
+        const callbackV2 = (() => {
+            let call = 0;
+            return () => {
+                call += 1;
+                return call === 1 ? of({ which: 'stale' }).pipe(delay(50)) : of({ which: 'fresh' });
+            };
+        })();
+        const callbackV1 = vi.fn(() => of({}));
+        const deps = createDeps({ callback: { callbackV2, callback: callbackV1 } as any });
+        const epic = callbackConnectorEpic as any;
+        const action$ = new Subject<any>();
+        const stateValue = { connectors: { connectors: [{ uuid: 'c-1', version: ConnectorVersion.V2 }], connector: undefined } };
+        const state$ = of(stateValue) as any;
+        state$.value = stateValue;
+        const collected = firstValueFrom(epic(action$, state$, deps).pipe(toArray())) as Promise<any[]>;
+
+        const mk = () =>
+            slice.actions.callbackConnector({
+                callbackId: 'cb-1',
+                callbackConnector: { uuid: 'c-1', functionGroup: 'FG', kind: 'k', requestAttributeCallback: { mappings: [] } } as any,
+            });
+        action$.next(mk());
+        action$.next(mk());
+        action$.complete();
+
+        const emitted = await collected;
+        const successes = emitted.filter((a: any) => a.type === slice.actions.callbackSuccess.type);
+        expect(successes).toHaveLength(1);
+        expect(successes[0].payload.data).toEqual({ which: 'fresh' });
+        // V2 path used (V1 never called); stale absent.
+        expect(callbackV1).not.toHaveBeenCalled();
+        expect(emitted.some((a: any) => a?.payload?.data?.which === 'stale')).toBe(false);
     });
 });

--- a/src/ducks/connectors-epic.ts
+++ b/src/ducks/connectors-epic.ts
@@ -1,6 +1,6 @@
 import type { AppEpic } from 'ducks';
 import { of } from 'rxjs';
-import { catchError, filter, map, mergeMap, startWith, switchMap } from 'rxjs/operators';
+import { catchError, filter, groupBy, map, mergeMap, startWith, switchMap } from 'rxjs/operators';
 import { LockWidgetNameEnum } from 'types/user-interface';
 import { AuthType, ConnectorVersion } from 'types/openapi';
 import { extractError } from 'utils/net';
@@ -456,43 +456,52 @@ const bulkForceDeleteConnectors: AppEpic = (action$, state, deps) => {
 const callbackConnector: AppEpic = (action$, state, deps) => {
     return action$.pipe(
         filter(slice.actions.callbackConnector.match),
-        mergeMap((action) => {
-            const { callbackConnector: payload } = action.payload;
-            const requestAttributeCallback = transformCallbackAttributeModelToDto(payload.requestAttributeCallback);
-            // Guard against missing UUID (would produce /v1/connectors/undefined/... URLs)
-            if (!payload.uuid) {
-                return of(slice.actions.callbackFailure({ callbackId: action.payload.callbackId }));
-            }
-            const rootState: any = (state as any).value ?? (state as any);
-            const connectorsState: any = rootState.connectors;
-            const connector = connectorsState?.connectors?.find((c: any) => c.uuid === payload.uuid) ?? connectorsState?.connector;
-            // Fall back to v1 when the connector is not in connectors state (e.g. authority/credential providers)
-            const isV2 = connector?.version === ConnectorVersion.V2;
-            const api$ = isV2
-                ? deps.apiClients.callback.callbackV2({
-                      uuid: payload.uuid,
-                      requestAttributeCallback,
-                  })
-                : deps.apiClients.callback.callback({
-                      uuid: payload.uuid,
-                      functionGroup: payload.functionGroup,
-                      kind: payload.kind,
-                      requestAttributeCallback,
-                  });
+        // Group by callbackId (the per-control form name) and switchMap WITHIN each group so a
+        // newer dispatch for the SAME control cancels the previous in-flight request — the per-control
+        // stale-response discard. Different controls (different callbackIds) run concurrently via
+        // mergeMap, so a cascading dependsOn callback on one control is never dropped by another.
+        groupBy((action) => action.payload.callbackId),
+        mergeMap((group$) =>
+            group$.pipe(
+                switchMap((action) => {
+                    const { callbackConnector: payload } = action.payload;
+                    const requestAttributeCallback = transformCallbackAttributeModelToDto(payload.requestAttributeCallback);
+                    // Guard against missing UUID (would produce /v1/connectors/undefined/... URLs)
+                    if (!payload.uuid) {
+                        return of(slice.actions.callbackFailure({ callbackId: action.payload.callbackId }));
+                    }
+                    const rootState: any = (state as any).value ?? (state as any);
+                    const connectorsState: any = rootState.connectors;
+                    const connector = connectorsState?.connectors?.find((c: any) => c.uuid === payload.uuid) ?? connectorsState?.connector;
+                    // Fall back to v1 when the connector is not in connectors state (e.g. authority/credential providers)
+                    const isV2 = connector?.version === ConnectorVersion.V2;
+                    const api$ = isV2
+                        ? deps.apiClients.callback.callbackV2({
+                              uuid: payload.uuid,
+                              requestAttributeCallback,
+                          })
+                        : deps.apiClients.callback.callback({
+                              uuid: payload.uuid,
+                              functionGroup: payload.functionGroup,
+                              kind: payload.kind,
+                              requestAttributeCallback,
+                          });
 
-            return api$.pipe(
-                map((data) => {
-                    return slice.actions.callbackSuccess({ callbackId: action.payload.callbackId, data });
+                    return api$.pipe(
+                        map((data) => {
+                            return slice.actions.callbackSuccess({ callbackId: action.payload.callbackId, data });
+                        }),
+
+                        catchError((error) =>
+                            of(
+                                slice.actions.callbackFailure({ callbackId: action.payload.callbackId }),
+                                appRedirectActions.fetchError({ error, message: 'Connector callback failure' }),
+                            ),
+                        ),
+                    );
                 }),
-
-                catchError((error) =>
-                    of(
-                        slice.actions.callbackFailure({ callbackId: action.payload.callbackId }),
-                        appRedirectActions.fetchError({ error, message: 'Connector callback failure' }),
-                    ),
-                ),
-            );
-        }),
+            ),
+        ),
 
         catchError((error) =>
             of(
@@ -506,26 +515,33 @@ const callbackConnector: AppEpic = (action$, state, deps) => {
 const callbackResource: AppEpic = (action$, state, deps) => {
     return action$.pipe(
         filter(slice.actions.callbackResource.match),
-        mergeMap((action) =>
-            deps.apiClients.callback
-                .resourceCallback({
-                    ...action.payload.callbackResource,
-                    requestAttributeCallback: transformCallbackAttributeModelToDto(
-                        action.payload.callbackResource.requestAttributeCallback,
-                    ),
-                })
-                .pipe(
-                    map((data) => {
-                        return slice.actions.callbackSuccess({ callbackId: action.payload.callbackId, data });
-                    }),
+        // Per-callbackId stale-response discard: switchMap within each callbackId group cancels a
+        // superseded same-control request; distinct controls stay concurrent via mergeMap.
+        groupBy((action) => action.payload.callbackId),
+        mergeMap((group$) =>
+            group$.pipe(
+                switchMap((action) =>
+                    deps.apiClients.callback
+                        .resourceCallback({
+                            ...action.payload.callbackResource,
+                            requestAttributeCallback: transformCallbackAttributeModelToDto(
+                                action.payload.callbackResource.requestAttributeCallback,
+                            ),
+                        })
+                        .pipe(
+                            map((data) => {
+                                return slice.actions.callbackSuccess({ callbackId: action.payload.callbackId, data });
+                            }),
 
-                    catchError((error) =>
-                        of(
-                            slice.actions.callbackFailure({ callbackId: action.payload.callbackId }),
-                            appRedirectActions.fetchError({ error, message: 'Resource callback failure' }),
+                            catchError((error) =>
+                                of(
+                                    slice.actions.callbackFailure({ callbackId: action.payload.callbackId }),
+                                    appRedirectActions.fetchError({ error, message: 'Resource callback failure' }),
+                                ),
+                            ),
                         ),
-                    ),
                 ),
+            ),
         ),
 
         catchError((error) =>
@@ -567,6 +583,12 @@ const getConnectorAuthAttributesDescriptors: AppEpic = (action$, state, deps) =>
         }),
     );
 };
+
+// Named exports for the callback epics so tests can reference them directly instead of
+// by a fragile positional index into the default `epics` array (which shifts on insert).
+// These are the SAME function instances used in the array below — no behavior change.
+export const callbackConnectorEpic = callbackConnector;
+export const callbackResourceEpic = callbackResource;
 
 const epics = [
     listConnectors,

--- a/src/types/openapi/models/AttributeCallback.ts
+++ b/src/types/openapi/models/AttributeCallback.ts
@@ -36,4 +36,10 @@ export interface AttributeCallback {
      * @memberof AttributeCallback
      */
     mappings: Array<AttributeCallbackMapping>;
+    /**
+     * Names of the attributes this Attributes v2 callback consumes and is triggered by. Marks an NG (Attributes v2) callback; at most one of dependsOn / callbackContext may be set (neither = no callback). Forbidden on RESOURCE attributes. Enforced by Core.
+     * @type {Array<string>}
+     * @memberof AttributeCallback
+     */
+    dependsOn?: Array<string>;
 }

--- a/src/types/openapi/models/RequestAttributeCallback.ts
+++ b/src/types/openapi/models/RequestAttributeCallback.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import type { PaginationRequestDto } from './';
+import type { PaginationRequestDto, RequestAttribute } from './';
 
 /**
  * @export
@@ -60,4 +60,10 @@ export interface RequestAttributeCallback {
      * @memberof RequestAttributeCallback
      */
     pagination?: PaginationRequestDto;
+    /**
+     * Attributes v2 callback values: the dependsOn-named attributes the callback consumes, reference-typed values expanded inline by Core. Used by the NG (Attributes v2) callback path.
+     * @type {Array<RequestAttribute>}
+     * @memberof RequestAttributeCallback
+     */
+    attributes?: Array<RequestAttribute>;
 }


### PR DESCRIPTION
## What
NG `dependsOn` callback support in `AttributeEditor`. Subscribe to the dependsOn-named attributes; fire when all set, re-fire on change, fire once on mount for `dependsOn: []`, clear+reset the dependent locally on a cleared dependency. Send only the dependsOn-named **raw** content (no dot-path resolution) via a pure `collectDependsOnValues` helper. Render RESOURCE-typed options from Core.

## Where
- `AttributeEditor/index.tsx` — NG path (`executeNgCallback`, change-path branch, mount/injected-child initial fire, cleared-dep reset)
- `collectDependsOnValues.ts` — pure helper (+ unit spec)
- `ducks/connectors-epic.ts` — per-`callbackId` stale-discard (`groupBy(callbackId) → switchMap`), 600ms debounce retained; named-epic exports for testability
- `_pages/certificates/form/index.tsx` — scope fix
- generated models: `AttributeCallback.dependsOn`, `RequestAttributeCallback.attributes`

## Concurrency (AC-7)
Per-`callbackId` gating: the NG branch is gated on `isRunningCallback[id]` and runs before the legacy global `isRunningCb` gate — preserves the edit-mode callback-storm suppression yet does NOT drop a different control's cascade edit. Legacy `callbackContext`+mappings path byte-identical.

## Scope / not here (on purpose)
- Only the **certificates** form changes (`Resource.Certificates` + RA-profile UUID as parent). The other four already pass Core UUIDs (verified, not assumed); ra-profiles is a latent v3 fix gated on core#1621.
- AC-5: RESOURCE option **rendering** done; the `{resource,uuid,name}` serialisation is expanded inline by Core (not FE-emitted) — routed, not faked.
- Broad GROUP-child re-subscription deferred to **fe#1797** (initial fire done).
- Leaf consumer: unit/CT-green now; end-to-end smoke after core#1621/#1622 land.

## Tests
Vitest unit + redux-observable epic specs (incl. a load-bearing drain-all stale-race) and Playwright component tests: cascade A→B not suppressed, both-present tiebreak, `dependsOn:[]` once-on-mount, cleared-dependency reset (load-bearing), legacy-path regression.

## Review
Built TDD. Reviewed by fan-out Claude agents (plan-review, correctness/concurrency, AC-conformance, conventions, adversarial try-to-break) + two independent Copilot deep passes (gpt-5.5 / claude-sonnet) — all **SHIP**. Tracked follow-up hardening from the adversarial pass: the callback epics' outer `catchError` should re-subscribe rather than emit a blank-id failure (latent, unreachable today); `groupBy` group disposal across navigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
