### PR TITLE
Preserve extensible object list values

### DIFF
--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldSelect.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldSelect.spec.tsx
@@ -349,10 +349,7 @@ test.describe('AttributeFieldSelect', () => {
             contentType: AttributeContentType.Object,
             properties: { ...defaultProperties, list: true, extensibleList: true, label: 'PKI Engine' },
         } as any);
-        const currentEngine = {
-            label: 'Legacy Engine',
-            value: { reference: 'Legacy Engine', data: { engineName: 'legacy-pki' } },
-        };
+        const currentEngine = { reference: 'Legacy Engine', data: { engineName: 'legacy-pki' } };
 
         await mount(
             <AttributeFieldSelectTestWrapper

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldSelect.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldSelect.spec.tsx
@@ -344,6 +344,65 @@ test.describe('AttributeFieldSelect', () => {
         await expect(page.getByRole('option', { name: 'extra' })).toBeVisible();
     });
 
+    test('extensible object list preserves a structured current value not in options', async ({ mount, page }) => {
+        const descriptor = minimalDescriptor({
+            contentType: AttributeContentType.Object,
+            properties: { ...defaultProperties, list: true, extensibleList: true, label: 'PKI Engine' },
+        } as any);
+        const currentEngine = {
+            label: 'Legacy Engine',
+            value: { reference: 'Legacy Engine', data: { engineName: 'legacy-pki' } },
+        };
+
+        await mount(
+            <AttributeFieldSelectTestWrapper
+                name="testSelect"
+                descriptor={descriptor}
+                options={[{ label: 'Known Engine', value: { reference: 'Known Engine', data: { engineName: 'known-pki' } } } as any]}
+                defaultValues={{ testSelect: currentEngine }}
+            />,
+        );
+
+        await page.getByTestId('select-testSelectSelect-trigger').click();
+        await expect(page.getByRole('option', { name: 'Known Engine' })).toBeVisible();
+        await expect(page.getByRole('option', { name: 'Legacy Engine' })).toBeVisible();
+    });
+
+    test('extensible object list matches structured values independent of property order', async ({ mount, page }) => {
+        const descriptor = minimalDescriptor({
+            contentType: AttributeContentType.Object,
+            properties: { ...defaultProperties, list: true, extensibleList: true, label: 'PKI Engine' },
+        } as any);
+        const currentEngine = {
+            label: 'Duplicate Engine',
+            value: { data: { engineName: 'known-pki' }, reference: 'Known Engine' },
+        };
+
+        await mount(
+            <AttributeFieldSelectTestWrapper
+                name="testSelect"
+                descriptor={descriptor}
+                options={[{ label: 'Known Engine', value: { reference: 'Known Engine', data: { engineName: 'known-pki' } } } as any]}
+                defaultValues={{ testSelect: currentEngine }}
+            />,
+        );
+
+        await page.getByTestId('select-testSelectSelect-trigger').click();
+        await expect(page.getByRole('option', { name: 'Known Engine' })).toBeVisible();
+        await expect(page.getByRole('option', { name: 'Duplicate Engine' })).toHaveCount(0);
+    });
+
+    test('extensible object list does not offer schema-less custom text input', async ({ mount, page }) => {
+        const descriptor = minimalDescriptor({
+            contentType: AttributeContentType.Object,
+            properties: { ...defaultProperties, list: true, extensibleList: true, label: 'PKI Engine' },
+        } as any);
+
+        await mount(<AttributeFieldSelectTestWrapper name="testSelect" descriptor={descriptor} />);
+
+        await expect(page.getByRole('button', { name: 'Add custom value' })).toHaveCount(0);
+    });
+
     test('extensible list multi-select adds extra options for current values not in options', async ({ mount, page }) => {
         const descriptor = minimalDescriptor({
             properties: { ...defaultProperties, multiSelect: true, extensibleList: true, label: 'Extensible Multi' },

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldSelect.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldSelect.tsx
@@ -1,12 +1,13 @@
 import type React from 'react';
 import { useCallback, useRef, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import Select from 'components/Select';
+import Select, { getOptionValueString } from 'components/Select';
 import Label from 'components/Label';
 import Button from 'components/Button';
 import { AddCustomValuePanel } from 'components/Input/DynamicContent/AddCustomValuePanel';
 import { Plus } from 'lucide-react';
 import type { CustomAttributeModel, DataAttributeModel } from 'types/attributes';
+import { AttributeContentType } from 'types/openapi';
 import { getSelectValueFromField, buildAttributeValidators, parseListValueByContentType } from './attributeHelpers';
 
 type AttributeFieldSelectProps = {
@@ -19,6 +20,26 @@ type AttributeFieldSelectProps = {
     onSelectChangeMulti: (fieldOnChange: (v: any) => void) => (newValue: any) => void;
     onSelectChangeSingle: (fieldOnChange: (v: any) => void) => (newValue: any) => void;
 };
+
+function unwrapSelectValue(value: any): any {
+    return value && typeof value === 'object' && 'value' in value ? value.value : value;
+}
+
+function getSelectValueIdentity(value: any): string {
+    return getOptionValueString(unwrapSelectValue(value));
+}
+
+function getExtraOption(value: any): { label: string; value: any } {
+    const rawValue = unwrapSelectValue(value);
+    if (value && typeof value === 'object' && 'label' in value) {
+        return { label: String(value.label), value: rawValue };
+    }
+    if (rawValue && typeof rawValue === 'object') {
+        const label = rawValue.reference ?? rawValue.data?.name ?? rawValue.data?.engineName ?? JSON.stringify(rawValue.data ?? rawValue);
+        return { label: String(label), value: rawValue };
+    }
+    return { label: String(rawValue), value: rawValue };
+}
 
 export function AttributeFieldSelect({
     name,
@@ -67,10 +88,10 @@ export function AttributeFieldSelect({
                 } else {
                     currentValues = field.value != null && field.value !== '' ? [field.value] : [];
                 }
-                const seen = new Set(baseOptions.map((o: { value: any }) => String(o.value)));
+                const seen = new Set(baseOptions.map((o: { value: any }) => getSelectValueIdentity(o.value)));
                 const extra =
                     descriptor.properties.extensibleList === true
-                        ? currentValues.filter((v: any) => !seen.has(String(v))).map((v: any) => ({ label: String(v), value: v }))
+                        ? currentValues.filter((v: any) => !seen.has(getSelectValueIdentity(v))).map(getExtraOption)
                         : [];
                 const selectOptionsList = [...baseOptions, ...extra];
                 const selectOptions = addNewAttributeValue
@@ -124,32 +145,34 @@ export function AttributeFieldSelect({
                             </div>
                             {deleteButton}
                         </div>
-                        {descriptor.properties.extensibleList === true && !descriptor.properties.readOnly && (
-                            <>
-                                {!showAddCustom && (
-                                    <Button
-                                        type="button"
-                                        variant="transparent"
-                                        className="text-blue-600 mt-1"
-                                        onClick={() => setShowAddCustom(true)}
-                                    >
-                                        <Plus size={14} className="mr-1" />
-                                        Add custom value
-                                    </Button>
-                                )}
-                                <AddCustomValuePanel
-                                    open={showAddCustom}
-                                    onClose={() => setShowAddCustom(false)}
-                                    idPrefix={name}
-                                    contentType={descriptor.contentType}
-                                    multiSelect={descriptor.properties.multiSelect}
-                                    readOnly={descriptor.properties.readOnly}
-                                    fieldValue={field.value}
-                                    onFieldChange={field.onChange}
-                                    parseValue={(v) => parseListValueByContentType(descriptor.contentType, v) ?? v}
-                                />
-                            </>
-                        )}
+                        {descriptor.properties.extensibleList === true &&
+                            descriptor.contentType !== AttributeContentType.Object &&
+                            !descriptor.properties.readOnly && (
+                                <>
+                                    {!showAddCustom && (
+                                        <Button
+                                            type="button"
+                                            variant="transparent"
+                                            className="text-blue-600 mt-1"
+                                            onClick={() => setShowAddCustom(true)}
+                                        >
+                                            <Plus size={14} className="mr-1" />
+                                            Add custom value
+                                        </Button>
+                                    )}
+                                    <AddCustomValuePanel
+                                        open={showAddCustom}
+                                        onClose={() => setShowAddCustom(false)}
+                                        idPrefix={name}
+                                        contentType={descriptor.contentType}
+                                        multiSelect={descriptor.properties.multiSelect}
+                                        readOnly={descriptor.properties.readOnly}
+                                        fieldValue={field.value}
+                                        onFieldChange={field.onChange}
+                                        parseValue={(v) => parseListValueByContentType(descriptor.contentType, v) ?? v}
+                                    />
+                                </>
+                            )}
                         {descriptor.properties.visible && (
                             <>
                                 {descriptor.description && (

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -88,7 +88,7 @@ const getUuidFromValue = (val: any): string | null => {
     return null;
 };
 
-const getOptionValueString = (val: OptionValue): string => {
+export const getOptionValueString = (val: OptionValue): string => {
     if (typeof val === 'object' && val !== null) {
         if ('reference' in val && typeof (val as any).reference === 'string') {
             return (val as any).reference;


### PR DESCRIPTION
## Summary
- preserve structured current `OBJECT` values when connector callback options no longer include them
- reuse Select option identity so object matching follows existing reference-based de-duplication
- suppress schema-less custom text entry for `OBJECT` lists while retaining scalar extensible-list authoring
- add component coverage for out-of-list objects, property ordering, and unsupported text entry

## Context
Supports OmniTrustILM/hashicorp-vault-connector#129. Vault RA engine values must retain `{ reference, data: { engineName } }`; generic custom text parsing would reduce them to strings.

## Testing
- 25 `AttributeFieldSelect` Chromium component tests
- targeted Biome check
- Vite production build