### PR TITLE
Request-attribute mapping badge on the Issue form (#1779)

### DIFF
--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.spec.tsx
@@ -1,7 +1,8 @@
 import { test, expect } from '../../../../../playwright/ct-test';
 import { AttributeFieldInputTestWrapper } from './AttributeFieldInputTestWrapper';
 import type { DataAttributeModel } from 'types/attributes';
-import { AttributeContentType } from 'types/openapi';
+import { AttributeContentType, AttributeType, FieldType, ObjectType } from 'types/openapi';
+import type { FieldMapping } from 'types/openapi';
 
 const defaultProperties = {
     label: 'Test Field',
@@ -14,7 +15,7 @@ const defaultProperties = {
 
 function minimalDescriptor(contentType: AttributeContentType, overrides: Partial<DataAttributeModel> = {}): DataAttributeModel {
     return {
-        type: 'Data',
+        type: AttributeType.Data,
         name: 'testField',
         uuid: 'test-uuid',
         contentType,
@@ -224,5 +225,33 @@ test.describe('AttributeFieldInput', () => {
         await expect(input).toBeVisible();
         await expect(input).toHaveAttribute('placeholder', 'Enter My Input');
         await expect(input).toHaveValue('');
+    });
+
+    test('renders the request-attribute mapping badge for a String field with fieldMapping', async ({ mount, page }) => {
+        const fieldMapping = {
+            objectType: ObjectType.X509Certificate,
+            fields: [
+                { fieldType: FieldType.Rdn, rdn: 'CN', order: 1 },
+                { fieldType: FieldType.San, generalNameType: 'dns', order: 2 },
+            ],
+        } as unknown as FieldMapping;
+        const descriptor = minimalDescriptor(AttributeContentType.String, {
+            properties: { ...defaultProperties, label: 'Server FQDN' },
+            fieldMapping,
+        } as any);
+        await mount(<AttributeFieldInputTestWrapper name="testField" descriptor={descriptor} />);
+
+        await expect(page.getByTestId('request-attribute-mapping-badge')).toBeVisible();
+        await expect(page.getByText('→ Subject CN + SAN dNSName')).toBeVisible();
+    });
+
+    test('does not render a mapping badge for a String field without fieldMapping', async ({ mount, page }) => {
+        const descriptor = minimalDescriptor(AttributeContentType.String, {
+            properties: { ...defaultProperties, label: 'Plain Field' },
+        } as any);
+        await mount(<AttributeFieldInputTestWrapper name="testField" descriptor={descriptor} />);
+
+        await expect(page.getByText('Plain Field')).toBeVisible();
+        await expect(page.getByTestId('request-attribute-mapping-badge')).toHaveCount(0);
     });
 });

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.tsx
@@ -8,6 +8,8 @@ import Editor from 'components/Input/CodeEditor/CodeEditor';
 import cn from 'classnames';
 import type { CustomAttributeModel, DataAttributeModel } from 'types/attributes';
 import { AttributeContentType } from 'types/openapi';
+import RequestAttributeMappingBadge from 'components/RequestAttributes/RequestAttributeMappingBadge';
+import { getFieldMapping } from 'utils/requestAttributes';
 import { getCodeBlockLanguage } from '../../../../utils/attributes/attributes';
 import { getHighLightedCode } from '../../CodeBlock';
 import {
@@ -208,6 +210,7 @@ export function AttributeFieldInput({ name, descriptor, busy, deleteButton }: Re
                             {descriptor.properties.label}
                         </Label>
                     )}
+                    {showLabel && <RequestAttributeMappingBadge fieldMapping={getFieldMapping(descriptor)} />}
                     <div className="flex items-center">
                         <StandardInputControl
                             name={name}

--- a/src/components/RequestAttributes/RequestAttributeMappingBadge.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeMappingBadge.spec.tsx
@@ -20,11 +20,11 @@ test.describe('RequestAttributeMappingBadge', () => {
 
     test('exposes a "Maps to" tooltip title', async ({ mount }) => {
         const component = await mount(<RequestAttributeMappingBadge fieldMapping={mapping([{ fieldType: FieldType.Rdn, rdn: 'O' }])} />);
-        await expect(component.getByTestId('request-attribute-mapping-badge')).toHaveAttribute('title', 'Maps to: Subject O');
+        await expect(component).toHaveAttribute('title', 'Maps to: Subject O');
     });
 
     test('renders nothing when there is no mapping', async ({ mount }) => {
         const component = await mount(<RequestAttributeMappingBadge />);
-        await expect(component.getByTestId('request-attribute-mapping-badge')).toHaveCount(0);
+        await expect(component).toBeEmpty();
     });
 });

--- a/src/components/RequestAttributes/RequestAttributeMappingBadge.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeMappingBadge.spec.tsx
@@ -1,0 +1,30 @@
+import { test, expect } from '../../../playwright/ct-test';
+import { FieldType, ObjectType } from 'types/openapi';
+import type { FieldMapping } from 'types/openapi';
+import RequestAttributeMappingBadge from './RequestAttributeMappingBadge';
+
+const mapping = (fields: unknown[]): FieldMapping => ({ objectType: ObjectType.X509Certificate, fields }) as unknown as FieldMapping;
+
+test.describe('RequestAttributeMappingBadge', () => {
+    test('renders the mapping summary tokens', async ({ mount }) => {
+        const component = await mount(
+            <RequestAttributeMappingBadge
+                fieldMapping={mapping([
+                    { fieldType: FieldType.Rdn, rdn: 'CN', order: 1 },
+                    { fieldType: FieldType.San, generalNameType: 'dns', order: 2 },
+                ])}
+            />,
+        );
+        await expect(component.getByText('→ Subject CN + SAN dNSName')).toBeVisible();
+    });
+
+    test('exposes a "Maps to" tooltip title', async ({ mount }) => {
+        const component = await mount(<RequestAttributeMappingBadge fieldMapping={mapping([{ fieldType: FieldType.Rdn, rdn: 'O' }])} />);
+        await expect(component.getByTestId('request-attribute-mapping-badge')).toHaveAttribute('title', 'Maps to: Subject O');
+    });
+
+    test('renders nothing when there is no mapping', async ({ mount }) => {
+        const component = await mount(<RequestAttributeMappingBadge />);
+        await expect(component.getByTestId('request-attribute-mapping-badge')).toHaveCount(0);
+    });
+});

--- a/src/components/RequestAttributes/RequestAttributeMappingBadge.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeMappingBadge.spec.tsx
@@ -21,6 +21,7 @@ test.describe('RequestAttributeMappingBadge', () => {
     test('exposes a "Maps to" tooltip title', async ({ mount }) => {
         const component = await mount(<RequestAttributeMappingBadge fieldMapping={mapping([{ fieldType: FieldType.Rdn, rdn: 'O' }])} />);
         await expect(component).toHaveAttribute('title', 'Maps to: Subject O');
+        await expect(component).toHaveAttribute('data-testid', 'request-attribute-mapping-badge');
     });
 
     test('renders nothing when there is no mapping', async ({ mount }) => {

--- a/src/components/RequestAttributes/RequestAttributeMappingBadge.tsx
+++ b/src/components/RequestAttributes/RequestAttributeMappingBadge.tsx
@@ -1,7 +1,7 @@
 import { Info } from 'lucide-react';
 import type { FieldMapping } from 'types/openapi';
 import Badge from 'components/Badge';
-import { fieldMappingSummary } from 'utils/requestAttributes';
+import { fieldMappingTokens } from 'utils/requestAttributes';
 
 type Props = {
     fieldMapping?: FieldMapping;
@@ -9,15 +9,19 @@ type Props = {
 };
 
 function RequestAttributeMappingBadge({ fieldMapping, dataTestId = 'request-attribute-mapping-badge' }: Readonly<Props>) {
-    const summary = fieldMappingSummary(fieldMapping);
-    if (!summary) return null;
+    const tokens = fieldMappingTokens(fieldMapping);
+    if (tokens.length === 0) return null;
 
-    const tooltip = `Maps to: ${summary.split(' + ').join(', ')}`;
+    const summary = tokens.join(' + ');
+    const tooltip = `Maps to: ${tokens.join(', ')}`;
 
     return (
-        <Badge color="info" size="small" className="mt-1 gap-x-1" title={tooltip} dataTestId={dataTestId}>
+        <Badge color="info" size="small" className="mt-1" title={tooltip} dataTestId={dataTestId}>
             <Info size={12} aria-hidden />
-            <span>→ {summary}</span>
+            <span>
+                <span aria-hidden>→ </span>
+                {summary}
+            </span>
         </Badge>
     );
 }

--- a/src/components/RequestAttributes/RequestAttributeMappingBadge.tsx
+++ b/src/components/RequestAttributes/RequestAttributeMappingBadge.tsx
@@ -1,0 +1,25 @@
+import { Info } from 'lucide-react';
+import type { FieldMapping } from 'types/openapi';
+import Badge from 'components/Badge';
+import { fieldMappingSummary } from 'utils/requestAttributes';
+
+type Props = {
+    fieldMapping?: FieldMapping;
+    dataTestId?: string;
+};
+
+function RequestAttributeMappingBadge({ fieldMapping, dataTestId = 'request-attribute-mapping-badge' }: Readonly<Props>) {
+    const summary = fieldMappingSummary(fieldMapping);
+    if (!summary) return null;
+
+    const tooltip = `Maps to: ${summary.split(' + ').join(', ')}`;
+
+    return (
+        <Badge color="info" size="small" className="mt-1 gap-x-1" title={tooltip} dataTestId={dataTestId}>
+            <Info size={12} aria-hidden />
+            <span>→ {summary}</span>
+        </Badge>
+    );
+}
+
+export default RequestAttributeMappingBadge;

--- a/src/utils/requestAttributes.spec.ts
+++ b/src/utils/requestAttributes.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'vitest';
+import { AttributeContentType, AttributeType, FieldType, ObjectType } from 'types/openapi';
+import type { FieldMapping } from 'types/openapi';
+import type { AttributeDescriptorModel } from 'types/attributes';
+import { fieldMappingSummary, getFieldMapping, isRequestAttribute } from './requestAttributes';
+
+// fields carry rdn/generalNameType/extensionOid that the generated TS subtypes omit,
+// so build plain objects and cast to the FieldMapping shape.
+const mapping = (fields: unknown[]): FieldMapping => ({ objectType: ObjectType.X509Certificate, fields }) as unknown as FieldMapping;
+
+const dataDescriptor = (fieldMapping?: FieldMapping): AttributeDescriptorModel =>
+    ({
+        uuid: 'u1',
+        name: 'serverFqdn',
+        type: AttributeType.Data,
+        contentType: AttributeContentType.String,
+        properties: { label: 'Server FQDN', visible: true, required: true },
+        fieldMapping,
+    }) as unknown as AttributeDescriptorModel;
+
+const customDescriptor = (): AttributeDescriptorModel =>
+    ({
+        uuid: 'u2',
+        name: 'custom',
+        type: AttributeType.Custom,
+        contentType: AttributeContentType.String,
+        properties: { label: 'Custom', visible: true },
+    }) as unknown as AttributeDescriptorModel;
+
+describe('getFieldMapping', () => {
+    test('returns the mapping for a data attribute that has one', () => {
+        const fm = mapping([{ fieldType: FieldType.Rdn, rdn: 'CN' }]);
+        expect(getFieldMapping(dataDescriptor(fm))).toBe(fm);
+    });
+    test('returns undefined for a data attribute without a mapping', () => {
+        expect(getFieldMapping(dataDescriptor())).toBeUndefined();
+    });
+    test('returns undefined for a non-data attribute', () => {
+        expect(getFieldMapping(customDescriptor())).toBeUndefined();
+    });
+    test('returns undefined for undefined', () => {
+        expect(getFieldMapping(undefined)).toBeUndefined();
+    });
+});
+
+describe('isRequestAttribute', () => {
+    test('true when mapping has at least one field', () => {
+        expect(isRequestAttribute(dataDescriptor(mapping([{ fieldType: FieldType.Rdn, rdn: 'CN' }])))).toBe(true);
+    });
+    test('false when fields is empty', () => {
+        expect(isRequestAttribute(dataDescriptor(mapping([])))).toBe(false);
+    });
+    test('false when no mapping', () => {
+        expect(isRequestAttribute(dataDescriptor())).toBe(false);
+    });
+    test('false for non-data attribute', () => {
+        expect(isRequestAttribute(customDescriptor())).toBe(false);
+    });
+});
+
+describe('fieldMappingSummary', () => {
+    test('rdn renders Subject <rdn>', () => {
+        expect(fieldMappingSummary(mapping([{ fieldType: FieldType.Rdn, rdn: 'O' }]))).toBe('Subject O');
+    });
+    test('san with known general name type renders friendly X.509 name', () => {
+        expect(fieldMappingSummary(mapping([{ fieldType: FieldType.San, generalNameType: 'dns' }]))).toBe('SAN dNSName');
+    });
+    test('san with unknown general name type falls back to the raw value', () => {
+        expect(fieldMappingSummary(mapping([{ fieldType: FieldType.San, generalNameType: 'futureType' }]))).toBe('SAN futureType');
+    });
+    test('extension renders Extension <oid>', () => {
+        expect(fieldMappingSummary(mapping([{ fieldType: FieldType.Extension, extensionOid: '2.5.29.17' }]))).toBe('Extension 2.5.29.17');
+    });
+    test('multiple fields join with " + " sorted by order ascending', () => {
+        const fm = mapping([
+            { fieldType: FieldType.San, generalNameType: 'dns', order: 2 },
+            { fieldType: FieldType.Rdn, rdn: 'CN', order: 1 },
+        ]);
+        expect(fieldMappingSummary(fm)).toBe('Subject CN + SAN dNSName');
+    });
+    test('unknown fieldType falls back to the raw fieldType', () => {
+        expect(fieldMappingSummary(mapping([{ fieldType: 'newKind' }]))).toBe('newKind');
+    });
+    test('missing sub-field renders the bare field label', () => {
+        expect(fieldMappingSummary(mapping([{ fieldType: FieldType.Rdn }]))).toBe('Subject');
+    });
+    test('undefined / empty mapping renders empty string', () => {
+        expect(fieldMappingSummary(undefined)).toBe('');
+        expect(fieldMappingSummary(mapping([]))).toBe('');
+    });
+});

--- a/src/utils/requestAttributes.spec.ts
+++ b/src/utils/requestAttributes.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { AttributeContentType, AttributeType, FieldType, ObjectType } from 'types/openapi';
 import type { FieldMapping } from 'types/openapi';
 import type { AttributeDescriptorModel } from 'types/attributes';
-import { fieldMappingSummary, getFieldMapping, isRequestAttribute } from './requestAttributes';
+import { fieldMappingSummary, getFieldMapping } from './requestAttributes';
 
 // fields carry rdn/generalNameType/extensionOid that the generated TS subtypes omit,
 // so build plain objects and cast to the FieldMapping shape.
@@ -40,21 +40,6 @@ describe('getFieldMapping', () => {
     });
     test('returns undefined for undefined', () => {
         expect(getFieldMapping(undefined)).toBeUndefined();
-    });
-});
-
-describe('isRequestAttribute', () => {
-    test('true when mapping has at least one field', () => {
-        expect(isRequestAttribute(dataDescriptor(mapping([{ fieldType: FieldType.Rdn, rdn: 'CN' }])))).toBe(true);
-    });
-    test('false when fields is empty', () => {
-        expect(isRequestAttribute(dataDescriptor(mapping([])))).toBe(false);
-    });
-    test('false when no mapping', () => {
-        expect(isRequestAttribute(dataDescriptor())).toBe(false);
-    });
-    test('false for non-data attribute', () => {
-        expect(isRequestAttribute(customDescriptor())).toBe(false);
     });
 });
 

--- a/src/utils/requestAttributes.spec.ts
+++ b/src/utils/requestAttributes.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { AttributeContentType, AttributeType, FieldType, ObjectType } from 'types/openapi';
 import type { FieldMapping } from 'types/openapi';
 import type { AttributeDescriptorModel } from 'types/attributes';
-import { fieldMappingSummary, getFieldMapping } from './requestAttributes';
+import { fieldMappingSummary, fieldMappingTokens, getFieldMapping } from './requestAttributes';
 
 // fields carry rdn/generalNameType/extensionOid that the generated TS subtypes omit,
 // so build plain objects and cast to the FieldMapping shape.
@@ -63,6 +63,16 @@ describe('fieldMappingSummary', () => {
         ]);
         expect(fieldMappingSummary(fm)).toBe('Subject CN + SAN dNSName');
     });
+    test('groups by type before order so per-type order never interleaves types', () => {
+        // order is a per-type index: SAN order 1 must not sort ahead of RDN order 2.
+        const fm = mapping([
+            { fieldType: FieldType.San, generalNameType: 'dns', order: 1 },
+            { fieldType: FieldType.Rdn, rdn: 'OU', order: 2 },
+            { fieldType: FieldType.Rdn, rdn: 'CN', order: 1 },
+            { fieldType: FieldType.Extension, extensionOid: '2.5.29.17', order: 1 },
+        ]);
+        expect(fieldMappingSummary(fm)).toBe('Subject CN + Subject OU + SAN dNSName + Extension 2.5.29.17');
+    });
     test('unknown fieldType falls back to the raw fieldType', () => {
         expect(fieldMappingSummary(mapping([{ fieldType: 'newKind' }]))).toBe('newKind');
     });
@@ -72,5 +82,19 @@ describe('fieldMappingSummary', () => {
     test('undefined / empty mapping renders empty string', () => {
         expect(fieldMappingSummary(undefined)).toBe('');
         expect(fieldMappingSummary(mapping([]))).toBe('');
+    });
+});
+
+describe('fieldMappingTokens', () => {
+    test('returns one token per field, grouped by type', () => {
+        const fm = mapping([
+            { fieldType: FieldType.San, generalNameType: 'dns', order: 1 },
+            { fieldType: FieldType.Rdn, rdn: 'CN', order: 1 },
+        ]);
+        expect(fieldMappingTokens(fm)).toEqual(['Subject CN', 'SAN dNSName']);
+    });
+    test('returns an empty array for undefined / empty mapping', () => {
+        expect(fieldMappingTokens(undefined)).toEqual([]);
+        expect(fieldMappingTokens(mapping([]))).toEqual([]);
     });
 });

--- a/src/utils/requestAttributes.ts
+++ b/src/utils/requestAttributes.ts
@@ -1,21 +1,26 @@
 import type { DataAttributeV3, FieldMapping, MappedField } from 'types/openapi';
-import { FieldType } from 'types/openapi';
-import type { AttributeDescriptorModel, CustomAttributeModel, DataAttributeModel } from 'types/attributes';
+import { FieldType, GeneralNameType } from 'types/openapi';
+import type { AttributeDescriptorModel } from 'types/attributes';
 import { isDataAttributeModel } from 'types/attributes';
 
-type AnyDescriptor = AttributeDescriptorModel | DataAttributeModel | CustomAttributeModel | undefined;
+type AnyDescriptor = AttributeDescriptorModel | undefined;
 
-// Friendly X.509 SAN names keyed by GeneralNameType value. Best-effort: any value not
-// present here falls back to its raw string, so new backend enum members still render.
-const GENERAL_NAME_LABELS: Record<string, string> = {
-    dns: 'dNSName',
-    email: 'rfc822Name',
-    ip: 'iPAddress',
-    uri: 'uniformResourceIdentifier',
-    directoryName: 'directoryName',
-    registeredId: 'registeredID',
-    otherName: 'otherName',
+// Friendly X.509 SAN names keyed by GeneralNameType. Typing the map by the enum makes a
+// future enum change a compile error here; the raw-value fallback in generalNameLabel keeps
+// forward-compatibility for values not (yet) in the generated enum.
+const GENERAL_NAME_LABELS: Record<GeneralNameType, string> = {
+    [GeneralNameType.Dns]: 'dNSName',
+    [GeneralNameType.Email]: 'rfc822Name',
+    [GeneralNameType.Ip]: 'iPAddress',
+    [GeneralNameType.Uri]: 'uniformResourceIdentifier',
+    [GeneralNameType.DirectoryName]: 'directoryName',
+    [GeneralNameType.RegisteredId]: 'registeredID',
+    [GeneralNameType.OtherName]: 'otherName',
 };
+
+// Group order for tokens; `order` on MappedField is scoped per field type, so we group by
+// type first and only sort by `order` within a group (never across types).
+const FIELD_TYPE_ORDER: FieldType[] = [FieldType.Rdn, FieldType.San, FieldType.Extension];
 
 /** Extracts fieldMapping defensively; only DataAttribute (V3) carries it. */
 export function getFieldMapping(descriptor: AnyDescriptor): FieldMapping | undefined {
@@ -24,7 +29,7 @@ export function getFieldMapping(descriptor: AnyDescriptor): FieldMapping | undef
 }
 
 function generalNameLabel(value: string): string {
-    return GENERAL_NAME_LABELS[value] ?? value;
+    return GENERAL_NAME_LABELS[value as GeneralNameType] ?? value;
 }
 
 function fieldToken(field: MappedField): string {
@@ -46,13 +51,31 @@ function fieldToken(field: MappedField): string {
     }
 }
 
+function typeRank(field: MappedField): number {
+    const index = FIELD_TYPE_ORDER.indexOf(field?.fieldType);
+    return index === -1 ? FIELD_TYPE_ORDER.length : index;
+}
+
+/**
+ * Tokens describing where the value lands, e.g. ["Subject CN", "SAN dNSName"]. Fields are
+ * grouped by type (RDN → SAN → Extension) and only sorted by `order` within each group,
+ * because `order` is a per-type index. This is the single source both the badge summary and
+ * its tooltip build on, so their delimiters can never drift apart.
+ */
+export function fieldMappingTokens(fieldMapping: FieldMapping | undefined): string[] {
+    const fields = fieldMapping?.fields;
+    if (!Array.isArray(fields) || fields.length === 0) return [];
+    return [...(fields as MappedField[])]
+        .sort((a, b) => {
+            const byType = typeRank(a) - typeRank(b);
+            if (byType !== 0) return byType;
+            return (a?.order ?? Number.MAX_SAFE_INTEGER) - (b?.order ?? Number.MAX_SAFE_INTEGER);
+        })
+        .map((field) => fieldToken(field))
+        .filter((token) => token.length > 0);
+}
+
 /** Human summary of where the value lands, e.g. "Subject CN + SAN dNSName". */
 export function fieldMappingSummary(fieldMapping: FieldMapping | undefined): string {
-    const fields = fieldMapping?.fields;
-    if (!Array.isArray(fields) || fields.length === 0) return '';
-    return [...fields]
-        .sort((a, b) => ((a as MappedField)?.order ?? Number.MAX_SAFE_INTEGER) - ((b as MappedField)?.order ?? Number.MAX_SAFE_INTEGER))
-        .map((field) => fieldToken(field as MappedField))
-        .filter((token) => token.length > 0)
-        .join(' + ');
+    return fieldMappingTokens(fieldMapping).join(' + ');
 }

--- a/src/utils/requestAttributes.ts
+++ b/src/utils/requestAttributes.ts
@@ -23,12 +23,6 @@ export function getFieldMapping(descriptor: AnyDescriptor): FieldMapping | undef
     return (descriptor as DataAttributeV3).fieldMapping ?? undefined;
 }
 
-/** True when the descriptor is a data attribute with at least one mapped field. */
-export function isRequestAttribute(descriptor: AnyDescriptor): boolean {
-    const fields = getFieldMapping(descriptor)?.fields;
-    return Array.isArray(fields) && fields.length > 0;
-}
-
 function generalNameLabel(value: string): string {
     return GENERAL_NAME_LABELS[value] ?? value;
 }

--- a/src/utils/requestAttributes.ts
+++ b/src/utils/requestAttributes.ts
@@ -1,0 +1,64 @@
+import type { DataAttributeV3, FieldMapping, MappedField } from 'types/openapi';
+import { FieldType } from 'types/openapi';
+import type { AttributeDescriptorModel, CustomAttributeModel, DataAttributeModel } from 'types/attributes';
+import { isDataAttributeModel } from 'types/attributes';
+
+type AnyDescriptor = AttributeDescriptorModel | DataAttributeModel | CustomAttributeModel | undefined;
+
+// Friendly X.509 SAN names keyed by GeneralNameType value. Best-effort: any value not
+// present here falls back to its raw string, so new backend enum members still render.
+const GENERAL_NAME_LABELS: Record<string, string> = {
+    dns: 'dNSName',
+    email: 'rfc822Name',
+    ip: 'iPAddress',
+    uri: 'uniformResourceIdentifier',
+    directoryName: 'directoryName',
+    registeredId: 'registeredID',
+    otherName: 'otherName',
+};
+
+/** Extracts fieldMapping defensively; only DataAttribute (V3) carries it. */
+export function getFieldMapping(descriptor: AnyDescriptor): FieldMapping | undefined {
+    if (!descriptor || !isDataAttributeModel(descriptor as AttributeDescriptorModel)) return undefined;
+    return (descriptor as DataAttributeV3).fieldMapping ?? undefined;
+}
+
+/** True when the descriptor is a data attribute with at least one mapped field. */
+export function isRequestAttribute(descriptor: AnyDescriptor): boolean {
+    const fields = getFieldMapping(descriptor)?.fields;
+    return Array.isArray(fields) && fields.length > 0;
+}
+
+function generalNameLabel(value: string): string {
+    return GENERAL_NAME_LABELS[value] ?? value;
+}
+
+function fieldToken(field: MappedField): string {
+    switch (field?.fieldType) {
+        case FieldType.Rdn: {
+            const rdn = (field as { rdn?: string }).rdn;
+            return rdn ? `Subject ${rdn}` : 'Subject';
+        }
+        case FieldType.San: {
+            const generalNameType = (field as { generalNameType?: string }).generalNameType;
+            return generalNameType ? `SAN ${generalNameLabel(generalNameType)}` : 'SAN';
+        }
+        case FieldType.Extension: {
+            const extensionOid = (field as { extensionOid?: string }).extensionOid;
+            return extensionOid ? `Extension ${extensionOid}` : 'Extension';
+        }
+        default:
+            return field?.fieldType ? String(field.fieldType) : '';
+    }
+}
+
+/** Human summary of where the value lands, e.g. "Subject CN + SAN dNSName". */
+export function fieldMappingSummary(fieldMapping: FieldMapping | undefined): string {
+    const fields = fieldMapping?.fields;
+    if (!Array.isArray(fields) || fields.length === 0) return '';
+    return [...fields]
+        .sort((a, b) => ((a as MappedField)?.order ?? Number.MAX_SAFE_INTEGER) - ((b as MappedField)?.order ?? Number.MAX_SAFE_INTEGER))
+        .map((field) => fieldToken(field as MappedField))
+        .filter((token) => token.length > 0)
+        .join(' + ');
+}


### PR DESCRIPTION
Closes #1779.

## What

On the certificate **Issue** form → **Request Attributes** tab, each request-attribute field now shows a small badge reading **where the value lands** (e.g. `→ Subject CN + SAN dNSName`), driven by the descriptor's `fieldMapping`. Friendly label / required / help text / regex validation were already free via `AttributeEditor`; this adds the "where it lands" affordance.

## How

- **`src/utils/requestAttributes.ts`** (new, Vitest) — `getFieldMapping(descriptor)` and `fieldMappingSummary(fieldMapping)`. Reads `fieldMapping` **defensively**: the generated TS subtypes (`RdnMappedField`/`SanMappedField`/`ExtensionMappedField`) collapse to bare `MappedField`, so `rdn`/`generalNameType`/`extensionOid` are read via guarded access. Unknown `FieldType`/`GeneralNameType` members render their **raw string** rather than crashing or dropping — no hardcoded exhaustive enum switch. Tokens: `rdn`→`Subject <rdn>`, `san`→`SAN <friendly-or-raw>`, `extension`→`Extension <oid>`, sorted by `order`, joined with `" + "`.
- **`src/components/RequestAttributes/RequestAttributeMappingBadge.tsx`** (new, Playwright CT) — renders the shared `Badge` (info, small) with an `Info` icon + `→ {summary}` and a `Maps to: …` tooltip; returns `null` when there's no mapping (this is what hides it for non-request attributes).
- **`AttributeFieldInput.tsx`** — 3-line wire: renders the badge after the field label, gated purely on `fieldMapping` presence, so there's **zero visible change** to any other attribute, tab, or page.
- **Mode A submit unchanged** — the cert form already sends `csrAttributes` + `keyUuid` + `tokenProfileUuid`; that file is untouched on this branch.

## Notes

- The issue's example JSON used mis-cased enums (`"RDN"`, `"DNS_NAME"`); the live spec is lowercase (`rdn`, `dns`). This follows the regenerated `src/types/openapi/**`, per the issue's "confirm against types, don't hardcode" note.
- The External / Mode B branch is out of scope (FE-2).

## Tests

- Vitest: `requestAttributes.spec.ts` — every branch (rdn/san/extension, order sort, unknown-enum fallback, missing sub-field, empty/undefined).
- Playwright CT: `RequestAttributeMappingBadge.spec.tsx` (renders tokens / tooltip title / testid / null) + two integration tests in `AttributeFieldInput.spec.tsx` proving the wired renderer shows the badge for a mapped descriptor and hides it otherwise.
- All green on chromium locally; firefox/webkit run in CI. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)