### PR TITLE
Remove qcStatement from OidCategory

### DIFF
--- a/src/types/openapi/models/OidCategory.ts
+++ b/src/types/openapi/models/OidCategory.ts
@@ -19,7 +19,6 @@
 export enum OidCategory {
     RdnAttributeType = 'rdnAttributeType',
     ExtendedKeyUsage = 'extendedKeyUsage',
-    QcStatement = 'qcStatement',
     CertificateExtension = 'certificateExtension',
     Generic = 'generic',
 }


### PR DESCRIPTION
QC Statement no longer appears as a category for custom OID:
<img width="912" height="762" alt="image" src="https://github.com/user-attachments/assets/d872cda5-6e4a-4e38-aabf-5b0830f17d52" />
