### PR TITLE
Bump vulnerable dev transitives brace-expansion and ws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10185,9 +10185,9 @@
             "license": "MIT"
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11099,9 +11099,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
         "js-yaml": "$js-yaml",
         "shell-quote": "^1.8.4",
         "esbuild": "^0.28.1",
+        "brace-expansion@2": "2.1.2",
+        "ws@8": "8.21.1",
         "nyc": {
             "istanbul-lib-processinfo": {
                 "uuid": "^14.0.0"


### PR DESCRIPTION
## Summary

Fixes two SonarQube-reported security findings on **dev-only transitive** dependencies by forcing patched versions via scoped npm `overrides`.

| Package | Before | After | Advisory | Pulled in via |
|---|---|---|---|---|
| `brace-expansion` | 2.1.1 | **2.1.2** | CVE-2026-13149 — ReDoS (CWE-400/407), CVSS 7.7 | `test-exclude` → `glob@10` (istanbul/nyc coverage) |
| `ws` | 8.21.0 | **8.21.1** | CVE-2026-62389 — unbounded allocation (CWE-770), CVSS 7.5 | `happy-dom` (Vitest test env) |

Version-scoped keys (`brace-expansion@2`, `ws@8`) target only the vulnerable major lines. The separate, non-vulnerable `brace-expansion@5.0.7` and `@types/ws@8.18.1` instances are left untouched.

Both packages are build/test-time only and never part of the shipped production bundle.

## Verification

- `npm install` → `changed 2 packages`, **`found 0 vulnerabilities`**
- Resolved trees confirmed: `test-exclude/node_modules/brace-expansion` → 2.1.2, `node_modules/ws` → 8.21.1
- Smoke test (happy-dom env boots): `vitest run` on a unit spec → passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)