### PR TITLE
Use numeric nginx user for Kubernetes deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM nginxinc/nginx-unprivileged:1.31.2-alpine
 # is ever unavailable, keeping the Trivy scan gate reliably green.
 USER root
 RUN apk add --no-cache --upgrade "c-ares>=1.34.8-r0"
-USER nginx
+USER 101
 
 WORKDIR /usr/share/nginx/html
 


### PR DESCRIPTION
## Problem

PR #1860 temporarily switches to `root` to patch `c-ares`, then sets the runtime user to the name `nginx`. Kubernetes cannot verify a named image user for containers configured with `runAsNonRoot: true`, so the deployment fails before startup.

## Fix

Restore the nginx-unprivileged image's numeric runtime UID by changing the final instruction to `USER 101`.

This preserves both the CVE patch and non-root execution while allowing kubelet to validate the image user.

## Verification

- Built the production image successfully
- Confirmed OCI `Config.User` is `101`
- Confirmed runtime UID is `101`
- Confirmed `nginx -t` succeeds