### PR TITLE
Request-attribute mapping & settings improvements (#1894)

### DIFF
--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInputTestWrapper.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInputTestWrapper.tsx
@@ -1,5 +1,8 @@
 import type React from 'react';
+import { useMemo } from 'react';
+import { Provider } from 'react-redux';
 import * as ReactHookForm from 'react-hook-form';
+import { createMockStore } from 'utils/test-helpers';
 import { AttributeFieldInput } from './AttributeFieldInput';
 import type { DataAttributeModel } from 'types/attributes';
 
@@ -25,26 +28,31 @@ export function AttributeFieldInputTestWrapper({
         },
         mode: 'onTouched',
     });
+    // AttributeFieldInput renders the redux-backed request-attribute mapping badge, which reads the
+    // oids slice, so the field needs a store even though these tests don't exercise the badge itself.
+    const store = useMemo(() => createMockStore(), []);
     return (
-        <ReactHookForm.FormProvider {...methods}>
-            <AttributeFieldInput name={name} descriptor={descriptor} busy={busy} deleteButton={deleteButton} />
+        <Provider store={store}>
+            <ReactHookForm.FormProvider {...methods}>
+                <AttributeFieldInput name={name} descriptor={descriptor} busy={busy} deleteButton={deleteButton} />
 
-            <button type="button" data-testid="outside-blur-target">
-                Outside
-            </button>
+                <button type="button" data-testid="outside-blur-target">
+                    Outside
+                </button>
 
-            <button
-                type="button"
-                data-testid="trigger-validation"
-                onClick={() => {
-                    methods.setValue(name, '', {
-                        shouldTouch: true,
-                        shouldValidate: true,
-                    });
-                }}
-            >
-                Trigger validation
-            </button>
-        </ReactHookForm.FormProvider>
+                <button
+                    type="button"
+                    data-testid="trigger-validation"
+                    onClick={() => {
+                        methods.setValue(name, '', {
+                            shouldTouch: true,
+                            shouldValidate: true,
+                        });
+                    }}
+                >
+                    Trigger validation
+                </button>
+            </ReactHookForm.FormProvider>
+        </Provider>
     );
 }

--- a/src/components/Attributes/AttributeEditor/index.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/index.spec.tsx
@@ -269,6 +269,22 @@ test.describe('AttributeEditor', () => {
         await expect(input).toHaveValue('defaultValue');
     });
 
+    test('read-only attribute with a default value is pre-filled and locked', async ({ mount, page }) => {
+        const descriptors: AttributeDescriptorModel[] = [
+            dataDescriptor({
+                name: 'readOnlyDefault',
+                uuid: 'readonly-default-uuid',
+                properties: { label: 'Read Only Default', required: false, readOnly: true, list: false, multiSelect: false } as any,
+                content: [{ data: 'lockedValue' }] as any,
+            }),
+        ];
+        await mount(<AttributeEditorTestWrapper id={editorId} attributeDescriptors={descriptors} />);
+        const input = page.getByTestId('text-input-__attributes__testEditor__.readOnlyDefault');
+        await expect(input).toBeVisible({ timeout: 10000 });
+        await expect(input).toHaveValue('lockedValue');
+        await expect(input).toBeDisabled();
+    });
+
     test('Boolean required with no value shows false', async ({ mount, page }) => {
         const descriptors: AttributeDescriptorModel[] = [
             dataDescriptor({

--- a/src/components/Attributes/AttributeEditor/index.tsx
+++ b/src/components/Attributes/AttributeEditor/index.tsx
@@ -592,9 +592,10 @@ function AttributeEditorInner({
             } else if (
                 descriptor.content &&
                 descriptor.content.length > 0 &&
-                (!setDefaultOnRequiredValuesOnly || descriptor.properties.required)
+                (!setDefaultOnRequiredValuesOnly || descriptor.properties.required || descriptor.properties.readOnly)
             ) {
-                // This acts as a fallback for the case when the attribute has no value, but has a default value in the descriptor
+                // This acts as a fallback for the case when the attribute has no value, but has a default value in the
+                // descriptor. Read-only attributes are always seeded so a locked field shows its predefined default.
                 const firstDescriptorContent = descriptor.content[0] as any;
                 formAttributeValue = firstDescriptorContent?.data ?? firstDescriptorContent?.reference;
             }

--- a/src/components/Input/DynamicContent/AddCustomValueInput.tsx
+++ b/src/components/Input/DynamicContent/AddCustomValueInput.tsx
@@ -16,6 +16,7 @@ type Props = {
     onChange: (v: string | number | boolean) => void;
     readOnly: boolean;
     inputClassName?: string;
+    placeholder?: string;
 };
 
 export function AddCustomValueInput({
@@ -27,6 +28,7 @@ export function AddCustomValueInput({
     onChange,
     readOnly,
     inputClassName = defaultInputClassName,
+    placeholder,
 }: Readonly<Props>): React.ReactNode {
     if (inputType === 'datetime-local') {
         let dateVal = typeof value === 'string' && value ? value : undefined;
@@ -52,6 +54,7 @@ export function AddCustomValueInput({
                 value={value === '' ? '' : Number(value)}
                 onChange={handleNumberChange}
                 disabled={readOnly}
+                placeholder={placeholder}
             />
         );
     }
@@ -65,6 +68,7 @@ export function AddCustomValueInput({
             value={String(value ?? '')}
             onChange={(v) => onChange(v)}
             disabled={readOnly}
+            placeholder={placeholder}
         />
     );
 }

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,4 +1,6 @@
 import cn from 'classnames';
+import { Info } from 'lucide-react';
+import Tooltip from 'components/Tooltip';
 
 export type SingleValue<T> = T | undefined;
 export type MultiValue<T> = T[] | undefined;
@@ -11,9 +13,11 @@ type Props = {
     className?: string;
     onClick?: () => void;
     dataTestId?: string;
+    /** When set, renders an info icon after the label text that shows this text as a hover tooltip. */
+    labelTooltip?: string;
 };
 
-function Label({ htmlFor, title, children, required, className, onClick, dataTestId }: Readonly<Props>) {
+function Label({ htmlFor, title, children, required, className, onClick, dataTestId, labelTooltip }: Readonly<Props>) {
     const defaultClasses = 'block text-left text-sm font-medium mb-2 text-center dark:text-white text-[var(--dark-gray-color)]';
     if (onClick) {
         return (
@@ -42,6 +46,16 @@ function Label({ htmlFor, title, children, required, className, onClick, dataTes
         >
             {title || children}
             {required && <span className="text-red-500"> *</span>}
+            {labelTooltip && (
+                <Tooltip content={labelTooltip}>
+                    <span
+                        className="ml-1 inline-flex align-middle text-gray-400 hover:text-gray-600 dark:hover:text-neutral-200 cursor-help"
+                        data-testid={htmlFor ? `label-tooltip-${htmlFor}` : 'label-tooltip'}
+                    >
+                        <Info size={13} aria-hidden />
+                    </span>
+                </Tooltip>
+            )}
         </label>
     );
 }

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -54,25 +54,26 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         expect(parsed.attributes[0].label).toBe('Server FQDN');
     });
 
-    test('the attribute dialog gives first-time guidance and per-field hints', async ({ mount, page }) => {
+    test('the attribute dialog surfaces per-field guidance via label tooltips', async ({ mount, page }) => {
         const component = await mount(withProviders(<RequestAttributeAuthoringEditorHarness showMergeMode />));
 
         await component.getByTestId('request-attribute-authoring-attribute-add').click();
 
-        await expect(page.getByTestId('request-attribute-authoring-attribute-form-intro')).toBeVisible();
-        await expect(page.getByTestId('request-attribute-authoring-attribute-name-hint')).toBeVisible();
-        await expect(page.getByTestId('request-attribute-authoring-attribute-label-hint')).toBeVisible();
-        await expect(page.getByTestId('request-attribute-authoring-attribute-mapping-hint')).toContainText('certificate');
+        // Guidance now lives in an info icon next to the field label, not in inline hint paragraphs.
+        await expect(page.getByTestId('label-tooltip-ra-attr-name')).toBeVisible();
+        await expect(page.getByTestId('label-tooltip-ra-attr-mapping')).toBeVisible();
+        // Label and Description are self-explanatory, so they carry no tooltip.
+        await expect(page.getByTestId('label-tooltip-ra-attr-label')).toHaveCount(0);
+        await expect(page.getByTestId('label-tooltip-ra-attr-description')).toHaveCount(0);
     });
 
-    test('mapping target explains the chosen target', async ({ mount, page }) => {
+    test('hovering a field label tooltip reveals its guidance', async ({ mount, page }) => {
         const component = await mount(withProviders(<RequestAttributeAuthoringEditorHarness showMergeMode />));
 
         await component.getByTestId('request-attribute-authoring-attribute-add').click();
-        await page.getByTestId('select-ra-attr-mapping-trigger').click();
-        await page.getByRole('option', { name: 'RDN (subject)' }).click();
+        await page.getByTestId('label-tooltip-ra-attr-mapping').hover();
 
-        await expect(page.getByTestId('select-ra-attr-mapping-selected-description')).toBeVisible();
+        await expect(page.getByRole('tooltip')).toContainText('certificate');
     });
 
     test('authoring a granular RDN mapping requires selecting an RDN', async ({ mount, page }) => {

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -518,4 +518,18 @@ test.describe('RequestAttributeAuthoringEditor', () => {
 
         await expect(page.getByTestId('value-json')).toContainText('"defaultValue":"prod"');
     });
+
+    test('free-input Read Only checkbox toggles the readOnly flag in the emitted form', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('env');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+        await page.locator('#ra-attr-readonly').check();
+        await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
+
+        await expect(page.getByTestId('value-json')).toContainText('"readOnly":true');
+    });
 });

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -478,4 +478,29 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await component.getByTestId('request-attribute-authoring-attribute-remove').click();
         await expect(component.getByTestId('request-attribute-authoring-attributes-empty')).toBeVisible();
     });
+
+    test('configured-attribute summary shows the RDN code, not the OID, for a system RDN', async ({ mount, page }) => {
+        const initialValue = {
+            ...emptyAuthoringForm(),
+            attributes: [
+                {
+                    ...emptyAuthoredAttribute(),
+                    name: 'cn',
+                    label: 'Common Name',
+                    mappingFieldType: FieldType.Rdn,
+                    mappingRdnCode: '2.5.4.3',
+                },
+            ],
+        };
+        await mount(
+            <RequestAttributeAuthoringEditorHarness
+                initialValue={initialValue}
+                rdnOptions={[{ value: '2.5.4.3', label: 'Common Name (CN)', code: 'CN' }]}
+            />,
+        );
+
+        const row = page.getByTestId('request-attribute-authoring-attribute-row');
+        await expect(row).toContainText('→ RDN CN');
+        await expect(row).not.toContainText('2.5.4.3');
+    });
 });

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -327,8 +327,8 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
 
-        await expect(page.locator('#ra-attr-list')).not.toBeChecked();
-        await expect(page.locator('#ra-attr-list')).toBeEnabled();
+        // Free input (default) does not offer the List checkbox at all.
+        await expect(page.locator('#ra-attr-list')).toHaveCount(0);
 
         await page.getByTestId('select-ra-attr-value-source-trigger').click();
         await page.getByRole('option', { name: 'Static list' }).click();
@@ -534,7 +534,30 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await expect(page.getByTestId('value-json')).toContainText('"readOnly":true');
     });
 
-    test('Read Only persists when the Value source is a Static list', async ({ mount, page }) => {
+    test('Free input value source shows Read Only and hides List/Multi select', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+
+        // Free input is the default value source.
+        await expect(page.locator('#ra-attr-readonly')).toBeVisible();
+        await expect(page.locator('#ra-attr-list')).toHaveCount(0);
+        await expect(page.locator('#ra-attr-multi')).toHaveCount(0);
+    });
+
+    test('Static list value source shows List/Multi select and hides Read Only', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.getByTestId('select-ra-attr-value-source-trigger').click();
+        await page.getByRole('option', { name: 'Static list' }).click();
+
+        await expect(page.locator('#ra-attr-list')).toBeVisible();
+        await expect(page.locator('#ra-attr-multi')).toBeVisible();
+        await expect(page.locator('#ra-attr-readonly')).toHaveCount(0);
+    });
+
+    test('selecting a Static list value source clears Read Only', async ({ mount, page }) => {
         await mount(<RequestAttributeAuthoringEditorHarness />);
 
         await page.getByTestId('request-attribute-authoring-attribute-add').click();
@@ -553,7 +576,31 @@ test.describe('RequestAttributeAuthoringEditor', () => {
 
         await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
 
-        await expect(page.getByTestId('value-json')).toContainText('"readOnly":true');
+        await expect(page.getByTestId('value-json')).toContainText('"readOnly":false');
         await expect(page.getByTestId('value-json')).toContainText('"valueSourceType":"staticList"');
+    });
+
+    test('switching from Static list to Free input hides List/Multi and clears the list flag', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('env');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+
+        // Static list forces List on and shows the checkbox...
+        await page.getByTestId('select-ra-attr-value-source-trigger').click();
+        await page.getByRole('option', { name: 'Static list' }).click();
+        await expect(page.locator('#ra-attr-list')).toBeChecked();
+
+        // ...switching to Free input hides List/Multi and clears the flag in the emitted form.
+        await page.getByTestId('select-ra-attr-value-source-trigger').click();
+        await page.getByRole('option', { name: 'Free input' }).click();
+        await expect(page.locator('#ra-attr-list')).toHaveCount(0);
+        await expect(page.locator('#ra-attr-multi')).toHaveCount(0);
+
+        await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
+        await expect(page.getByTestId('value-json')).toContainText('"list":false');
     });
 });

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -532,4 +532,27 @@ test.describe('RequestAttributeAuthoringEditor', () => {
 
         await expect(page.getByTestId('value-json')).toContainText('"readOnly":true');
     });
+
+    test('switching Value source to Static list clears the Read Only flag', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('env');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+        await page.locator('#ra-attr-readonly').check();
+
+        await page.getByTestId('select-ra-attr-value-source-trigger').click();
+        await page.getByRole('option', { name: 'Static list' }).click();
+
+        await page.getByTestId('request-attribute-authoring-static-value-add').click();
+        await page.locator('#ra-attr-static-value-0').click();
+        await page.locator('#ra-attr-static-value-0').fill('prod');
+
+        await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
+
+        await expect(page.getByTestId('value-json')).toContainText('"readOnly":false');
+        await expect(page.getByTestId('value-json')).toContainText('"valueSourceType":"staticList"');
+    });
 });

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -519,7 +519,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await expect(page.getByTestId('value-json')).toContainText('"defaultValue":"prod"');
     });
 
-    test('free-input Read Only checkbox toggles the readOnly flag in the emitted form', async ({ mount, page }) => {
+    test('Read Only checkbox toggles the readOnly flag in the emitted form', async ({ mount, page }) => {
         await mount(<RequestAttributeAuthoringEditorHarness />);
 
         await page.getByTestId('request-attribute-authoring-attribute-add').click();
@@ -533,7 +533,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await expect(page.getByTestId('value-json')).toContainText('"readOnly":true');
     });
 
-    test('switching Value source to Static list clears the Read Only flag', async ({ mount, page }) => {
+    test('Read Only persists when the Value source is a Static list', async ({ mount, page }) => {
         await mount(<RequestAttributeAuthoringEditorHarness />);
 
         await page.getByTestId('request-attribute-authoring-attribute-add').click();
@@ -552,7 +552,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
 
         await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
 
-        await expect(page.getByTestId('value-json')).toContainText('"readOnly":false');
+        await expect(page.getByTestId('value-json')).toContainText('"readOnly":true');
         await expect(page.getByTestId('value-json')).toContainText('"valueSourceType":"staticList"');
     });
 });

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -503,4 +503,19 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await expect(row).toContainText('→ RDN CN');
         await expect(row).not.toContainText('2.5.4.3');
     });
+
+    test('free-input default value serialises into the emitted form content', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('env');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+        await page.locator('#ra-attr-default-value').click();
+        await page.locator('#ra-attr-default-value').fill('prod');
+        await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
+
+        await expect(page.getByTestId('value-json')).toContainText('"defaultValue":"prod"');
+    });
 });

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -520,6 +520,39 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await expect(page.getByTestId('value-json')).toContainText('"defaultValue":"prod"');
     });
 
+    test('free-input default value starts empty (not the content-type initial) for a numeric type', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.getByTestId('select-ra-attr-content-type-trigger').click();
+        await page.getByRole('option', { name: 'Integer', exact: true }).click();
+
+        // The numeric editor has no id, so scope to the default-value block. It must start blank rather
+        // than pre-filled with the content-type initial ('0'), which would be indistinguishable from an
+        // intentional default of 0.
+        await expect(page.getByTestId('request-attribute-authoring-default-value-block').locator('input')).toHaveValue('');
+    });
+
+    test('changing the content type clears an entered free-input default value', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('env');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+        await page.locator('#ra-attr-default-value').click();
+        await page.locator('#ra-attr-default-value').fill('prod');
+
+        await page.getByTestId('select-ra-attr-content-type-trigger').click();
+        await page.getByRole('option', { name: 'Integer', exact: true }).click();
+        await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
+
+        // The default entered under String must not survive the type switch and serialise as a
+        // wrong-typed (NaN) content entry.
+        await expect(page.getByTestId('value-json')).not.toContainText('"defaultValue"');
+    });
+
     test('Read Only checkbox toggles the readOnly flag in the emitted form', async ({ mount, page }) => {
         await mount(<RequestAttributeAuthoringEditorHarness />);
 

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -372,7 +372,7 @@ export default function RequestAttributeAuthoringEditor({
                     id="ra-attr-name"
                     label="Name"
                     labelTooltip="Internal identifier, unique within this set. Not shown to the requester."
-                    placeholder="e.g. environment"
+                    placeholder="Enter name"
                     required
                     value={d.name}
                     onChange={(v) => set({ name: v })}
@@ -385,7 +385,7 @@ export default function RequestAttributeAuthoringEditor({
                 <TextInput
                     id="ra-attr-label"
                     label="Label"
-                    placeholder="e.g. Environment"
+                    placeholder="Enter label"
                     required
                     value={d.label}
                     onChange={(v) => set({ label: v })}
@@ -393,7 +393,7 @@ export default function RequestAttributeAuthoringEditor({
                 <TextInput
                     id="ra-attr-description"
                     label="Description"
-                    placeholder="e.g. Target deployment environment"
+                    placeholder="Enter description"
                     value={d.description ?? ''}
                     onChange={(v) => set({ description: v })}
                 />
@@ -627,6 +627,7 @@ export default function RequestAttributeAuthoringEditor({
                     value={d.defaultValue ?? config.initial}
                     onChange={(next) => set({ defaultValue: next })}
                     readOnly={disabled}
+                    placeholder="Enter default value"
                 />
             </div>
         );

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -441,6 +441,7 @@ export default function RequestAttributeAuthoringEditor({
                         label="Multi select"
                         disabled={!d.list}
                     />
+                    <Checkbox id="ra-attr-readonly" checked={d.readOnly} onChange={(c) => set({ readOnly: c })} label="Read Only" />
                 </Container>
                 <Select
                     id="ra-attr-mapping"
@@ -538,10 +539,10 @@ export default function RequestAttributeAuthoringEditor({
                     onChange={(v) => {
                         const valueSourceType = v as ValueSourceType;
                         // Selecting a static list forces `list` on (see DTO builder) so the toggle and
-                        // the authored options never disagree; Read Only is free-input-only, so clear it.
+                        // the authored options never disagree.
                         set({
                             valueSourceType,
-                            ...(valueSourceType === ValueSourceType.StaticList ? { list: true, readOnly: false } : {}),
+                            ...(valueSourceType === ValueSourceType.StaticList ? { list: true } : {}),
                         });
                     }}
                     options={isStaticListSupportedForContentType(d.contentType) ? VALUE_SOURCE_OPTIONS : FREE_INPUT_ONLY_OPTIONS}
@@ -628,29 +629,22 @@ export default function RequestAttributeAuthoringEditor({
     // the content type; persisted like a single-entry static list. Non-scalar types have no editor.
     const renderFreeInputDefault = (d: AuthoredAttributeFormValues, set: (p: Partial<AuthoredAttributeFormValues>) => void) => {
         const config = ContentFieldConfiguration[d.contentType];
+        if (!config) return null;
         return (
             <div className="space-y-2" data-testid={`${dataTestId}-default-value-block`}>
-                <Checkbox id="ra-attr-readonly" checked={d.readOnly} onChange={(c) => set({ readOnly: c })} label="Read Only" />
-                <FieldHint dataTestId={`${dataTestId}-readonly-hint`}>
-                    The value is fixed to the default and the requester cannot change it.
+                <Label>Default value</Label>
+                <AddCustomValueInput
+                    id="ra-attr-default-value"
+                    inputType={config.type}
+                    contentType={d.contentType}
+                    fieldStepValue={getStepValue(config.type)}
+                    value={d.defaultValue ?? config.initial}
+                    onChange={(next) => set({ defaultValue: next })}
+                    readOnly={disabled}
+                />
+                <FieldHint dataTestId={`${dataTestId}-default-value-hint`}>
+                    Optional. Pre-fills the field on the request form; the requester can change it unless Read Only is set.
                 </FieldHint>
-                {config && (
-                    <>
-                        <Label>Default value</Label>
-                        <AddCustomValueInput
-                            id="ra-attr-default-value"
-                            inputType={config.type}
-                            contentType={d.contentType}
-                            fieldStepValue={getStepValue(config.type)}
-                            value={d.defaultValue ?? config.initial}
-                            onChange={(next) => set({ defaultValue: next })}
-                            readOnly={disabled}
-                        />
-                        <FieldHint dataTestId={`${dataTestId}-default-value-hint`}>
-                            Optional. Pre-fills the field on the request form; the requester can change it unless Read Only is set.
-                        </FieldHint>
-                    </>
-                )}
             </div>
         );
     };
@@ -794,7 +788,7 @@ export default function RequestAttributeAuthoringEditor({
             <Dialog
                 isOpen={!!attrDraft}
                 toggle={() => setAttrDraft(null)}
-                size="md"
+                size="lg"
                 caption={attrDraft?.index === null ? 'Add request attribute' : 'Edit request attribute'}
                 body={renderAttributeDialog()}
                 buttons={[

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -103,15 +103,6 @@ function valueSourceLabel(type: ValueSourceType): string {
     return VALUE_SOURCE_OPTIONS.find((o) => o.value === type)?.label ?? 'Free input';
 }
 
-/** Inline guidance line rendered beneath a field the shared inputs can't describe themselves. */
-function FieldHint({ children, dataTestId }: Readonly<{ children: React.ReactNode; dataTestId?: string }>) {
-    return (
-        <p className="-mt-1.5 text-xs text-gray-500" data-testid={dataTestId}>
-            {children}
-        </p>
-    );
-}
-
 /** `value` = attribute UUID, `label` = human display, `description` = internal attribute name (the binding name-fallback key). */
 type ConnectorAttributeOption = { value: string; label: string; description?: string };
 
@@ -377,36 +368,39 @@ export default function RequestAttributeAuthoringEditor({
         const set = (p: Partial<AuthoredAttributeFormValues>) => setAttrDraft({ ...attrDraft, data: { ...d, ...p } });
         return (
             <div className="space-y-3 text-left" data-testid={`${dataTestId}-attribute-form`}>
-                <p className="text-sm text-gray-500" data-testid={`${dataTestId}-attribute-form-intro`}>
-                    A request attribute is a value the requester supplies when asking for a certificate. Define what it is called, its data
-                    type, and — optionally — where its value is placed in the issued certificate.
-                </p>
-                <TextInput id="ra-attr-name" label="Name" required value={d.name} onChange={(v) => set({ name: v })} />
-                {attrNameDuplicate ? (
+                <TextInput
+                    id="ra-attr-name"
+                    label="Name"
+                    labelTooltip="Internal identifier, unique within this set. Not shown to the requester."
+                    placeholder="e.g. environment"
+                    required
+                    value={d.name}
+                    onChange={(v) => set({ name: v })}
+                />
+                {attrNameDuplicate && (
                     <p className="text-sm text-red-600" data-testid={`${dataTestId}-attribute-name-duplicate`}>
                         An attribute with this name already exists in the set.
                     </p>
-                ) : (
-                    <FieldHint dataTestId={`${dataTestId}-attribute-name-hint`}>
-                        Internal identifier, unique within this set. Not shown to the requester.
-                    </FieldHint>
                 )}
-                <TextInput id="ra-attr-label" label="Label" required value={d.label} onChange={(v) => set({ label: v })} />
-                <FieldHint dataTestId={`${dataTestId}-attribute-label-hint`}>
-                    The name shown to the requester on the request form.
-                </FieldHint>
+                <TextInput
+                    id="ra-attr-label"
+                    label="Label"
+                    placeholder="e.g. Environment"
+                    required
+                    value={d.label}
+                    onChange={(v) => set({ label: v })}
+                />
                 <TextInput
                     id="ra-attr-description"
                     label="Description"
+                    placeholder="e.g. Target deployment environment"
                     value={d.description ?? ''}
                     onChange={(v) => set({ description: v })}
                 />
-                <FieldHint dataTestId={`${dataTestId}-attribute-description-hint`}>
-                    Optional help text shown to the requester explaining what to enter.
-                </FieldHint>
                 <Select
                     id="ra-attr-content-type"
                     label="Content type"
+                    labelTooltip="The data type of the value the requester provides."
                     value={d.contentType}
                     onChange={(v) => {
                         const contentType = v as AttributeContentType;
@@ -421,9 +415,6 @@ export default function RequestAttributeAuthoringEditor({
                     }}
                     options={CONTENT_TYPE_OPTIONS}
                 />
-                <FieldHint dataTestId={`${dataTestId}-attribute-content-type-hint`}>
-                    The data type of the value the requester provides.
-                </FieldHint>
                 <Container className="flex-row items-center" gap={4}>
                     <Checkbox id="ra-attr-required" checked={d.required} onChange={(c) => set({ required: c })} label="Required" />
                     <Checkbox
@@ -446,6 +437,7 @@ export default function RequestAttributeAuthoringEditor({
                 <Select
                     id="ra-attr-mapping"
                     label="Mapping target"
+                    labelTooltip="Where this attribute's value is placed in the issued certificate: an RDN (subject) component, a Subject Alternative Name, or a certificate extension. Leave it unmapped if the connector or workflow consumes the value directly."
                     value={d.mappingFieldType ?? ''}
                     onChange={(v) =>
                         set({ mappingFieldType: (v as FieldType) || undefined, mappingObjectType: ObjectType.X509Certificate })
@@ -453,12 +445,7 @@ export default function RequestAttributeAuthoringEditor({
                     options={MAPPING_OPTIONS}
                     isClearable
                     placeholder="Not mapped"
-                    showSelectedDescriptionAsHelp
                 />
-                <FieldHint dataTestId={`${dataTestId}-attribute-mapping-hint`}>
-                    Where this attribute&apos;s value is placed in the issued certificate. Leave it unmapped if the connector or workflow
-                    consumes the value directly.
-                </FieldHint>
                 {d.mappingFieldType === FieldType.Rdn && (
                     <OidMappingSelect
                         id="ra-attr-rdn"
@@ -535,6 +522,7 @@ export default function RequestAttributeAuthoringEditor({
                 <Select
                     id="ra-attr-value-source"
                     label="Value source"
+                    labelTooltip="How the requester provides the value: free input (they type any value) or a static list (they pick from a fixed set of values you define)."
                     value={d.valueSourceType}
                     onChange={(v) => {
                         const valueSourceType = v as ValueSourceType;
@@ -546,11 +534,7 @@ export default function RequestAttributeAuthoringEditor({
                         });
                     }}
                     options={isStaticListSupportedForContentType(d.contentType) ? VALUE_SOURCE_OPTIONS : FREE_INPUT_ONLY_OPTIONS}
-                    showSelectedDescriptionAsHelp
                 />
-                <FieldHint dataTestId={`${dataTestId}-attribute-value-source-hint`}>
-                    How the requester provides the value — free input, or a fixed list of choices you define.
-                </FieldHint>
                 {d.valueSourceType === ValueSourceType.StaticList && renderStaticValues(d, set)}
                 {d.valueSourceType === ValueSourceType.None && renderFreeInputDefault(d, set)}
             </div>
@@ -632,7 +616,9 @@ export default function RequestAttributeAuthoringEditor({
         if (!config) return null;
         return (
             <div className="space-y-2" data-testid={`${dataTestId}-default-value-block`}>
-                <Label>Default value</Label>
+                <Label labelTooltip="Optional. Pre-fills the field on the request form; the requester can change it unless Read Only is set.">
+                    Default value
+                </Label>
                 <AddCustomValueInput
                     id="ra-attr-default-value"
                     inputType={config.type}
@@ -642,9 +628,6 @@ export default function RequestAttributeAuthoringEditor({
                     onChange={(next) => set({ defaultValue: next })}
                     readOnly={disabled}
                 />
-                <FieldHint dataTestId={`${dataTestId}-default-value-hint`}>
-                    Optional. Pre-fills the field on the request form; the requester can change it unless Read Only is set.
-                </FieldHint>
             </div>
         );
     };

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -415,25 +415,6 @@ export default function RequestAttributeAuthoringEditor({
                     }}
                     options={CONTENT_TYPE_OPTIONS}
                 />
-                <Container className="flex-row items-center" gap={4}>
-                    <Checkbox id="ra-attr-required" checked={d.required} onChange={(c) => set({ required: c })} label="Required" />
-                    <Checkbox
-                        id="ra-attr-list"
-                        checked={d.list || d.valueSourceType === ValueSourceType.StaticList}
-                        onChange={(c) => set({ list: c, multiSelect: c ? d.multiSelect : false })}
-                        label="List"
-                        // A static list is inherently a list attribute — locked on while it's selected.
-                        disabled={d.valueSourceType === ValueSourceType.StaticList}
-                    />
-                    <Checkbox
-                        id="ra-attr-multi"
-                        checked={d.multiSelect}
-                        onChange={(c) => set({ multiSelect: c })}
-                        label="Multi select"
-                        disabled={!d.list}
-                    />
-                    <Checkbox id="ra-attr-readonly" checked={d.readOnly} onChange={(c) => set({ readOnly: c })} label="Read Only" />
-                </Container>
                 <Select
                     id="ra-attr-mapping"
                     label="Mapping target"
@@ -527,14 +508,47 @@ export default function RequestAttributeAuthoringEditor({
                     onChange={(v) => {
                         const valueSourceType = v as ValueSourceType;
                         // Selecting a static list forces `list` on (see DTO builder) so the toggle and
-                        // the authored options never disagree.
+                        // the authored options never disagree; List and Read Only are mutually exclusive, so clear it.
+                        // Free input is a single typed value, so it clears the list/multi-select toggles.
                         set({
                             valueSourceType,
-                            ...(valueSourceType === ValueSourceType.StaticList ? { list: true } : {}),
+                            ...(valueSourceType === ValueSourceType.StaticList
+                                ? { list: true, readOnly: false }
+                                : { list: false, multiSelect: false }),
                         });
                     }}
                     options={isStaticListSupportedForContentType(d.contentType) ? VALUE_SOURCE_OPTIONS : FREE_INPUT_ONLY_OPTIONS}
                 />
+                <div className="space-y-2">
+                    <Label>Properties</Label>
+                    <Container className="flex-row items-center" gap={4}>
+                        <Checkbox id="ra-attr-required" checked={d.required} onChange={(c) => set({ required: c })} label="Required" />
+                        {/* List/Multi select apply to a static list only; free input is a single typed value. */}
+                        {d.valueSourceType === ValueSourceType.StaticList && (
+                            <>
+                                <Checkbox
+                                    id="ra-attr-list"
+                                    checked={d.list || d.valueSourceType === ValueSourceType.StaticList}
+                                    onChange={(c) => set({ list: c, multiSelect: c ? d.multiSelect : false })}
+                                    label="List"
+                                    // A static list is inherently a list attribute — locked on while it's selected.
+                                    disabled={d.valueSourceType === ValueSourceType.StaticList}
+                                />
+                                <Checkbox
+                                    id="ra-attr-multi"
+                                    checked={d.multiSelect}
+                                    onChange={(c) => set({ multiSelect: c })}
+                                    label="Multi select"
+                                    disabled={!d.list}
+                                />
+                            </>
+                        )}
+                        {/* Read Only applies to free input only (lock the single value to its default). */}
+                        {d.valueSourceType === ValueSourceType.None && (
+                            <Checkbox id="ra-attr-readonly" checked={d.readOnly} onChange={(c) => set({ readOnly: c })} label="Read Only" />
+                        )}
+                    </Container>
+                </div>
                 {d.valueSourceType === ValueSourceType.StaticList && renderStaticValues(d, set)}
                 {d.valueSourceType === ValueSourceType.None && renderFreeInputDefault(d, set)}
             </div>

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -115,7 +115,7 @@ function FieldHint({ children, dataTestId }: Readonly<{ children: React.ReactNod
 /** `value` = attribute UUID, `label` = human display, `description` = internal attribute name (the binding name-fallback key). */
 type ConnectorAttributeOption = { value: string; label: string; description?: string };
 
-export type OidSelectOption = { value: string; label: string; description?: string; aliases?: string[] };
+export type OidSelectOption = { value: string; label: string; description?: string; aliases?: string[]; code?: string };
 
 // Resolve a stored mapping value to the option it belongs to. A legacy value may be an RDN code
 // (e.g. CN) rather than the dotted OID the dropdown now emits, so match aliases too and return the

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -407,9 +407,12 @@ export default function RequestAttributeAuthoringEditor({
                         // Static list is only authorable for scalar content types; drop back to free
                         // input if the new type can't carry one, so we never render a missing editor.
                         const keepStaticList = isStaticListSupportedForContentType(contentType);
+                        // Drop both the static list and any free-input default — a value entered under
+                        // the old type would otherwise survive and serialise as a wrong-typed content entry.
                         set({
                             contentType,
                             staticValues: [],
+                            defaultValue: undefined,
                             valueSourceType: keepStaticList ? d.valueSourceType : ValueSourceType.None,
                         });
                     }}
@@ -497,6 +500,7 @@ export default function RequestAttributeAuthoringEditor({
                             checked={d.mappingCriticalOverridable ?? false}
                             onChange={(c) => set({ mappingCriticalOverridable: c })}
                             label="Requester may override criticality"
+                            disabled={disabled}
                         />
                     </>
                 )}
@@ -522,7 +526,13 @@ export default function RequestAttributeAuthoringEditor({
                 <div className="space-y-2">
                     <Label>Properties</Label>
                     <Container className="flex-row items-center" gap={4}>
-                        <Checkbox id="ra-attr-required" checked={d.required} onChange={(c) => set({ required: c })} label="Required" />
+                        <Checkbox
+                            id="ra-attr-required"
+                            checked={d.required}
+                            onChange={(c) => set({ required: c })}
+                            label="Required"
+                            disabled={disabled}
+                        />
                         {/* List/Multi select apply to a static list only; free input is a single typed value. */}
                         {d.valueSourceType === ValueSourceType.StaticList && (
                             <>
@@ -532,20 +542,26 @@ export default function RequestAttributeAuthoringEditor({
                                     onChange={(c) => set({ list: c, multiSelect: c ? d.multiSelect : false })}
                                     label="List"
                                     // A static list is inherently a list attribute — locked on while it's selected.
-                                    disabled={d.valueSourceType === ValueSourceType.StaticList}
+                                    disabled={disabled || d.valueSourceType === ValueSourceType.StaticList}
                                 />
                                 <Checkbox
                                     id="ra-attr-multi"
                                     checked={d.multiSelect}
                                     onChange={(c) => set({ multiSelect: c })}
                                     label="Multi select"
-                                    disabled={!d.list}
+                                    disabled={disabled || !d.list}
                                 />
                             </>
                         )}
                         {/* Read Only applies to free input only (lock the single value to its default). */}
                         {d.valueSourceType === ValueSourceType.None && (
-                            <Checkbox id="ra-attr-readonly" checked={d.readOnly} onChange={(c) => set({ readOnly: c })} label="Read Only" />
+                            <Checkbox
+                                id="ra-attr-readonly"
+                                checked={d.readOnly}
+                                onChange={(c) => set({ readOnly: c })}
+                                label="Read Only"
+                                disabled={disabled}
+                            />
                         )}
                     </Container>
                 </div>
@@ -638,7 +654,7 @@ export default function RequestAttributeAuthoringEditor({
                     inputType={config.type}
                     contentType={d.contentType}
                     fieldStepValue={getStepValue(config.type)}
-                    value={d.defaultValue ?? config.initial}
+                    value={d.defaultValue ?? ''}
                     onChange={(next) => set({ defaultValue: next })}
                     readOnly={disabled}
                     placeholder="Enter default value"

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -538,8 +538,11 @@ export default function RequestAttributeAuthoringEditor({
                     onChange={(v) => {
                         const valueSourceType = v as ValueSourceType;
                         // Selecting a static list forces `list` on (see DTO builder) so the toggle and
-                        // the authored options never disagree.
-                        set({ valueSourceType, ...(valueSourceType === ValueSourceType.StaticList ? { list: true } : {}) });
+                        // the authored options never disagree; Read Only is free-input-only, so clear it.
+                        set({
+                            valueSourceType,
+                            ...(valueSourceType === ValueSourceType.StaticList ? { list: true, readOnly: false } : {}),
+                        });
                     }}
                     options={isStaticListSupportedForContentType(d.contentType) ? VALUE_SOURCE_OPTIONS : FREE_INPUT_ONLY_OPTIONS}
                     showSelectedDescriptionAsHelp
@@ -625,22 +628,29 @@ export default function RequestAttributeAuthoringEditor({
     // the content type; persisted like a single-entry static list. Non-scalar types have no editor.
     const renderFreeInputDefault = (d: AuthoredAttributeFormValues, set: (p: Partial<AuthoredAttributeFormValues>) => void) => {
         const config = ContentFieldConfiguration[d.contentType];
-        if (!config) return null;
         return (
             <div className="space-y-2" data-testid={`${dataTestId}-default-value-block`}>
-                <Label>Default value</Label>
-                <AddCustomValueInput
-                    id="ra-attr-default-value"
-                    inputType={config.type}
-                    contentType={d.contentType}
-                    fieldStepValue={getStepValue(config.type)}
-                    value={d.defaultValue ?? config.initial}
-                    onChange={(next) => set({ defaultValue: next })}
-                    readOnly={disabled}
-                />
-                <FieldHint dataTestId={`${dataTestId}-default-value-hint`}>
-                    Optional. Pre-fills the field on the request form; the requester can change it unless Read Only is set.
+                <Checkbox id="ra-attr-readonly" checked={d.readOnly} onChange={(c) => set({ readOnly: c })} label="Read Only" />
+                <FieldHint dataTestId={`${dataTestId}-readonly-hint`}>
+                    The value is fixed to the default and the requester cannot change it.
                 </FieldHint>
+                {config && (
+                    <>
+                        <Label>Default value</Label>
+                        <AddCustomValueInput
+                            id="ra-attr-default-value"
+                            inputType={config.type}
+                            contentType={d.contentType}
+                            fieldStepValue={getStepValue(config.type)}
+                            value={d.defaultValue ?? config.initial}
+                            onChange={(next) => set({ defaultValue: next })}
+                            readOnly={disabled}
+                        />
+                        <FieldHint dataTestId={`${dataTestId}-default-value-hint`}>
+                            Optional. Pre-fills the field on the request form; the requester can change it unless Read Only is set.
+                        </FieldHint>
+                    </>
+                )}
             </div>
         );
     };

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -548,6 +548,7 @@ export default function RequestAttributeAuthoringEditor({
                     How the requester provides the value — free input, or a fixed list of choices you define.
                 </FieldHint>
                 {d.valueSourceType === ValueSourceType.StaticList && renderStaticValues(d, set)}
+                {d.valueSourceType === ValueSourceType.None && renderFreeInputDefault(d, set)}
             </div>
         );
     };
@@ -616,6 +617,30 @@ export default function RequestAttributeAuthoringEditor({
                     <Plus className="w-4 h-4" />
                     Add value
                 </Button>
+            </div>
+        );
+    };
+
+    // Optional default for a free-input attribute (valueSourceType === NONE). One scalar input typed by
+    // the content type; persisted like a single-entry static list. Non-scalar types have no editor.
+    const renderFreeInputDefault = (d: AuthoredAttributeFormValues, set: (p: Partial<AuthoredAttributeFormValues>) => void) => {
+        const config = ContentFieldConfiguration[d.contentType];
+        if (!config) return null;
+        return (
+            <div className="space-y-2" data-testid={`${dataTestId}-default-value-block`}>
+                <Label>Default value</Label>
+                <AddCustomValueInput
+                    id="ra-attr-default-value"
+                    inputType={config.type}
+                    contentType={d.contentType}
+                    fieldStepValue={getStepValue(config.type)}
+                    value={d.defaultValue ?? config.initial}
+                    onChange={(next) => set({ defaultValue: next })}
+                    readOnly={disabled}
+                />
+                <FieldHint dataTestId={`${dataTestId}-default-value-hint`}>
+                    Optional. Pre-fills the field on the request form; the requester can change it unless Read Only is set.
+                </FieldHint>
             </div>
         );
     };

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -284,10 +284,16 @@ export default function RequestAttributeAuthoringEditor({
         setAttrDraft(null);
     };
 
+    const rdnCodeDisplay = (stored?: string) => {
+        const v = stored?.trim();
+        if (!v) return '?';
+        return rdnOptions.find((o) => o.value === v)?.code ?? v;
+    };
+
     const mappingSummary = (attr: AuthoredAttributeFormValues) => {
         switch (attr.mappingFieldType) {
             case FieldType.Rdn:
-                return `→ RDN ${attr.mappingRdnCode || '?'}`;
+                return `→ RDN ${rdnCodeDisplay(attr.mappingRdnCode)}`;
             case FieldType.San:
                 return `→ SAN ${attr.mappingGeneralNameType ? GENERAL_NAME_TYPE_LABELS[attr.mappingGeneralNameType] : '?'}`;
             case FieldType.Extension:

--- a/src/components/RequestAttributes/RequestAttributeMappingBadge.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeMappingBadge.spec.tsx
@@ -1,6 +1,7 @@
 import { test, expect } from '../../../playwright/ct-test';
 import { FieldType, ObjectType } from 'types/openapi';
 import type { FieldMapping } from 'types/openapi';
+import { withProviders } from 'utils/test-helpers';
 import RequestAttributeMappingBadge from './RequestAttributeMappingBadge';
 
 const mapping = (fields: unknown[]): FieldMapping => ({ objectType: ObjectType.X509Certificate, fields }) as unknown as FieldMapping;
@@ -8,24 +9,28 @@ const mapping = (fields: unknown[]): FieldMapping => ({ objectType: ObjectType.X
 test.describe('RequestAttributeMappingBadge', () => {
     test('renders the mapping summary tokens', async ({ mount }) => {
         const component = await mount(
-            <RequestAttributeMappingBadge
-                fieldMapping={mapping([
-                    { fieldType: FieldType.Rdn, rdn: 'CN', order: 1 },
-                    { fieldType: FieldType.San, generalNameType: 'dns', order: 2 },
-                ])}
-            />,
+            withProviders(
+                <RequestAttributeMappingBadge
+                    fieldMapping={mapping([
+                        { fieldType: FieldType.Rdn, rdn: 'CN', order: 1 },
+                        { fieldType: FieldType.San, generalNameType: 'dns', order: 2 },
+                    ])}
+                />,
+            ),
         );
         await expect(component.getByText('→ Subject CN + SAN dNSName')).toBeVisible();
     });
 
     test('exposes a "Maps to" tooltip title', async ({ mount }) => {
-        const component = await mount(<RequestAttributeMappingBadge fieldMapping={mapping([{ fieldType: FieldType.Rdn, rdn: 'O' }])} />);
+        const component = await mount(
+            withProviders(<RequestAttributeMappingBadge fieldMapping={mapping([{ fieldType: FieldType.Rdn, rdn: 'O' }])} />),
+        );
         await expect(component).toHaveAttribute('title', 'Maps to: Subject O');
         await expect(component).toHaveAttribute('data-testid', 'request-attribute-mapping-badge');
     });
 
     test('renders nothing when there is no mapping', async ({ mount }) => {
-        const component = await mount(<RequestAttributeMappingBadge />);
+        const component = await mount(withProviders(<RequestAttributeMappingBadge />));
         await expect(component).toBeEmpty();
     });
 });

--- a/src/components/RequestAttributes/RequestAttributeMappingBadge.tsx
+++ b/src/components/RequestAttributes/RequestAttributeMappingBadge.tsx
@@ -1,6 +1,11 @@
 import { Info } from 'lucide-react';
+import { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import type { FieldMapping } from 'types/openapi';
+import { OidCategory } from 'types/openapi';
 import Badge from 'components/Badge';
+import { actions as oidActions, selectors as oidSelectors } from 'ducks/oids';
+import { buildRdnCodeByOid } from 'utils/oid';
 import { fieldMappingTokens } from 'utils/requestAttributes';
 
 type Props = {
@@ -9,7 +14,26 @@ type Props = {
 };
 
 function RequestAttributeMappingBadge({ fieldMapping, dataTestId = 'request-attribute-mapping-badge' }: Readonly<Props>) {
-    const tokens = fieldMappingTokens(fieldMapping);
+    const dispatch = useDispatch();
+    const systemOidsByCategory = useSelector(oidSelectors.systemOidsByCategory);
+    const oidsByCategory = useSelector(oidSelectors.oidsByCategory);
+
+    // System RDNs (CN, O, …) are stored on the mapping as their dotted OID; the fetch is guarded so
+    // this dispatch resolves the code list once even though the badge renders per mapped attribute.
+    useEffect(() => {
+        dispatch(oidActions.listSystemOids());
+    }, [dispatch]);
+
+    const rdnCodeByOid = useMemo(
+        () =>
+            buildRdnCodeByOid([
+                ...(systemOidsByCategory[OidCategory.RdnAttributeType] ?? []),
+                ...(oidsByCategory[OidCategory.RdnAttributeType] ?? []),
+            ]),
+        [systemOidsByCategory, oidsByCategory],
+    );
+
+    const tokens = fieldMappingTokens(fieldMapping, rdnCodeByOid);
     if (tokens.length === 0) return null;
 
     const summary = tokens.join(' + ');

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -46,6 +46,7 @@ interface BaseProps {
     placeholder?: string;
     disabled?: boolean;
     label?: string;
+    labelTooltip?: string;
     isDisabled?: boolean;
     placement?: 'top' | 'bottom';
     isClearable?: boolean;
@@ -159,6 +160,7 @@ function Select({
     className,
     placeholder = 'Select...',
     label,
+    labelTooltip,
     isDisabled,
     placement,
     isMulti = false,
@@ -452,7 +454,7 @@ function Select({
 
     return (
         <div data-testid={dataTestId ?? `select-${id}`}>
-            {label && <Label htmlFor={id} title={label} required={required} />}
+            {label && <Label htmlFor={id} title={label} required={required} labelTooltip={labelTooltip} />}
             <div ref={wrapperRef} className={cn('relative', className)} style={minWidth ? { minWidth: `${minWidth}px` } : undefined}>
                 <Popover.Root
                     modal={modal}

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -19,6 +19,7 @@ type Props = {
     invalid?: boolean;
     error?: string;
     label?: string;
+    labelTooltip?: string;
     className?: string;
     required?: boolean;
     buttonRight?: ReactNode;
@@ -36,6 +37,7 @@ function TextInput({
     invalid = false,
     error,
     label,
+    labelTooltip,
     className,
     required = false,
     buttonRight,
@@ -74,7 +76,7 @@ function TextInput({
         return (
             <>
                 {label && (
-                    <Label htmlFor={id} required={required}>
+                    <Label htmlFor={id} required={required} labelTooltip={labelTooltip}>
                         {label}
                     </Label>
                 )}
@@ -97,7 +99,7 @@ function TextInput({
         return (
             <>
                 {label && (
-                    <Label htmlFor={id} required={required}>
+                    <Label htmlFor={id} required={required} labelTooltip={labelTooltip}>
                         {label}
                     </Label>
                 )}
@@ -126,7 +128,7 @@ function TextInput({
     return (
         <>
             {label && (
-                <Label htmlFor={id} required={required}>
+                <Label htmlFor={id} required={required} labelTooltip={labelTooltip}>
                     {label}
                 </Label>
             )}

--- a/src/components/_pages/certificates/form/index.spec.tsx
+++ b/src/components/_pages/certificates/form/index.spec.tsx
@@ -3,7 +3,13 @@ import { testInitialState } from 'ducks/test-reducers';
 import { CertificateFormTestWrapper } from './CertificateFormTestWrapper';
 
 test.describe('CertificateForm', () => {
-    test('defaults to Issue now: key-source select visible, challenge input absent', async ({ mount, page }) => {
+    test('request mode radio is labelled "Request"', async ({ mount, page }) => {
+        await mount(<CertificateFormTestWrapper />);
+
+        await expect(page.getByTestId('requestType-issue')).toHaveText('Request');
+    });
+
+    test('defaults to Request mode: key-source select visible, challenge input absent', async ({ mount, page }) => {
         await mount(<CertificateFormTestWrapper />);
 
         await expect(page.getByTestId('keySource')).toBeVisible();
@@ -32,7 +38,7 @@ test.describe('CertificateForm', () => {
         await expect(page.getByTestId('label-authorizationSecret').locator('.text-red-500')).toBeVisible();
     });
 
-    test('switching back to Issue now restores the key-source select and hides the challenge input', async ({ mount, page }) => {
+    test('switching back to Request mode restores the key-source select and hides the challenge input', async ({ mount, page }) => {
         await mount(<CertificateFormTestWrapper />);
 
         await page.getByTestId('requestType-register').click();
@@ -44,7 +50,7 @@ test.describe('CertificateForm', () => {
         await expect(page.getByTestId('authorizationSecret')).toHaveCount(0);
     });
 
-    test('Issue now mode shows both the Connector Attributes and Custom Attributes tabs', async ({ mount, page }) => {
+    test('Request mode shows both the Connector Attributes and Custom Attributes tabs', async ({ mount, page }) => {
         await mount(<CertificateFormTestWrapper />);
 
         await expect(page.getByRole('tab', { name: 'Connector Attributes' })).toBeVisible();

--- a/src/components/_pages/certificates/form/index.spec.tsx
+++ b/src/components/_pages/certificates/form/index.spec.tsx
@@ -3,10 +3,10 @@ import { testInitialState } from 'ducks/test-reducers';
 import { CertificateFormTestWrapper } from './CertificateFormTestWrapper';
 
 test.describe('CertificateForm', () => {
-    test('request mode radio is labelled "Request"', async ({ mount, page }) => {
+    test('request mode radio is labelled "Request now"', async ({ mount, page }) => {
         await mount(<CertificateFormTestWrapper />);
 
-        await expect(page.getByTestId('requestType-issue')).toHaveText('Request');
+        await expect(page.getByTestId('requestType-issue')).toHaveText('Request now');
     });
 
     test('defaults to Request mode: key-source select visible, challenge input absent', async ({ mount, page }) => {

--- a/src/components/_pages/certificates/form/index.tsx
+++ b/src/components/_pages/certificates/form/index.tsx
@@ -363,7 +363,7 @@ export default function CertificateForm({ onCancel }: CertificateFormProps = {})
                                                     className="font-medium text-[var(--dark-gray-color)] dark:text-white"
                                                     data-testid="requestType-issue"
                                                 >
-                                                    Request
+                                                    Request now
                                                 </span>
                                                 <span className="text-gray-500 dark:text-neutral-400">
                                                     Submit a certificate request to the authority immediately.

--- a/src/components/_pages/certificates/form/index.tsx
+++ b/src/components/_pages/certificates/form/index.tsx
@@ -363,7 +363,7 @@ export default function CertificateForm({ onCancel }: CertificateFormProps = {})
                                                     className="font-medium text-[var(--dark-gray-color)] dark:text-white"
                                                     data-testid="requestType-issue"
                                                 >
-                                                    Issue now
+                                                    Request
                                                 </span>
                                                 <span className="text-gray-500 dark:text-neutral-400">
                                                     Submit a certificate request to the authority immediately.

--- a/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.spec.tsx
+++ b/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.spec.tsx
@@ -36,4 +36,16 @@ test.describe('RequestAttributesSettings (platform default set)', () => {
         await expect(component.getByTestId('request-attribute-authoring-attribute-add')).toBeDisabled();
         await expect(page.getByRole('button', { name: 'Save', exact: true })).toHaveCount(0);
     });
+
+    test('reflects the preloaded strict validation flag', async ({ mount, page }) => {
+        await mount(<RequestAttributesSettingsWithStore strict />);
+
+        await expect(page.getByTestId('switch-externalCsrValidationStrict-input')).toBeChecked();
+    });
+
+    test('strict validation switch is off when the platform default is unset', async ({ mount, page }) => {
+        await mount(<RequestAttributesSettingsWithStore />);
+
+        await expect(page.getByTestId('switch-externalCsrValidationStrict-input')).not.toBeChecked();
+    });
 });

--- a/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.tsx
+++ b/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.tsx
@@ -1,4 +1,5 @@
 import RequestAttributeAuthoringEditor from 'components/RequestAttributes/RequestAttributeAuthoringEditor';
+import Switch from 'components/Switch';
 import Widget from 'components/Widget';
 import { actions as oidActions, selectors as oidSelectors } from 'ducks/oids';
 import { actions, selectors } from 'ducks/raProfileRequestAttributes';
@@ -66,7 +67,11 @@ export default function RequestAttributesSettings() {
     // every `defaultSet` reference change would clobber in-progress edits when a late fetch resolves.
     useEffect(() => {
         if (defaultSet !== undefined && !loaded) {
-            setForm({ ...emptyAuthoringForm(), attributes: parsePlatformDefaultDto(defaultSet) });
+            setForm({
+                ...emptyAuthoringForm(),
+                attributes: parsePlatformDefaultDto(defaultSet),
+                externalCsrValidationStrict: defaultSet?.externalCsrValidationStrict,
+            });
             setLoaded(true);
         }
     }, [defaultSet, loaded]);
@@ -83,7 +88,7 @@ export default function RequestAttributesSettings() {
             if (!loaded) return;
             dispatch(
                 actions.updatePlatformDefaultRequestAttributes({
-                    data: buildPlatformDefaultUpdateDto(next.attributes),
+                    data: buildPlatformDefaultUpdateDto(next.attributes, next.externalCsrValidationStrict),
                 }),
             );
         },
@@ -127,6 +132,13 @@ export default function RequestAttributesSettings() {
                     The platform default request-attribute set is the terminal fallback used when an RA Profile does not define its own set.
                     Changes are saved automatically.
                 </p>
+                <Switch
+                    id="externalCsrValidationStrict"
+                    label="Strict external CSR validation"
+                    checked={form.externalCsrValidationStrict ?? false}
+                    onChange={(c) => onChange({ ...form, externalCsrValidationStrict: c })}
+                    disabled={isUpdating || !loaded}
+                />
                 {editor}
             </div>
         </Widget>

--- a/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettingsWithStore.tsx
+++ b/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettingsWithStore.tsx
@@ -9,14 +9,12 @@ import RequestAttributesSettings from './RequestAttributesSettings';
 // resolves on its own; a browser-side preloaded store is the supported way to reach the loaded
 // state (mirrors SigningRecordsDashboardWithStore). Creating the store inside this component
 // keeps it in the browser context — a store built in the Node test body does not transfer.
-const preloadedState = {
-    raProfileRequestAttributes: {
-        defaultSet: { requestAttributes: [] },
-    },
-} as any;
-
-export default function RequestAttributesSettingsWithStore() {
-    const store = createMockStore(preloadedState);
+export default function RequestAttributesSettingsWithStore({ strict }: Readonly<{ strict?: boolean }>) {
+    const store = createMockStore({
+        raProfileRequestAttributes: {
+            defaultSet: { requestAttributes: [], externalCsrValidationStrict: strict },
+        },
+    } as any);
     return (
         <Provider store={store}>
             <MemoryRouter initialEntries={['/platformsettings/request-attributes']}>

--- a/src/utils/oid.spec.ts
+++ b/src/utils/oid.spec.ts
@@ -146,4 +146,30 @@ describe('oid utils', () => {
             expect(options[1].aliases).toBeUndefined();
         });
     });
+
+    describe('toOidSelectOptions RDN code label', () => {
+        test('appends the RDN code in brackets and exposes it as `code`', () => {
+            const [opt] = toOidSelectOptions([
+                {
+                    oid: '2.5.4.3',
+                    displayName: 'Common Name',
+                    additionalProperties: { code: 'CN' },
+                } as any,
+            ]);
+            expect(opt.label).toBe('Common Name (CN)');
+            expect(opt.code).toBe('CN');
+        });
+
+        test('leaves non-RDN (extension) options without a code and unbracketed', () => {
+            const [opt] = toOidSelectOptions([
+                {
+                    oid: '2.5.29.19',
+                    displayName: 'Basic Constraints',
+                    additionalProperties: { valueEncoding: 'BASE64' },
+                } as any,
+            ]);
+            expect(opt.label).toBe('Basic Constraints');
+            expect(opt.code).toBeUndefined();
+        });
+    });
 });

--- a/src/utils/oid.spec.ts
+++ b/src/utils/oid.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { OidCategory, ExtensionValueEncoding, type CustomOidEntryDetailResponseDtoAdditionalProperties } from 'types/openapi';
 import type { OIDResponseModel } from 'types/oids';
 import {
@@ -10,6 +10,7 @@ import {
     isCertificateExtensionProperties,
     isRdnProperties,
     toOidSelectOptions,
+    buildRdnCodeByOid,
 } from './oid';
 
 describe('oid utils', () => {
@@ -171,5 +172,15 @@ describe('oid utils', () => {
             expect(opt.label).toBe('Basic Constraints');
             expect(opt.code).toBeUndefined();
         });
+    });
+});
+
+describe('buildRdnCodeByOid', () => {
+    it('maps RDN OIDs to their codes and skips non-RDN entries', () => {
+        const map = buildRdnCodeByOid([
+            { oid: '2.5.4.3', additionalProperties: { code: 'CN' } } as any,
+            { oid: '2.5.29.19', additionalProperties: { valueEncoding: 'BASE64' } } as any,
+        ]);
+        expect(map).toEqual({ '2.5.4.3': 'CN' });
     });
 });

--- a/src/utils/oid.ts
+++ b/src/utils/oid.ts
@@ -56,12 +56,14 @@ export const isRdnProperties = (props?: CustomOidEntryDetailResponseDtoAdditiona
 
 export const toOidSelectOptions = (
     entries: OIDResponseModel[],
-): { value: string; label: string; description?: string; aliases?: string[] }[] =>
+): { value: string; label: string; description?: string; aliases?: string[]; code?: string }[] =>
     entries.map((e) => {
         // RDN entries carry a code (+altCodes); a legacy mapping may store one of those instead of the
         // dotted OID, so expose them as aliases the dropdown can reconcile back to this option.
+        const code = isRdnProperties(e.additionalProperties) ? e.additionalProperties.code : undefined;
         const aliases = isRdnProperties(e.additionalProperties)
             ? [e.additionalProperties.code, ...(e.additionalProperties.altCodes ?? [])].filter(Boolean)
             : undefined;
-        return { value: e.oid, label: e.displayName?.trim() || e.oid, description: e.description, aliases };
+        const name = e.displayName?.trim() || e.oid;
+        return { value: e.oid, label: code ? `${name} (${code})` : name, description: e.description, aliases, code };
     });

--- a/src/utils/oid.ts
+++ b/src/utils/oid.ts
@@ -67,3 +67,13 @@ export const toOidSelectOptions = (
         const name = e.displayName?.trim() || e.oid;
         return { value: e.oid, label: code ? `${name} (${code})` : name, description: e.description, aliases, code };
     });
+
+export const buildRdnCodeByOid = (entries: OIDResponseModel[]): Record<string, string> => {
+    const map: Record<string, string> = {};
+    for (const e of entries) {
+        if (isRdnProperties(e.additionalProperties) && e.additionalProperties.code) {
+            map[e.oid] = e.additionalProperties.code;
+        }
+    }
+    return map;
+};

--- a/src/utils/requestAttributeAuthoring.spec.ts
+++ b/src/utils/requestAttributeAuthoring.spec.ts
@@ -612,6 +612,19 @@ describe('requestAttributeAuthoring', () => {
             expect(form.valueSourceType).toBe(ValueSourceType.None);
             expect(form.defaultValue).toBe('prod');
         });
+
+        it('does not leak a free-input default into staticValues', () => {
+            const form = parseAuthoredAttributeDto({
+                uuid: 'u1',
+                name: 'env',
+                type: AttributeType.Data,
+                contentType: AttributeContentType.String,
+                properties: { label: 'Environment' },
+                content: [{ data: 'prod' }],
+            } as any);
+            expect(form.defaultValue).toBe('prod');
+            expect(form.staticValues).toEqual([]);
+        });
     });
 
     describe('hasAuthoredRequestAttributes', () => {

--- a/src/utils/requestAttributeAuthoring.spec.ts
+++ b/src/utils/requestAttributeAuthoring.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import {
     AttributeContentType,
     AttributeSetMergeMode,
@@ -573,6 +573,44 @@ describe('requestAttributeAuthoring', () => {
             const parsed = parsePlatformDefaultDto({ requestAttributes: [buildAuthoredAttributeDto(baseAttr()) as BaseAttributeDto] });
             expect(parsed).toHaveLength(1);
             expect(parsed[0].name).toBe('serverFqdn');
+        });
+    });
+
+    describe('free-input default value <-> content round-trip', () => {
+        it('serialises a free-input default value into a single content entry', () => {
+            const dto = buildAuthoredAttributeDto({
+                ...emptyAuthoredAttribute(),
+                name: 'env',
+                label: 'Environment',
+                contentType: AttributeContentType.String,
+                valueSourceType: ValueSourceType.None,
+                defaultValue: 'prod',
+            });
+            expect(dto.content).toEqual([{ data: 'prod', contentType: AttributeContentType.String }]);
+        });
+
+        it('omits content when the free-input default value is blank', () => {
+            const dto = buildAuthoredAttributeDto({
+                ...emptyAuthoredAttribute(),
+                name: 'env',
+                label: 'Environment',
+                valueSourceType: ValueSourceType.None,
+                defaultValue: '   ',
+            });
+            expect(dto.content).toBeUndefined();
+        });
+
+        it('parses a free-input content entry back into defaultValue', () => {
+            const form = parseAuthoredAttributeDto({
+                uuid: 'u1',
+                name: 'env',
+                type: AttributeType.Data,
+                contentType: AttributeContentType.String,
+                properties: { label: 'Environment' },
+                content: [{ data: 'prod' }],
+            } as any);
+            expect(form.valueSourceType).toBe(ValueSourceType.None);
+            expect(form.defaultValue).toBe('prod');
         });
     });
 

--- a/src/utils/requestAttributeAuthoring.spec.ts
+++ b/src/utils/requestAttributeAuthoring.spec.ts
@@ -633,3 +633,15 @@ describe('requestAttributeAuthoring', () => {
         });
     });
 });
+
+describe('buildPlatformDefaultUpdateDto strict flag', () => {
+    it('includes externalCsrValidationStrict in the update DTO', () => {
+        const dto = buildPlatformDefaultUpdateDto([], true);
+        expect(dto.externalCsrValidationStrict).toBe(true);
+    });
+
+    it('carries false through so toggling strictness off persists', () => {
+        const dto = buildPlatformDefaultUpdateDto([], false);
+        expect(dto.externalCsrValidationStrict).toBe(false);
+    });
+});

--- a/src/utils/requestAttributeAuthoring.ts
+++ b/src/utils/requestAttributeAuthoring.ts
@@ -463,9 +463,13 @@ export function parseRaProfileRequestAttributesDto(
     };
 }
 
-export function buildPlatformDefaultUpdateDto(attributes: AuthoredAttributeFormValues[]): CertificateRequestAttributesSettingsUpdateDto {
+export function buildPlatformDefaultUpdateDto(
+    attributes: AuthoredAttributeFormValues[],
+    externalCsrValidationStrict?: boolean,
+): CertificateRequestAttributesSettingsUpdateDto {
     return {
         requestAttributes: attributes.map((attr) => buildAuthoredAttributeDto(attr) as BaseAttributeDto),
+        externalCsrValidationStrict,
     };
 }
 

--- a/src/utils/requestAttributeAuthoring.ts
+++ b/src/utils/requestAttributeAuthoring.ts
@@ -70,6 +70,8 @@ export interface AuthoredAttributeFormValues {
      * `contentType`, mirroring how custom attributes store predefined content.
      */
     staticValues: (string | number | boolean)[];
+    /** Free-input default (valueSourceType === NONE) — pre-fills the field. Persisted as a single `content` entry. */
+    defaultValue?: string | number | boolean;
     /** Reserved for the COLLECTION source (stubbed for now). */
     collectionRef?: string;
     /** Cascading dependency params, preserved on round-trip (no authoring UI yet). */
@@ -145,6 +147,7 @@ export function emptyAuthoredAttribute(): AuthoredAttributeFormValues {
         mappingCriticalOverridable: false,
         valueSourceType: ValueSourceType.None,
         staticValues: [],
+        defaultValue: undefined,
         collectionRef: '',
     };
 }
@@ -246,6 +249,12 @@ function normalizeStaticContentValue(value: string | number | boolean, contentTy
     }
 }
 
+/** True when a free-input attribute (valueSourceType === NONE) has a non-blank default value to persist. */
+function hasFreeInputDefault(form: AuthoredAttributeFormValues): boolean {
+    const v = form.defaultValue;
+    return v !== undefined && (typeof v !== 'string' || v.trim() !== '');
+}
+
 export function buildAuthoredAttributeDto(form: AuthoredAttributeFormValues): DataAttributeV3 {
     // A static list presents a predefined set of options, so it is a list attribute by definition —
     // force `list` on regardless of the toggle so the DTO does not contradict the content array.
@@ -285,6 +294,13 @@ export function buildAuthoredAttributeDto(form: AuthoredAttributeFormValues): Da
             data: normalizeStaticContentValue(value, form.contentType),
             contentType: form.contentType,
         })) as DataAttributeV3['content'];
+    } else if (form.valueSourceType === ValueSourceType.None && hasFreeInputDefault(form)) {
+        dto.content = [
+            {
+                data: normalizeStaticContentValue(form.defaultValue as string | number | boolean, form.contentType),
+                contentType: form.contentType,
+            },
+        ] as DataAttributeV3['content'];
     }
     return dto;
 }
@@ -319,6 +335,10 @@ export function parseAuthoredAttributeDto(dto: BaseAttributeDto): AuthoredAttrib
         mappingCriticalOverridable: ext?.criticalOverridable ?? false,
         valueSourceType: view.valueSource?.kind ?? ValueSourceType.None,
         staticValues: (view.content ?? []).map((item) => (item as { data: string | number | boolean }).data),
+        defaultValue:
+            (view.valueSource?.kind ?? ValueSourceType.None) === ValueSourceType.None
+                ? (view.content?.[0] as { data?: string | number | boolean } | undefined)?.data
+                : undefined,
         collectionRef: '',
         valueSourceParams: view.valueSource?.params,
     };

--- a/src/utils/requestAttributeAuthoring.ts
+++ b/src/utils/requestAttributeAuthoring.ts
@@ -315,6 +315,7 @@ export function parseAuthoredAttributeDto(dto: BaseAttributeDto): AuthoredAttrib
     const rdn = firstField && firstField.fieldType === FieldType.Rdn ? firstField : undefined;
     const san = firstField && firstField.fieldType === FieldType.San ? firstField : undefined;
     const ext = firstField && firstField.fieldType === FieldType.Extension ? firstField : undefined;
+    const valueSourceKind = view.valueSource?.kind ?? ValueSourceType.None;
     return {
         uuid: view.uuid,
         name: view.name ?? '',
@@ -333,10 +334,15 @@ export function parseAuthoredAttributeDto(dto: BaseAttributeDto): AuthoredAttrib
         mappingOtherNameEncoding: san?.otherNameValueEncoding,
         mappingExtensionOid: ext?.extensionOid ?? '',
         mappingCriticalOverridable: ext?.criticalOverridable ?? false,
-        valueSourceType: view.valueSource?.kind ?? ValueSourceType.None,
-        staticValues: (view.content ?? []).map((item) => (item as { data: string | number | boolean }).data),
+        valueSourceType: valueSourceKind,
+        // A free-input default is stored in `content` too, so only lift `content` into `staticValues`
+        // for an actual static list — otherwise a free-input default leaks into the static-list editor.
+        staticValues:
+            valueSourceKind === ValueSourceType.StaticList
+                ? (view.content ?? []).map((item) => (item as { data: string | number | boolean }).data)
+                : [],
         defaultValue:
-            (view.valueSource?.kind ?? ValueSourceType.None) === ValueSourceType.None
+            valueSourceKind === ValueSourceType.None
                 ? (view.content?.[0] as { data?: string | number | boolean } | undefined)?.data
                 : undefined,
         collectionRef: '',

--- a/src/utils/requestAttributes.spec.ts
+++ b/src/utils/requestAttributes.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { AttributeContentType, AttributeType, FieldType, ObjectType } from 'types/openapi';
 import type { FieldMapping } from 'types/openapi';
 import type { AttributeDescriptorModel } from 'types/attributes';
@@ -96,5 +96,17 @@ describe('fieldMappingTokens', () => {
     test('returns an empty array for undefined / empty mapping', () => {
         expect(fieldMappingTokens(undefined)).toEqual([]);
         expect(fieldMappingTokens(mapping([]))).toEqual([]);
+    });
+});
+
+describe('fieldMappingTokens RDN code resolution', () => {
+    const mapping = { objectType: 'x509Certificate', fields: [{ fieldType: 'rdn', rdn: '2.5.4.3' }] } as any;
+
+    it('renders the resolved RDN code when a map is supplied', () => {
+        expect(fieldMappingTokens(mapping, { '2.5.4.3': 'CN' })).toEqual(['Subject CN']);
+    });
+
+    it('falls back to the raw OID when the map has no entry', () => {
+        expect(fieldMappingTokens(mapping, {})).toEqual(['Subject 2.5.4.3']);
     });
 });

--- a/src/utils/requestAttributes.ts
+++ b/src/utils/requestAttributes.ts
@@ -32,11 +32,12 @@ function generalNameLabel(value: string): string {
     return GENERAL_NAME_LABELS[value as GeneralNameType] ?? value;
 }
 
-function fieldToken(field: MappedField): string {
+function fieldToken(field: MappedField, rdnCodeByOid: Record<string, string> = {}): string {
     switch (field?.fieldType) {
         case FieldType.Rdn: {
             const rdn = (field as { rdn?: string }).rdn;
-            return rdn ? `Subject ${rdn}` : 'Subject';
+            const code = rdn ? (rdnCodeByOid[rdn] ?? rdn) : undefined;
+            return code ? `Subject ${code}` : 'Subject';
         }
         case FieldType.San: {
             const generalNameType = (field as { generalNameType?: string }).generalNameType;
@@ -62,7 +63,7 @@ function typeRank(field: MappedField): number {
  * because `order` is a per-type index. This is the single source both the badge summary and
  * its tooltip build on, so their delimiters can never drift apart.
  */
-export function fieldMappingTokens(fieldMapping: FieldMapping | undefined): string[] {
+export function fieldMappingTokens(fieldMapping: FieldMapping | undefined, rdnCodeByOid: Record<string, string> = {}): string[] {
     const fields = fieldMapping?.fields;
     if (!Array.isArray(fields) || fields.length === 0) return [];
     return [...(fields as MappedField[])]
@@ -71,11 +72,11 @@ export function fieldMappingTokens(fieldMapping: FieldMapping | undefined): stri
             if (byType !== 0) return byType;
             return (a?.order ?? Number.MAX_SAFE_INTEGER) - (b?.order ?? Number.MAX_SAFE_INTEGER);
         })
-        .map((field) => fieldToken(field))
+        .map((field) => fieldToken(field, rdnCodeByOid))
         .filter((token) => token.length > 0);
 }
 
 /** Human summary of where the value lands, e.g. "Subject CN + SAN dNSName". */
-export function fieldMappingSummary(fieldMapping: FieldMapping | undefined): string {
-    return fieldMappingTokens(fieldMapping).join(' + ');
+export function fieldMappingSummary(fieldMapping: FieldMapping | undefined, rdnCodeByOid: Record<string, string> = {}): string {
+    return fieldMappingTokens(fieldMapping, rdnCodeByOid).join(' + ');
 }


### PR DESCRIPTION
Closes #1894.

Six independent UX/correctness improvements to the add-certificate form, the request-attribute mapping editor, and platform settings.

## Changes (per acceptance criteria)

1. **Rename "Issue now" → "Request"** — the add-certificate mode radio label now reads "Request" (field value/testid and the submit button are unchanged, per scope).
2. **RDN code in the mapping dropdown** — RDN options now show the code in brackets, e.g. `Common Name (CN)`; extensions are unaffected.
3. **Editor set list shows the code** — the authored-attributes summary resolves a system RDN's stored OID back to its code (e.g. `→ RDN CN`), falling back to the raw value when unresolved.
4. **Request-form badge shows the code** — the mapping badge resolves system-RDN OIDs to their code via the `oids` slice (guarded one-time `listSystemOids`), falling back to the OID string when unavailable.
5. **Free-input default value** — a "Free input" Value Source now offers an optional default-value input, serialised into the DTO `content` array the same way the static-list flow works.
6. **Read Only for free input** — a "Read Only" checkbox (bound to the attribute `readOnly` property) for free-input mappings; it is cleared when switching to a Static list.
7. **Platform `externalCsrValidationStrict` switch** — platform settings → Request Attributes now exposes the CSR-validation-strictness flag as an on/off switch (a plain switch — there is no parent default to inherit at the platform level, unlike the RA-profile dialog).

## Testing

- Full unit suite: **2864/2864** passing.
- Component tests (chromium): cert form, mapping editor, mapping badge, platform request-attributes — **45/45** passing, including new coverage for the RDN label/code, free-input default round-trip, the Read Only reset invariant (verified red-on-broken), and the platform strict switch.
- `npm run lint`: 0 errors (291-warning baseline); per-file `tsc` clean on all touched files.

## Notes / follow-ups (non-blocking, from the whole-branch review)

- Badge RDN-code resolution covers system RDNs and any custom RDNs already loaded in the `oids` slice; otherwise it falls back to the OID string (no regression).
- Minor follow-ups suggested as one ticket: wire the dialog checkboxes (Required/List/Read Only) to the form-level `disabled` prop; guard `staticValues` to the Static-list case on parse; add a CT for the non-scalar free-input Read Only render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
