### PR TITLE
Label failed action executions as Failed instead of Skipped in evaluation details

### DIFF
--- a/src/components/_pages/notifications/events-settings/EvaluationDetailsDialog/EvaluationDetailsDialog.spec.tsx
+++ b/src/components/_pages/notifications/events-settings/EvaluationDetailsDialog/EvaluationDetailsDialog.spec.tsx
@@ -46,12 +46,12 @@ test.describe('EvaluationDetailsDialog', () => {
         await expect(page.getByText('Reason message A')).toBeVisible();
     });
 
-    test('renders execution record with Skipped result and reason', async ({ mount, page }) => {
+    test('renders execution record with Failed result and reason', async ({ mount, page }) => {
         await mount(
             withProviders(<EvaluationDetailsDialog isOpen={true} onClose={() => {}} objectLabel="yahoo.com" trigger={baseTrigger} />),
         );
         await expect(page.getByText('set custom attribute "department"')).toBeVisible();
-        await expect(page.getByText('Skipped', { exact: true })).toBeVisible();
+        await expect(page.getByText('Failed', { exact: true })).toBeVisible();
         await expect(page.getByText('Reason message B')).toBeVisible();
     });
 

--- a/src/components/_pages/notifications/events-settings/EvaluationDetailsDialog/index.tsx
+++ b/src/components/_pages/notifications/events-settings/EvaluationDetailsDialog/index.tsx
@@ -35,7 +35,7 @@ export default function EvaluationDetailsDialog({ isOpen, onClose, objectLabel, 
             const executionRows: Row[] = record.execution
                 ? [
                       { label: 'Action', value: record.execution.name },
-                      { label: 'Result', value: 'Skipped' },
+                      { label: 'Result', value: 'Failed' },
                   ]
                 : [];
             const reasonRows: Row[] = record.message ? [{ label: 'Reason', value: record.message }] : [];


### PR DESCRIPTION
Fixes #1621 