### PR TITLE
Fix SonarCloud reliability & security issues on main

### DIFF
--- a/.github/workflows/publish_docker.yaml
+++ b/.github/workflows/publish_docker.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   publish:
-    uses: OmniTrustILM/.github/.github/workflows/containers-build-and-push.yml@main
+    uses: OmniTrustILM/.github/.github/workflows/containers-build-and-push.yml@50f83b9285f0f12ed0b329696a920c811bf8fe23 # main
     secrets:
       CONTAINER_REGISTRY_USERNAME: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
       CONTAINER_REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}

--- a/.github/workflows/test_docker_image.yaml
+++ b/.github/workflows/test_docker_image.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   test:
-    uses: OmniTrustILM/.github/.github/workflows/containers-test.yml@main
+    uses: OmniTrustILM/.github/.github/workflows/containers-test.yml@50f83b9285f0f12ed0b329696a920c811bf8fe23 # main
     with:
       image: ilm/frontend-administrator
       cache-scope: frontend-administrator

--- a/src/tailwindcss.css
+++ b/src/tailwindcss.css
@@ -1,4 +1,5 @@
 @import 'simplebar-react/dist/simplebar.min.css';
+@import 'tailwindcss';
 
 /* Local Inter variable fonts (replaces Google Fonts) */
 @font-face {
@@ -41,8 +42,6 @@
     --modal-footer-background-color: var(--gray-100);
     --code-color: #be185d;
 }
-
-@import 'tailwindcss';
 
 @theme {
     --color-blue-50: #e6f2ff;


### PR DESCRIPTION
## What

Fixes the three open SonarCloud findings on `main` (1 reliability + 2 security):

| Rule | Severity | File | Fix |
|------|----------|------|-----|
| `css:S8778` | Reliability (MEDIUM) | `src/tailwindcss.css` | Move `@import 'tailwindcss'` to the top so all `@import` rules precede other rules (invalid `@import` position) |
| `githubactions:S7637` | Security (HIGH) | `.github/workflows/publish_docker.yaml` | Pin the reusable workflow to a full commit SHA instead of the mutable `@main` ref |
| `githubactions:S7637` | Security (HIGH) | `.github/workflows/test_docker_image.yaml` | Same — pin to a full commit SHA |

The `OmniTrustILM/.github` reusable workflows are pinned to `50f83b9285f0f12ed0b329696a920c811bf8fe23` (current `main` HEAD), with a trailing `# main` comment for readability.

## Why

- `css:S8778`: the CSS spec requires `@import` rules to appear before all other rules; `@import 'tailwindcss'` was sitting after `:root`/`@font-face`.
- `githubactions:S7637`: referencing an action by a mutable branch (`@main`) is a supply-chain risk — a compromised or changed upstream branch would run in our pipeline. Pinning to an immutable SHA mitigates this.

## Verification

- `npm run build` succeeds.
- Confirmed the built CSS bundle still contains both Tailwind theme variables and simplebar styles, so relocating the `@import` didn't break Tailwind processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)