### PR TITLE
Fix HIGH c-ares CVE in production Docker image (unblocks test-docker CI)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,11 @@ RUN npm run build
 # production environment
 FROM nginxinc/nginx-unprivileged:1.31.2-alpine
 
-# Patch base-image OS packages for known CVEs (c-ares CVE-2026-33630, fixed in 1.34.8-r0)
+# Patch base-image OS packages for known CVEs (c-ares CVE-2026-33630).
+# Pin the minimum fixed version so the build fails fast if the patched package
+# is ever unavailable, keeping the Trivy scan gate reliably green.
 USER root
-RUN apk upgrade --no-cache c-ares
+RUN apk add --no-cache --upgrade "c-ares>=1.34.8-r0"
 USER nginx
 
 WORKDIR /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ RUN npm run build
 # production environment
 FROM nginxinc/nginx-unprivileged:1.31.2-alpine
 
+# Patch base-image OS packages for known CVEs (c-ares CVE-2026-33630, fixed in 1.34.8-r0)
+USER root
+RUN apk upgrade --no-cache c-ares
+USER nginx
+
 WORKDIR /usr/share/nginx/html
 
 ENV API_URL=/api


### PR DESCRIPTION
## Problem

The **`test docker image`** pipeline (`test / Build amd64` / `arm64`) is failing on **every open PR** (e.g. #1855, #1859), not because of any PR's code — the image builds fine — but because the **Trivy** scan gate rejects a base-image CVE:

```
c-ares  CVE-2026-33630  HIGH  fixed  installed 1.34.6-r0 → fixed 1.34.8-r0
Total: 1 (HIGH: 1, CRITICAL: 0)  →  exit code 1
```

The production base image `nginxinc/nginx-unprivileged:1.31.2-alpine` ships `c-ares 1.34.6-r0`, which has **CVE-2026-33630** (HIGH — use-after-free / double-free in query-completion handling), fixed upstream in `1.34.8-r0`.

## Fix

Upgrade `c-ares` in the production stage of the `Dockerfile`. Since `nginx-unprivileged` runs as a non-root user, switch to `root` for the `apk upgrade` and back to the `nginx` user:

```dockerfile
USER root
RUN apk upgrade --no-cache c-ares
USER nginx
```

## Verification

Docker wasn't available in my local environment, so verification is via **this PR's own `test docker image` CI run** — the same build + Trivy scan that was failing. Once green, the HIGH finding is cleared.

## Note

This is an infrastructure/base-image issue independent of feature work — it unblocks all currently-open PRs. Keeping it as its own small PR rather than folding it into an unrelated feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)