### PR TITLE
Fix request-attribute v3 payloads and static-list authoring

### DIFF
--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -72,6 +72,70 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         expect(parsed.attributes[0].mappingRdnCode).toBe('CN');
     });
 
+    test('static list source requires at least one value, then persists the values', async ({ mount, page }) => {
+        const component = await mount(withProviders(<RequestAttributeAuthoringEditorHarness showMergeMode />));
+
+        await component.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('environment');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+
+        // Pick the static-list value source.
+        await page.getByTestId('select-ra-attr-value-source-trigger').click();
+        await page.getByRole('option', { name: 'Static list' }).click();
+
+        // A static list with no values is invalid → Save disabled.
+        const saveButton = page.getByRole('button', { name: 'Save', exact: true });
+        await expect(saveButton).toBeDisabled();
+
+        // Add two values.
+        await page.getByTestId('request-attribute-authoring-static-value-add').click();
+        await page.locator('#ra-attr-static-value-0').click();
+        await page.locator('#ra-attr-static-value-0').fill('prod');
+        await page.getByTestId('request-attribute-authoring-static-value-add').click();
+        await page.locator('#ra-attr-static-value-1').click();
+        await page.locator('#ra-attr-static-value-1').fill('staging');
+
+        await expect(saveButton).toBeEnabled();
+        await saveButton.click();
+
+        await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toContainText('Static list');
+        const attr = JSON.parse((await component.getByTestId('value-json').textContent()) ?? '{}').attributes[0];
+        expect(attr.valueSourceType).toBe('staticList');
+        expect(attr.staticValues).toEqual(['prod', 'staging']);
+    });
+
+    test('static list rejects duplicate values', async ({ mount, page }) => {
+        const component = await mount(withProviders(<RequestAttributeAuthoringEditorHarness showMergeMode />));
+
+        await component.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('environment');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+
+        await page.getByTestId('select-ra-attr-value-source-trigger').click();
+        await page.getByRole('option', { name: 'Static list' }).click();
+
+        await page.getByTestId('request-attribute-authoring-static-value-add').click();
+        await page.locator('#ra-attr-static-value-0').click();
+        await page.locator('#ra-attr-static-value-0').fill('prod');
+        await page.getByTestId('request-attribute-authoring-static-value-add').click();
+        await page.locator('#ra-attr-static-value-1').click();
+        await page.locator('#ra-attr-static-value-1').fill('prod');
+
+        // Duplicate → error visible and Save disabled.
+        await expect(page.getByTestId('request-attribute-authoring-static-values-duplicate')).toBeVisible();
+        const saveButton = page.getByRole('button', { name: 'Save', exact: true });
+        await expect(saveButton).toBeDisabled();
+
+        // Make the second value unique → error clears, Save enabled.
+        await page.locator('#ra-attr-static-value-1').fill('staging');
+        await expect(page.getByTestId('request-attribute-authoring-static-values-duplicate')).toHaveCount(0);
+        await expect(saveButton).toBeEnabled();
+    });
+
     test('a binding requires a uuid or name before it can be saved', async ({ mount, page }) => {
         const component = await mount(withProviders(<RequestAttributeAuthoringEditorHarness showMergeMode />));
 
@@ -128,6 +192,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
                     readOnly: false,
                     list: false,
                     multiSelect: false,
+                    staticValues: [],
                     valueSourceType: 'none' as const,
                 },
             ],
@@ -158,6 +223,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
                     readOnly: false,
                     list: false,
                     multiSelect: false,
+                    staticValues: [],
                     valueSourceType: 'none' as const,
                 },
             ],

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -81,15 +81,12 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
 
-        // Pick the static-list value source.
         await page.getByTestId('select-ra-attr-value-source-trigger').click();
         await page.getByRole('option', { name: 'Static list' }).click();
 
-        // A static list with no values is invalid → Save disabled.
         const saveButton = page.getByRole('button', { name: 'Save', exact: true });
         await expect(saveButton).toBeDisabled();
 
-        // Add two values.
         await page.getByTestId('request-attribute-authoring-static-value-add').click();
         await page.locator('#ra-attr-static-value-0').click();
         await page.locator('#ra-attr-static-value-0').fill('prod');
@@ -125,15 +122,75 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-static-value-1').click();
         await page.locator('#ra-attr-static-value-1').fill('prod');
 
-        // Duplicate → error visible and Save disabled.
         await expect(page.getByTestId('request-attribute-authoring-static-values-duplicate')).toBeVisible();
         const saveButton = page.getByRole('button', { name: 'Save', exact: true });
         await expect(saveButton).toBeDisabled();
 
-        // Make the second value unique → error clears, Save enabled.
         await page.locator('#ra-attr-static-value-1').fill('staging');
         await expect(page.getByTestId('request-attribute-authoring-static-values-duplicate')).toHaveCount(0);
         await expect(saveButton).toBeEnabled();
+    });
+
+    test('selecting a static list locks the List toggle on', async ({ mount, page }) => {
+        const component = await mount(withProviders(<RequestAttributeAuthoringEditorHarness showMergeMode />));
+
+        await component.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('environment');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+
+        await expect(page.locator('#ra-attr-list')).not.toBeChecked();
+        await expect(page.locator('#ra-attr-list')).toBeEnabled();
+
+        await page.getByTestId('select-ra-attr-value-source-trigger').click();
+        await page.getByRole('option', { name: 'Static list' }).click();
+
+        await expect(page.locator('#ra-attr-list')).toBeChecked();
+        await expect(page.locator('#ra-attr-list')).toBeDisabled();
+
+        await page.getByTestId('request-attribute-authoring-static-value-add').click();
+        await page.locator('#ra-attr-static-value-0').click();
+        await page.locator('#ra-attr-static-value-0').fill('prod');
+        await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+        const attr = JSON.parse((await component.getByTestId('value-json').textContent()) ?? '{}').attributes[0];
+        expect(attr.list).toBe(true);
+        expect(attr.valueSourceType).toBe('staticList');
+    });
+
+    test('does not offer a static list for a content type without a scalar editor', async ({ mount, page }) => {
+        const component = await mount(withProviders(<RequestAttributeAuthoringEditorHarness showMergeMode />));
+
+        await component.getByTestId('request-attribute-authoring-attribute-add').click();
+
+        await page.getByTestId('select-ra-attr-content-type-trigger').click();
+        await page.getByRole('option', { name: 'Secret' }).click();
+
+        // The static-list option must be absent so the editor never dereferences a missing content
+        // configuration and crashes.
+        await page.getByTestId('select-ra-attr-value-source-trigger').click();
+        await expect(page.getByRole('option', { name: 'Static list' })).toHaveCount(0);
+        await expect(page.getByRole('option', { name: 'Free input' })).toBeVisible();
+    });
+
+    test('resets a chosen static list when switching to an unsupported content type', async ({ mount, page }) => {
+        const component = await mount(withProviders(<RequestAttributeAuthoringEditorHarness showMergeMode />));
+
+        await component.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('environment');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+
+        await page.getByTestId('select-ra-attr-value-source-trigger').click();
+        await page.getByRole('option', { name: 'Static list' }).click();
+        await expect(page.getByTestId('request-attribute-authoring-static-values')).toBeVisible();
+
+        // Switching to Secret (no scalar editor) drops back to free input, tearing down the value rows.
+        await page.getByTestId('select-ra-attr-content-type-trigger').click();
+        await page.getByRole('option', { name: 'Secret' }).click();
+        await expect(page.getByTestId('request-attribute-authoring-static-values')).toHaveCount(0);
     });
 
     test('a binding requires a uuid or name before it can be saved', async ({ mount, page }) => {

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -2,10 +2,15 @@ import Button from 'components/Button';
 import Checkbox from 'components/Checkbox';
 import Container from 'components/Container';
 import Dialog from 'components/Dialog';
+import { AddCustomValueInput } from 'components/Input/DynamicContent/AddCustomValueInput';
+import { ContentFieldConfiguration } from 'components/Input/DynamicContent';
+import Label from 'components/Label';
 import RadioRow from 'components/RadioRow';
 import Select from 'components/Select';
 import TextInput from 'components/TextInput';
+import { Plus } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import { getStepValue } from 'utils/common-utils';
 import {
     AttributeContentType,
     AttributeSetMergeMode,
@@ -18,15 +23,13 @@ import {
 import {
     emptyAuthoredAttribute,
     emptyValueSourceBinding,
+    hasDuplicateStaticValues,
     isAuthoredAttributeValid,
     isValueSourceBindingValid,
     type AuthoredAttributeFormValues,
     type RequestAttributeAuthoringFormValues,
     type ValueSourceBindingFormValues,
 } from 'utils/requestAttributeAuthoring';
-
-/** Sentinel value for the COLLECTION source that is stubbed for now (no enum member yet). */
-const COLLECTION_STUB = '__collection_stub__';
 
 const MERGE_MODE_OPTIONS: { value: AttributeSetMergeMode; label: string }[] = [
     { value: AttributeSetMergeMode.StaticOnly, label: 'Static only' },
@@ -64,7 +67,6 @@ const ENCODING_OPTIONS = Object.values(ExtensionValueEncoding).map((v) => ({ val
 const VALUE_SOURCE_OPTIONS = [
     { value: ValueSourceType.None, label: 'Free input' },
     { value: ValueSourceType.StaticList, label: 'Static list' },
-    { value: COLLECTION_STUB, label: 'Collection (coming soon)', disabled: true },
 ];
 
 function valueSourceLabel(type: ValueSourceType): string {
@@ -239,7 +241,7 @@ export default function RequestAttributeAuthoringEditor({
                     id="ra-attr-content-type"
                     label="Content type"
                     value={d.contentType}
-                    onChange={(v) => set({ contentType: v as AttributeContentType })}
+                    onChange={(v) => set({ contentType: v as AttributeContentType, staticValues: [] })}
                     options={CONTENT_TYPE_OPTIONS}
                 />
                 <Container className="flex-row items-center" gap={4}>
@@ -334,12 +336,72 @@ export default function RequestAttributeAuthoringEditor({
                     id="ra-attr-value-source"
                     label="Value source"
                     value={d.valueSourceType}
-                    onChange={(v) => {
-                        if (v === COLLECTION_STUB) return; // stubbed for now
-                        set({ valueSourceType: v as ValueSourceType });
-                    }}
+                    onChange={(v) => set({ valueSourceType: v as ValueSourceType })}
                     options={VALUE_SOURCE_OPTIONS}
                 />
+                {d.valueSourceType === ValueSourceType.StaticList && renderStaticValues(d, set)}
+            </div>
+        );
+    };
+
+    // The static list options a requester picks from. Stored in the attribute `content` array
+    // (ValueSource carries no values); each input is typed by the attribute's content type,
+    // mirroring the custom-attribute "Add Content" UI.
+    const renderStaticValues = (d: AuthoredAttributeFormValues, set: (p: Partial<AuthoredAttributeFormValues>) => void) => {
+        const inputType = ContentFieldConfiguration[d.contentType].type;
+        const addValue = () => set({ staticValues: [...d.staticValues, ContentFieldConfiguration[d.contentType].initial] });
+        const setValueAt = (index: number, next: string | number | boolean) =>
+            set({ staticValues: d.staticValues.map((v, i) => (i === index ? next : v)) });
+        const removeValueAt = (index: number) => set({ staticValues: d.staticValues.filter((_, i) => i !== index) });
+        return (
+            <div className="space-y-2" data-testid={`${dataTestId}-static-values`}>
+                <Label htmlFor={`${dataTestId}-static-value-add`}>Static list values</Label>
+                {d.staticValues.map((v, index) => (
+                    <div key={index} className="flex items-center gap-2" data-testid={`${dataTestId}-static-value-row`}>
+                        <div className="flex-1">
+                            <AddCustomValueInput
+                                id={`ra-attr-static-value-${index}`}
+                                inputType={inputType}
+                                contentType={d.contentType}
+                                fieldStepValue={getStepValue(inputType)}
+                                value={v}
+                                onChange={(next) => setValueAt(index, next)}
+                                readOnly={disabled}
+                            />
+                        </div>
+                        <Button
+                            variant="outline"
+                            color="danger"
+                            onClick={() => removeValueAt(index)}
+                            disabled={disabled}
+                            type="button"
+                            data-testid={`${dataTestId}-static-value-remove`}
+                        >
+                            Remove
+                        </Button>
+                    </div>
+                ))}
+                {d.staticValues.length === 0 && (
+                    <p className="text-sm text-gray-400" data-testid={`${dataTestId}-static-values-empty`}>
+                        Add at least one value for the static list.
+                    </p>
+                )}
+                {hasDuplicateStaticValues(d.staticValues) && (
+                    <p className="text-sm text-red-600" data-testid={`${dataTestId}-static-values-duplicate`}>
+                        Static list values must be unique.
+                    </p>
+                )}
+                <Button
+                    variant="transparent"
+                    className="text-blue-600"
+                    onClick={addValue}
+                    disabled={disabled}
+                    type="button"
+                    data-testid={`${dataTestId}-static-value-add`}
+                >
+                    <Plus className="w-4 h-4" />
+                    Add value
+                </Button>
             </div>
         );
     };
@@ -462,10 +524,7 @@ export default function RequestAttributeAuthoringEditor({
                     id="ra-binding-value-source"
                     label="Value source"
                     value={d.valueSourceType}
-                    onChange={(v) => {
-                        if (v === COLLECTION_STUB) return;
-                        set({ valueSourceType: v as ValueSourceType });
-                    }}
+                    onChange={(v) => set({ valueSourceType: v as ValueSourceType })}
                     options={VALUE_SOURCE_OPTIONS}
                 />
                 {!bindingValid && (

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -25,6 +25,7 @@ import {
     emptyValueSourceBinding,
     hasDuplicateStaticValues,
     isAuthoredAttributeValid,
+    isStaticListSupportedForContentType,
     isValueSourceBindingValid,
     type AuthoredAttributeFormValues,
     type RequestAttributeAuthoringFormValues,
@@ -68,6 +69,9 @@ const VALUE_SOURCE_OPTIONS = [
     { value: ValueSourceType.None, label: 'Free input' },
     { value: ValueSourceType.StaticList, label: 'Static list' },
 ];
+
+// Offered when the content type has no scalar editor — a static list can't be authored there.
+const FREE_INPUT_ONLY_OPTIONS = VALUE_SOURCE_OPTIONS.slice(0, 1);
 
 function valueSourceLabel(type: ValueSourceType): string {
     return VALUE_SOURCE_OPTIONS.find((o) => o.value === type)?.label ?? 'Free input';
@@ -241,16 +245,28 @@ export default function RequestAttributeAuthoringEditor({
                     id="ra-attr-content-type"
                     label="Content type"
                     value={d.contentType}
-                    onChange={(v) => set({ contentType: v as AttributeContentType, staticValues: [] })}
+                    onChange={(v) => {
+                        const contentType = v as AttributeContentType;
+                        // Static list is only authorable for scalar content types; drop back to free
+                        // input if the new type can't carry one, so we never render a missing editor.
+                        const keepStaticList = isStaticListSupportedForContentType(contentType);
+                        set({
+                            contentType,
+                            staticValues: [],
+                            valueSourceType: keepStaticList ? d.valueSourceType : ValueSourceType.None,
+                        });
+                    }}
                     options={CONTENT_TYPE_OPTIONS}
                 />
                 <Container className="flex-row items-center" gap={4}>
                     <Checkbox id="ra-attr-required" checked={d.required} onChange={(c) => set({ required: c })} label="Required" />
                     <Checkbox
                         id="ra-attr-list"
-                        checked={d.list}
+                        checked={d.list || d.valueSourceType === ValueSourceType.StaticList}
                         onChange={(c) => set({ list: c, multiSelect: c ? d.multiSelect : false })}
                         label="List"
+                        // A static list is inherently a list attribute — locked on while it's selected.
+                        disabled={d.valueSourceType === ValueSourceType.StaticList}
                     />
                     <Checkbox
                         id="ra-attr-multi"
@@ -336,8 +352,13 @@ export default function RequestAttributeAuthoringEditor({
                     id="ra-attr-value-source"
                     label="Value source"
                     value={d.valueSourceType}
-                    onChange={(v) => set({ valueSourceType: v as ValueSourceType })}
-                    options={VALUE_SOURCE_OPTIONS}
+                    onChange={(v) => {
+                        const valueSourceType = v as ValueSourceType;
+                        // Selecting a static list forces `list` on (see DTO builder) so the toggle and
+                        // the authored options never disagree.
+                        set({ valueSourceType, ...(valueSourceType === ValueSourceType.StaticList ? { list: true } : {}) });
+                    }}
+                    options={isStaticListSupportedForContentType(d.contentType) ? VALUE_SOURCE_OPTIONS : FREE_INPUT_ONLY_OPTIONS}
                 />
                 {d.valueSourceType === ValueSourceType.StaticList && renderStaticValues(d, set)}
             </div>
@@ -348,14 +369,20 @@ export default function RequestAttributeAuthoringEditor({
     // (ValueSource carries no values); each input is typed by the attribute's content type,
     // mirroring the custom-attribute "Add Content" UI.
     const renderStaticValues = (d: AuthoredAttributeFormValues, set: (p: Partial<AuthoredAttributeFormValues>) => void) => {
-        const inputType = ContentFieldConfiguration[d.contentType].type;
-        const addValue = () => set({ staticValues: [...d.staticValues, ContentFieldConfiguration[d.contentType].initial] });
+        // Guard the lookup: value-source options are already filtered to configured content types, so
+        // this only trips if a content type without a scalar editor slips through — render nothing
+        // rather than dereference a missing configuration.
+        const config = ContentFieldConfiguration[d.contentType];
+        if (!config) return null;
+        const inputType = config.type;
+        const addValue = () => set({ staticValues: [...d.staticValues, config.initial] });
         const setValueAt = (index: number, next: string | number | boolean) =>
             set({ staticValues: d.staticValues.map((v, i) => (i === index ? next : v)) });
         const removeValueAt = (index: number) => set({ staticValues: d.staticValues.filter((_, i) => i !== index) });
         return (
             <div className="space-y-2" data-testid={`${dataTestId}-static-values`}>
-                <Label htmlFor={`${dataTestId}-static-value-add`}>Static list values</Label>
+                {/* Group label for the value rows below — not tied to a single input's id. */}
+                <Label>Static list values</Label>
                 {d.staticValues.map((v, index) => (
                     <div key={index} className="flex items-center gap-2" data-testid={`${dataTestId}-static-value-row`}>
                         <div className="flex-1">

--- a/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.spec.tsx
+++ b/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.spec.tsx
@@ -12,7 +12,7 @@ test.describe('RequestAttributesSettings (platform default set)', () => {
         await expect(component.getByTestId('request-attribute-authoring-merge-mode')).toHaveCount(0);
         await expect(component.getByTestId('request-attribute-authoring-bindings')).toHaveCount(0);
         await expect(component.getByTestId('request-attribute-authoring-attributes-empty')).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Save Default Request Attributes' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
     });
 
     test('authoring an attribute then saving runs the save handler', async ({ mount, page }) => {
@@ -26,12 +26,12 @@ test.describe('RequestAttributesSettings (platform default set)', () => {
         await page.locator('#ra-attr-name').fill('environment');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
-        await page.getByRole('button', { name: 'Save', exact: true }).click();
+        await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
 
         await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toContainText('Environment');
 
         // Save handler builds the platform DTO and dispatches without throwing.
-        await page.getByRole('button', { name: 'Save Default Request Attributes' }).click();
-        await expect(page.getByRole('button', { name: 'Save Default Request Attributes' })).toBeVisible();
+        await page.getByRole('button', { name: 'Save', exact: true }).click();
+        await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
     });
 });

--- a/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.tsx
+++ b/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.tsx
@@ -67,7 +67,7 @@ export default function RequestAttributesSettings() {
                 {editor}
                 <Container className="flex-row justify-end" gap={4}>
                     <ProgressButton
-                        title="Save Default Request Attributes"
+                        title="Save"
                         inProgressTitle="Saving..."
                         inProgress={isUpdating}
                         disabled={!loaded}

--- a/src/utils/requestAttributeAuthoring.spec.ts
+++ b/src/utils/requestAttributeAuthoring.spec.ts
@@ -24,6 +24,7 @@ import {
     emptyValueSourceBinding,
     isAuthoredAttributeMappingValid,
     isAuthoredAttributeValid,
+    isStaticListSupportedForContentType,
     isValueSourceBindingValid,
     parseAuthoredAttributeDto,
     parsePlatformDefaultDto,
@@ -174,6 +175,107 @@ describe('requestAttributeAuthoring', () => {
         test('omits content when STATIC_LIST has no values', () => {
             const dto = buildAuthoredAttributeDto({ ...baseAttr(), valueSourceType: ValueSourceType.StaticList, staticValues: [] });
             expect(dto.content).toBeUndefined();
+        });
+
+        test('forces properties.list on for a STATIC_LIST even when the toggle is off', () => {
+            const dto = buildAuthoredAttributeDto({
+                ...baseAttr(),
+                list: false,
+                valueSourceType: ValueSourceType.StaticList,
+                staticValues: ['prod'],
+            });
+            expect(dto.properties.list).toBe(true);
+        });
+
+        test('leaves properties.list under the toggle when the source is not STATIC_LIST', () => {
+            expect(buildAuthoredAttributeDto({ ...baseAttr(), list: false }).properties.list).toBe(false);
+            expect(buildAuthoredAttributeDto({ ...baseAttr(), list: true }).properties.list).toBe(true);
+        });
+
+        test('trims string static values written to content', () => {
+            const dto = buildAuthoredAttributeDto({
+                ...baseAttr(),
+                contentType: AttributeContentType.String,
+                valueSourceType: ValueSourceType.StaticList,
+                staticValues: ['  prod  ', 'staging'],
+            });
+            expect(dto.content).toEqual([
+                { data: 'prod', contentType: AttributeContentType.String },
+                { data: 'staging', contentType: AttributeContentType.String },
+            ]);
+        });
+
+        test('coerces integer static values to numbers (including the untouched string default)', () => {
+            const dto = buildAuthoredAttributeDto({
+                ...baseAttr(),
+                contentType: AttributeContentType.Integer,
+                valueSourceType: ValueSourceType.StaticList,
+                staticValues: ['0', 3, '  5 '],
+            });
+            expect(dto.content).toEqual([
+                { data: 0, contentType: AttributeContentType.Integer },
+                { data: 3, contentType: AttributeContentType.Integer },
+                { data: 5, contentType: AttributeContentType.Integer },
+            ]);
+            (dto.content ?? []).forEach((item) => {
+                expect(typeof (item as { data: unknown }).data).toBe('number');
+            });
+        });
+
+        test('coerces float static values to numbers', () => {
+            const dto = buildAuthoredAttributeDto({
+                ...baseAttr(),
+                contentType: AttributeContentType.Float,
+                valueSourceType: ValueSourceType.StaticList,
+                staticValues: ['0', '1.5'],
+            });
+            expect(dto.content).toEqual([
+                { data: 0, contentType: AttributeContentType.Float },
+                { data: 1.5, contentType: AttributeContentType.Float },
+            ]);
+        });
+
+        test('coerces boolean static values to booleans', () => {
+            const dto = buildAuthoredAttributeDto({
+                ...baseAttr(),
+                contentType: AttributeContentType.Boolean,
+                valueSourceType: ValueSourceType.StaticList,
+                staticValues: [true, 'false'],
+            });
+            expect(dto.content).toEqual([
+                { data: true, contentType: AttributeContentType.Boolean },
+                { data: false, contentType: AttributeContentType.Boolean },
+            ]);
+        });
+    });
+
+    describe('isStaticListSupportedForContentType', () => {
+        test('true for scalar content types with an authoring input', () => {
+            [
+                AttributeContentType.String,
+                AttributeContentType.Text,
+                AttributeContentType.Integer,
+                AttributeContentType.Float,
+                AttributeContentType.Boolean,
+                AttributeContentType.Date,
+                AttributeContentType.Time,
+                AttributeContentType.Datetime,
+            ].forEach((ct) => {
+                expect(isStaticListSupportedForContentType(ct)).toBe(true);
+            });
+        });
+
+        test('false for content types without a scalar authoring input', () => {
+            [
+                AttributeContentType.Secret,
+                AttributeContentType.File,
+                AttributeContentType.Credential,
+                AttributeContentType.Codeblock,
+                AttributeContentType.Object,
+                AttributeContentType.Resource,
+            ].forEach((ct) => {
+                expect(isStaticListSupportedForContentType(ct)).toBe(false);
+            });
         });
     });
 

--- a/src/utils/requestAttributeAuthoring.spec.ts
+++ b/src/utils/requestAttributeAuthoring.spec.ts
@@ -71,6 +71,7 @@ describe('requestAttributeAuthoring', () => {
             const dto = buildAuthoredAttributeDto(baseAttr());
             expect(dto.type).toBe(AttributeType.Data);
             expect(dto.schemaVersion).toBe(AttributeVersion.V3);
+            expect(dto.version).toBe(3);
             expect(dto.name).toBe('serverFqdn');
             expect(dto.contentType).toBe(AttributeContentType.String);
             expect(dto.properties.label).toBe('Server FQDN');
@@ -152,6 +153,28 @@ describe('requestAttributeAuthoring', () => {
             const dto = buildAuthoredAttributeDto({ ...baseAttr(), valueSourceType: ValueSourceType.StaticList });
             expect(dto.valueSource?.kind).toBe(ValueSourceType.StaticList);
         });
+
+        test('writes the static list values into content, typed by contentType', () => {
+            const dto = buildAuthoredAttributeDto({
+                ...baseAttr(),
+                valueSourceType: ValueSourceType.StaticList,
+                staticValues: ['prod', 'staging'],
+            });
+            expect(dto.content).toEqual([
+                { data: 'prod', contentType: AttributeContentType.String },
+                { data: 'staging', contentType: AttributeContentType.String },
+            ]);
+        });
+
+        test('omits content when the value source is not STATIC_LIST', () => {
+            const dto = buildAuthoredAttributeDto({ ...baseAttr(), valueSourceType: ValueSourceType.None, staticValues: ['x'] });
+            expect(dto.content).toBeUndefined();
+        });
+
+        test('omits content when STATIC_LIST has no values', () => {
+            const dto = buildAuthoredAttributeDto({ ...baseAttr(), valueSourceType: ValueSourceType.StaticList, staticValues: [] });
+            expect(dto.content).toBeUndefined();
+        });
     });
 
     describe('parseAuthoredAttributeDto round-trip', () => {
@@ -176,6 +199,17 @@ describe('requestAttributeAuthoring', () => {
             expect(parsed.mappingRdnCode).toBe('CN');
             expect(parsed.valueSourceType).toBe(ValueSourceType.StaticList);
             expect(parsed.uuid).toBe('u1');
+        });
+
+        test('round-trips STATIC_LIST values through content', () => {
+            const parsed = parseAuthoredAttributeDto(
+                buildAuthoredAttributeDto({
+                    ...baseAttr(),
+                    valueSourceType: ValueSourceType.StaticList,
+                    staticValues: ['prod', 'staging'],
+                }) as BaseAttributeDto,
+            );
+            expect(parsed.staticValues).toEqual(['prod', 'staging']);
         });
 
         test('round-trips a SAN otherName mapping', () => {
@@ -250,6 +284,36 @@ describe('requestAttributeAuthoring', () => {
             expect(isAuthoredAttributeValid({ ...baseAttr(), name: '', label: 'X' })).toBe(false);
             expect(isAuthoredAttributeValid({ ...baseAttr(), name: 'x', label: '' })).toBe(false);
             expect(isAuthoredAttributeValid(baseAttr())).toBe(true);
+        });
+
+        test('STATIC_LIST requires at least one value', () => {
+            expect(isAuthoredAttributeValid({ ...baseAttr(), valueSourceType: ValueSourceType.StaticList, staticValues: [] })).toBe(false);
+            expect(isAuthoredAttributeValid({ ...baseAttr(), valueSourceType: ValueSourceType.StaticList, staticValues: ['prod'] })).toBe(
+                true,
+            );
+        });
+
+        test('STATIC_LIST rejects blank string values', () => {
+            expect(isAuthoredAttributeValid({ ...baseAttr(), valueSourceType: ValueSourceType.StaticList, staticValues: ['  '] })).toBe(
+                false,
+            );
+        });
+
+        test('STATIC_LIST rejects duplicate values', () => {
+            expect(
+                isAuthoredAttributeValid({
+                    ...baseAttr(),
+                    valueSourceType: ValueSourceType.StaticList,
+                    staticValues: ['prod', 'prod'],
+                }),
+            ).toBe(false);
+            expect(
+                isAuthoredAttributeValid({
+                    ...baseAttr(),
+                    valueSourceType: ValueSourceType.StaticList,
+                    staticValues: ['prod', 'staging'],
+                }),
+            ).toBe(true);
         });
     });
 

--- a/src/utils/requestAttributeAuthoring.ts
+++ b/src/utils/requestAttributeAuthoring.ts
@@ -64,6 +64,12 @@ export interface AuthoredAttributeFormValues {
     mappingCriticalOverridable?: boolean;
     /** How Core resolves the value; NONE = free input. */
     valueSourceType: ValueSourceType;
+    /**
+     * Static list options — the values a requester picks from when valueSourceType === STATIC_LIST.
+     * Persisted in the attribute's `content` array (ValueSource itself carries no values). Typed by
+     * `contentType`, mirroring how custom attributes store predefined content.
+     */
+    staticValues: (string | number | boolean)[];
     /** Reserved for the COLLECTION source (stubbed for now). */
     collectionRef?: string;
     /** Cascading dependency params, preserved on round-trip (no authoring UI yet). */
@@ -117,6 +123,7 @@ export function emptyAuthoredAttribute(): AuthoredAttributeFormValues {
         mappingExtensionOid: '',
         mappingCriticalOverridable: false,
         valueSourceType: ValueSourceType.None,
+        staticValues: [],
         collectionRef: '',
     };
 }
@@ -202,7 +209,7 @@ export function buildAuthoredAttributeDto(form: AuthoredAttributeFormValues): Da
         uuid: form.uuid || generateUuid(),
         name: form.name,
         description: form.description || undefined,
-        version: 1,
+        version: 3,
         type: AttributeType.Data,
         contentType: form.contentType,
         properties,
@@ -217,6 +224,9 @@ export function buildAuthoredAttributeDto(form: AuthoredAttributeFormValues): Da
     const valueSource = buildValueSource(form);
     if (valueSource) {
         dto.valueSource = valueSource;
+    }
+    if (form.valueSourceType === ValueSourceType.StaticList && form.staticValues.length > 0) {
+        dto.content = form.staticValues.map((data) => ({ data, contentType: form.contentType })) as DataAttributeV3['content'];
     }
     return dto;
 }
@@ -250,6 +260,7 @@ export function parseAuthoredAttributeDto(dto: BaseAttributeDto): AuthoredAttrib
         mappingExtensionOid: ext?.extensionOid ?? '',
         mappingCriticalOverridable: ext?.criticalOverridable ?? false,
         valueSourceType: view.valueSource?.kind ?? ValueSourceType.None,
+        staticValues: (view.content ?? []).map((item) => (item as { data: string | number | boolean }).data),
         collectionRef: '',
         valueSourceParams: view.valueSource?.params,
     };
@@ -278,8 +289,41 @@ export function isAuthoredAttributeMappingValid(form: AuthoredAttributeFormValue
     }
 }
 
+/** Normalize a static value for equality comparison — strings compared trimmed, others by value. */
+function normalizeStaticValue(v: string | number | boolean): string {
+    return typeof v === 'string' ? v.trim() : String(v);
+}
+
+/** True when the same value appears more than once (strings compared trimmed). */
+export function hasDuplicateStaticValues(values: (string | number | boolean)[]): boolean {
+    const seen = new Set<string>();
+    for (const v of values) {
+        const key = normalizeStaticValue(v);
+        if (seen.has(key)) {
+            return true;
+        }
+        seen.add(key);
+    }
+    return false;
+}
+
+/**
+ * A STATIC_LIST source needs at least one option, no option may be a blank string, and the
+ * options must be unique.
+ */
+export function isStaticListValid(form: AuthoredAttributeFormValues): boolean {
+    if (form.valueSourceType !== ValueSourceType.StaticList) {
+        return true;
+    }
+    return (
+        form.staticValues.length > 0 &&
+        form.staticValues.every((v) => typeof v !== 'string' || v.trim() !== '') &&
+        !hasDuplicateStaticValues(form.staticValues)
+    );
+}
+
 export function isAuthoredAttributeValid(form: AuthoredAttributeFormValues): boolean {
-    return !!form.name.trim() && !!form.label.trim() && isAuthoredAttributeMappingValid(form);
+    return !!form.name.trim() && !!form.label.trim() && isAuthoredAttributeMappingValid(form) && isStaticListValid(form);
 }
 
 export function isValueSourceBindingValid(form: ValueSourceBindingFormValues): boolean {

--- a/src/utils/requestAttributeAuthoring.ts
+++ b/src/utils/requestAttributeAuthoring.ts
@@ -98,6 +98,26 @@ export interface RequestAttributeAuthoringFormValues {
 
 export const DEFAULT_MERGE_MODE = AttributeSetMergeMode.Merge;
 
+/**
+ * Content types a static list can be authored for — the scalar types with a concrete input in the
+ * authoring UI. The remaining types (secret/file/credential/codeblock/object/resource) have no
+ * scalar editor, so a static pick-list is neither meaningful nor renderable for them.
+ */
+export const STATIC_LIST_CONTENT_TYPES: readonly AttributeContentType[] = [
+    AttributeContentType.String,
+    AttributeContentType.Text,
+    AttributeContentType.Integer,
+    AttributeContentType.Float,
+    AttributeContentType.Boolean,
+    AttributeContentType.Date,
+    AttributeContentType.Time,
+    AttributeContentType.Datetime,
+];
+
+export function isStaticListSupportedForContentType(contentType: AttributeContentType): boolean {
+    return STATIC_LIST_CONTENT_TYPES.includes(contentType);
+}
+
 function generateUuid(): string {
     // crypto.randomUUID is available in all supported browsers and the test env; using it
     // (never Math.random) keeps the generated identifier cryptographically sound.
@@ -194,13 +214,39 @@ function buildValueSource(form: AuthoredAttributeFormValues): ValueSource | unde
     return source;
 }
 
+/**
+ * Coerce an authored static value into the runtime type Core expects for the attribute's content
+ * type: numbers for integer/float (the number input can leave the untouched initial `'0'` as a
+ * string), a boolean for boolean, and a trimmed string otherwise — so the persisted `content`
+ * matches the blank/uniqueness rules that compare trimmed.
+ */
+function normalizeStaticContentValue(value: string | number | boolean, contentType: AttributeContentType): string | number | boolean {
+    switch (contentType) {
+        case AttributeContentType.Integer: {
+            const n = typeof value === 'number' ? value : Number.parseInt(String(value).trim(), 10);
+            return Number.isNaN(n) ? 0 : Math.trunc(n);
+        }
+        case AttributeContentType.Float: {
+            const n = typeof value === 'number' ? value : Number.parseFloat(String(value).trim());
+            return Number.isNaN(n) ? 0 : n;
+        }
+        case AttributeContentType.Boolean:
+            return typeof value === 'boolean' ? value : String(value).trim().toLowerCase() === 'true';
+        default:
+            return typeof value === 'string' ? value.trim() : value;
+    }
+}
+
 export function buildAuthoredAttributeDto(form: AuthoredAttributeFormValues): DataAttributeV3 {
+    // A static list presents a predefined set of options, so it is a list attribute by definition —
+    // force `list` on regardless of the toggle so the DTO does not contradict the content array.
+    const isStaticList = form.valueSourceType === ValueSourceType.StaticList;
     const properties: DataAttributeProperties = {
         label: form.label,
         visible: true,
         required: form.required,
         readOnly: form.readOnly,
-        list: form.list,
+        list: isStaticList ? true : form.list,
         multiSelect: form.multiSelect,
         extensibleList: false,
     };
@@ -225,8 +271,11 @@ export function buildAuthoredAttributeDto(form: AuthoredAttributeFormValues): Da
     if (valueSource) {
         dto.valueSource = valueSource;
     }
-    if (form.valueSourceType === ValueSourceType.StaticList && form.staticValues.length > 0) {
-        dto.content = form.staticValues.map((data) => ({ data, contentType: form.contentType })) as DataAttributeV3['content'];
+    if (isStaticList && form.staticValues.length > 0) {
+        dto.content = form.staticValues.map((value) => ({
+            data: normalizeStaticContentValue(value, form.contentType),
+            contentType: form.contentType,
+        })) as DataAttributeV3['content'];
     }
     return dto;
 }


### PR DESCRIPTION
Follow-ups to the RA-Profile / platform-settings request-attribute editor (#1855).

## Changes

- **Fix outgoing attribute `version`** — `buildAuthoredAttributeDto` hardcoded `version: 1`, but a `DataAttributeV3` must send numeric **`version: 3`** to match `schemaVersion=v3` (Core rejected `1`). Fixes the save for **both** the RA-Profile form and platform settings (single shared builder).
- **Static-list value authoring** — when the value source is *Static list*, the dialog now lets you author the list options. Values persist in the attribute's **`content`** array (the live Core `ValueSource` schema carries only `kind`+`params`, no values field), typed by the attribute's Content Type by reusing `AddCustomValueInput` + `ContentFieldConfiguration`. Save is gated on ≥1 non-blank value.
- **Unique values** — duplicate static-list values are rejected (`hasDuplicateStaticValues`, strings compared trimmed) with an inline *"Static list values must be unique."* error.
- **Remove the "Collection (coming soon)" stub** — deleted the disabled option, the `COLLECTION_STUB` sentinel, and its now-dead `onChange` guards.
- **Shorten the platform-settings save button** to **"Save"** (the Widget is already titled *"Default Request Attributes"*).

## Scope note

The value-source **binding** dialog was left `kind`-only for Static list — a binding only references a connector attribute (UUID/name) + `kind`/`params` and has no `content` to store values in, so static-list persistence there is an architect/backend question, not something invented here.

## Testing

- **Vitest** — build/parse of `content`, `version: 3`, and validation (≥1 value, no blanks, uniqueness). 46 pass.
- **Playwright CT** — authoring a static list, save-gating, and duplicate rejection flows. Editor + platform-settings specs green.
- Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)