### PR TITLE
Fix TypeError crash on pre-registered certificate detail page

### DIFF
--- a/src/components/_pages/certificates/certificateTableHelpers.spec.tsx
+++ b/src/components/_pages/certificates/certificateTableHelpers.spec.tsx
@@ -145,6 +145,36 @@ test.describe('certificateTableHelpers', () => {
             });
         });
 
+        test('does not throw for a pre-registered certificate without key material', () => {
+            // A certificate in "registered" state has no issued certificate or key yet, so
+            // keySize, publicKeyAlgorithm, serialNumber, notBefore/notAfter are all absent.
+            const preRegisteredCert = {
+                uuid: 'uuid-registered',
+                commonName: 'pre-registered',
+                subjectDn: 'CN=pre-registered',
+                hybridCertificate: false,
+                state: 'registered',
+                validationStatus: 'not_checked',
+                complianceStatus: 'not_checked',
+                privateKeyAvailability: false,
+                archived: false,
+                groups: [],
+                certificateType: CertificateType.X509,
+            } as unknown as CertificateDetailResponseModel;
+
+            const rows = buildCertificateDetailBaseRows(
+                preRegisteredCert,
+                undefined,
+                false,
+                { certificateKeyUsage: {}, qcType: {} },
+                mockDateFormatter,
+                mockGetEnumLabel,
+            );
+
+            const keySizeRow = rows.find((r) => r.id === 'keySize');
+            expect(keySizeRow?.columns[1]).toBe('');
+        });
+
         test('adds hybrid rows when hybridCertificate is true', () => {
             const hybridCert = {
                 ...minimalCertificate,

--- a/src/components/_pages/certificates/certificateTableHelpers.tsx
+++ b/src/components/_pages/certificates/certificateTableHelpers.tsx
@@ -322,7 +322,7 @@ export function buildCertificateDetailBaseRows(
         },
         { id: 'fingerprint', columns: ['Fingerprint', certificate.fingerprint || ''] },
         { id: 'fingerprintAlgorithm', columns: ['Fingerprint Algorithm', 'SHA256'] },
-        { id: 'keySize', columns: ['Key Size', certificate.keySize.toString()] },
+        { id: 'keySize', columns: ['Key Size', certificate.keySize?.toString() ?? ''] },
     );
     if (certificate.hybridCertificate) {
         rows.push({


### PR DESCRIPTION
Closes #1870 

## Summary
- `certificate.keySize.toString()` was called unconditionally when rendering the Certificate Properties widget, but pre-registered certificates (state: `registered`) have no key material yet, so `keySize` is absent from the API response.
- Guards the read with optional chaining, matching the existing `altKeySize` handling on the line below it.
- Adds a regression test covering the pre-registered certificate shape (no `keySize`, `serialNumber`, `notBefore`/`notAfter`, `publicKeyAlgorithm`, etc.), which reproduces the crash before the fix.

## Test plan
- [x] `npx playwright test -c playwright-ct.config.ts --project=chromium certificateTableHelpers` — 11/11 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on changed files — no new warnings
- [x] Manually reproduced the crash in-browser on a pre-registered certificate detail page before the fix, confirmed the page renders correctly after