### PR TITLE
Split certificate settings into Validation and Registration panels

### DIFF
--- a/src/components/_pages/platform-settings/certificates/CertificateSettings.tsx
+++ b/src/components/_pages/platform-settings/certificates/CertificateSettings.tsx
@@ -23,9 +23,8 @@ const CertificateSettings = ({ platformSettings }: Props) => {
         [],
     );
 
-    const data: TableDataRow[] = useMemo(() => {
+    const validationData: TableDataRow[] = useMemo(() => {
         const validation = platformSettings?.certificates?.validation;
-        const registration = platformSettings?.certificates?.registration;
         const rows: TableDataRow[] = [];
 
         if (validation) {
@@ -50,6 +49,13 @@ const CertificateSettings = ({ platformSettings }: Props) => {
             }
         }
 
+        return rows;
+    }, [platformSettings]);
+
+    const registrationData: TableDataRow[] = useMemo(() => {
+        const registration = platformSettings?.certificates?.registration;
+        const rows: TableDataRow[] = [];
+
         if (registration) {
             rows.push(
                 {
@@ -67,8 +73,15 @@ const CertificateSettings = ({ platformSettings }: Props) => {
     }, [platformSettings]);
 
     return (
-        <div style={{ paddingTop: '1.5em', paddingBottom: '1.5em' }}>
-            <CustomTable headers={headers} data={data} />
+        <div style={{ paddingTop: '1.5em', paddingBottom: '1.5em' }} className="space-y-6">
+            <div className="space-y-2">
+                <h3 className="text-lg font-bold text-[var(--dark-gray-color)] dark:text-neutral-200">Validation</h3>
+                <CustomTable headers={headers} data={validationData} />
+            </div>
+            <div className="space-y-2">
+                <h3 className="text-lg font-bold text-[var(--dark-gray-color)] dark:text-neutral-200">Registration</h3>
+                <CustomTable headers={headers} data={registrationData} />
+            </div>
         </div>
     );
 };

--- a/src/components/_pages/platform-settings/certificates/CertificateSettings.tsx
+++ b/src/components/_pages/platform-settings/certificates/CertificateSettings.tsx
@@ -14,6 +14,7 @@ const CertificateSettings = ({ platformSettings }: Props) => {
             {
                 id: 'setting',
                 content: 'Setting',
+                width: '40%',
             },
             {
                 id: 'value',

--- a/src/components/_pages/platform-settings/certificates/CertificateSettingsForm.tsx
+++ b/src/components/_pages/platform-settings/certificates/CertificateSettingsForm.tsx
@@ -135,97 +135,100 @@ const CertificateSettingsForm = ({ onCancel, onSuccess }: CertificateSettingsFor
     return (
         <FormProvider {...methods}>
             <form onSubmit={handleSubmit(onSubmit)} className="mt-2 space-y-4">
-                <Controller
-                    name="enabled"
-                    control={control}
-                    render={({ field }) => (
-                        <Switch id="enabled" checked={field.value} onChange={field.onChange} label="Enable Certificate Validation" />
+                <div className="rounded-xl border border-gray-200 dark:border-neutral-700 p-4 md:p-5 shadow-2xs bg-white dark:bg-neutral-900 space-y-4">
+                    <h3 className="text-lg font-bold text-[var(--dark-gray-color)] dark:text-neutral-200">Validation</h3>
+                    <Controller
+                        name="enabled"
+                        control={control}
+                        render={({ field }) => (
+                            <Switch id="enabled" checked={field.value} onChange={field.onChange} label="Enable Certificate Validation" />
+                        )}
+                    />
+                    {watchedEnabled && (
+                        <>
+                            <div>
+                                <Controller
+                                    name="frequency"
+                                    control={control}
+                                    rules={buildValidationRules([validateNonZeroInteger(), validatePositiveInteger()])}
+                                    render={({ field, fieldState }) => (
+                                        <TextInput
+                                            {...field}
+                                            id="frequency"
+                                            type="number"
+                                            label="Validation Frequency"
+                                            invalid={fieldState.error && fieldState.isTouched}
+                                            error={getFieldErrorMessage(fieldState)}
+                                        />
+                                    )}
+                                />
+                                <p className="text-sm text-gray-500 mt-2">Validation frequency of certificates specified in days.</p>
+                            </div>
+                            <div>
+                                <Controller
+                                    name="expiringThreshold"
+                                    control={control}
+                                    rules={buildValidationRules([validateNonZeroInteger(), validatePositiveInteger()])}
+                                    render={({ field, fieldState }) => (
+                                        <TextInput
+                                            {...field}
+                                            id="expiringThreshold"
+                                            type="number"
+                                            label="Expiring Threshold"
+                                            invalid={fieldState.error && fieldState.isTouched}
+                                            error={getFieldErrorMessage(fieldState)}
+                                        />
+                                    )}
+                                />
+                                <p className="text-sm text-gray-500 mt-2">
+                                    How many days before expiration should certificate's validation status change to Expiring.
+                                </p>
+                            </div>
+                        </>
                     )}
-                />
-                {watchedEnabled && (
-                    <>
-                        <div>
-                            <Controller
-                                name="frequency"
-                                control={control}
-                                rules={buildValidationRules([validateNonZeroInteger(), validatePositiveInteger()])}
-                                render={({ field, fieldState }) => (
-                                    <TextInput
-                                        {...field}
-                                        id="frequency"
-                                        type="number"
-                                        label="Validation Frequency"
-                                        invalid={fieldState.error && fieldState.isTouched}
-                                        error={getFieldErrorMessage(fieldState)}
-                                    />
-                                )}
-                            />
-                            <p className="text-sm text-gray-500 mt-2">Validation frequency of certificates specified in days.</p>
-                        </div>
-                        <div>
-                            <Controller
-                                name="expiringThreshold"
-                                control={control}
-                                rules={buildValidationRules([validateNonZeroInteger(), validatePositiveInteger()])}
-                                render={({ field, fieldState }) => (
-                                    <TextInput
-                                        {...field}
-                                        id="expiringThreshold"
-                                        type="number"
-                                        label="Expiring Threshold"
-                                        invalid={fieldState.error && fieldState.isTouched}
-                                        error={getFieldErrorMessage(fieldState)}
-                                    />
-                                )}
-                            />
-                            <p className="text-sm text-gray-500 mt-2">
-                                How many days before expiration should certificate's validation status change to Expiring.
-                            </p>
-                        </div>
-                    </>
-                )}
-                <div>
-                    <h3 className="text-lg font-medium">Registration</h3>
                 </div>
-                <div>
-                    <Controller
-                        name="defaultIssuanceWindowDays"
-                        control={control}
-                        rules={buildValidationRules([validateNonZeroInteger(), validatePositiveInteger()])}
-                        render={({ field, fieldState }) => (
-                            <TextInput
-                                {...field}
-                                id="defaultIssuanceWindowDays"
-                                type="number"
-                                label="Default Issuance Window (days)"
-                                invalid={fieldState.error && fieldState.isTouched}
-                                error={getFieldErrorMessage(fieldState)}
-                            />
-                        )}
-                    />
-                    <p className="text-sm text-gray-500 mt-2">
-                        Default issuance window in days, applied when a pre-registration omits an explicit expiry.
-                    </p>
-                </div>
-                <div>
-                    <Controller
-                        name="maxFailedAttempts"
-                        control={control}
-                        rules={buildValidationRules([validateNonZeroInteger(), validatePositiveInteger()])}
-                        render={({ field, fieldState }) => (
-                            <TextInput
-                                {...field}
-                                id="maxFailedAttempts"
-                                type="number"
-                                label="Max Failed Attempts"
-                                invalid={fieldState.error && fieldState.isTouched}
-                                error={getFieldErrorMessage(fieldState)}
-                            />
-                        )}
-                    />
-                    <p className="text-sm text-gray-500 mt-2">
-                        Maximum failed challenge-verification attempts before the registration authorization locks.
-                    </p>
+                <div className="rounded-xl border border-gray-200 dark:border-neutral-700 p-4 md:p-5 shadow-2xs bg-white dark:bg-neutral-900 space-y-4">
+                    <h3 className="text-lg font-bold text-[var(--dark-gray-color)] dark:text-neutral-200">Registration</h3>
+                    <div>
+                        <Controller
+                            name="defaultIssuanceWindowDays"
+                            control={control}
+                            rules={buildValidationRules([validateNonZeroInteger(), validatePositiveInteger()])}
+                            render={({ field, fieldState }) => (
+                                <TextInput
+                                    {...field}
+                                    id="defaultIssuanceWindowDays"
+                                    type="number"
+                                    label="Default Issuance Window (days)"
+                                    invalid={fieldState.error && fieldState.isTouched}
+                                    error={getFieldErrorMessage(fieldState)}
+                                />
+                            )}
+                        />
+                        <p className="text-sm text-gray-500 mt-2">
+                            Default issuance window in days, applied when a pre-registration omits an explicit expiry.
+                        </p>
+                    </div>
+                    <div>
+                        <Controller
+                            name="maxFailedAttempts"
+                            control={control}
+                            rules={buildValidationRules([validateNonZeroInteger(), validatePositiveInteger()])}
+                            render={({ field, fieldState }) => (
+                                <TextInput
+                                    {...field}
+                                    id="maxFailedAttempts"
+                                    type="number"
+                                    label="Max Failed Attempts"
+                                    invalid={fieldState.error && fieldState.isTouched}
+                                    error={getFieldErrorMessage(fieldState)}
+                                />
+                            )}
+                        />
+                        <p className="text-sm text-gray-500 mt-2">
+                            Maximum failed challenge-verification attempts before the registration authorization locks.
+                        </p>
+                    </div>
                 </div>
                 <Container className="flex-row justify-end modal-footer" gap={4}>
                     <Button variant="outline" onClick={onCancel} disabled={isSubmitting || isBusy} type="button">


### PR DESCRIPTION
## Summary
Groups the platform **Certificates** settings into two clearly-labeled sections on both surfaces, so the pre-registration fields added in #1693 read as their own group rather than trailing the validation fields.

- **Edit dialog** (`CertificateSettingsForm`): existing validation controls (Enable Certificate Validation, Validation Frequency, Expiring Threshold) wrapped in a **Validation** panel; the pre-registration fields (Default Issuance Window, Max Failed Attempts) moved into a separate **Registration** panel.
- **Read-only detail page** (`CertificateSettings`): the single combined table is split into two labeled tables — **Validation** and **Registration**.

Lightweight bordered `<div>` panels (styled like `Widget`) are used in the dialog rather than the `Widget` component itself, which pulls in `useLocation`/redux-pagination machinery the component-test harness doesn't provide.

## Notes
- No behavior or field-mapping changes; form inputs keep their existing `id`s.
- Verified: `tsc` clean, `biome check` clean, existing `CertificateSettingsForm` CT tests pass (chromium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)