### PR TITLE
Validate request-attribute definitions client-side and roll back rejected saves

### DIFF
--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.spec.tsx
@@ -1,8 +1,21 @@
+import type { Page } from '@playwright/test';
 import { test, expect } from '../../../playwright/ct-test';
 import { withProviders } from 'utils/test-helpers';
 import RequestAttributeAuthoringEditorHarness from './RequestAttributeAuthoringEditorHarness';
 import { emptyAuthoringForm, emptyAuthoredAttribute } from 'utils/requestAttributeAuthoring';
 import { FieldType, ObjectType } from 'types/openapi';
+
+/**
+ * Every definition must carry a mapping target, so a test that is not about mapping still has to
+ * pick one to reach an enabled Save. SAN/dNSName is the cheapest: unlike RDN and Extension it needs
+ * no OID options wired into the harness.
+ */
+async function pickSanMapping(page: Page) {
+    await page.getByTestId('select-ra-attr-mapping-trigger').click();
+    await page.getByRole('option', { name: 'Subject Alternative Name' }).click();
+    await page.getByTestId('select-ra-attr-general-name-type-trigger').click();
+    await page.getByRole('option', { name: 'dNSName' }).click();
+}
 
 test.describe('RequestAttributeAuthoringEditor', () => {
     test('shows empty states and the merge-mode selector when enabled', async ({ mount }) => {
@@ -44,6 +57,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-name').fill('serverFqdn');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Server FQDN');
+        await pickSanMapping(page);
         await page.getByRole('button', { name: 'Save' }).click();
 
         await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(1);
@@ -96,11 +110,13 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.getByRole('option', { name: 'RDN (subject)' }).click();
 
         const saveButton = page.getByRole('button', { name: 'Save', exact: true });
-        await expect(saveButton).toBeDisabled();
+        await saveButton.click();
+        await expect(page.getByTestId('request-attribute-authoring-attribute-rdn-error')).toBeVisible();
+        await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(0);
 
         await page.getByTestId('select-ra-attr-rdn-trigger').click();
         await page.getByRole('option', { name: 'Common Name' }).click();
-        await expect(saveButton).toBeEnabled();
+        await expect(page.getByTestId('request-attribute-authoring-attribute-rdn-error')).toHaveCount(0);
         await saveButton.click();
 
         await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toContainText('→ RDN 1.3.6.1.4.1.99999.1');
@@ -308,12 +324,15 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-name').fill('environment');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
+        await pickSanMapping(page);
 
         await page.getByTestId('select-ra-attr-value-source-trigger').click();
         await page.getByRole('option', { name: 'Static list' }).click();
 
         const saveButton = page.getByRole('button', { name: 'Save', exact: true });
-        await expect(saveButton).toBeDisabled();
+        await saveButton.click();
+        await expect(page.getByTestId('request-attribute-authoring-static-values-error')).toContainText('at least one value');
+        await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(0);
 
         await page.getByTestId('request-attribute-authoring-static-value-add').click();
         await page.locator('#ra-attr-static-value-0').click();
@@ -322,7 +341,6 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-static-value-1').click();
         await page.locator('#ra-attr-static-value-1').fill('staging');
 
-        await expect(saveButton).toBeEnabled();
         await saveButton.click();
 
         await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toContainText('Static list');
@@ -339,6 +357,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-name').fill('environment');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
+        await pickSanMapping(page);
 
         await page.getByTestId('select-ra-attr-value-source-trigger').click();
         await page.getByRole('option', { name: 'Static list' }).click();
@@ -350,13 +369,17 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-static-value-1').click();
         await page.locator('#ra-attr-static-value-1').fill('prod');
 
-        await expect(page.getByTestId('request-attribute-authoring-static-values-duplicate')).toBeVisible();
+        const staticValuesError = page.getByTestId('request-attribute-authoring-static-values-error');
         const saveButton = page.getByRole('button', { name: 'Save', exact: true });
-        await expect(saveButton).toBeDisabled();
+        await saveButton.click();
+        await expect(staticValuesError).toContainText('unique');
+        await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(0);
 
+        // Once revealed, the message tracks the field live and clears as soon as it is fixed.
         await page.locator('#ra-attr-static-value-1').fill('staging');
-        await expect(page.getByTestId('request-attribute-authoring-static-values-duplicate')).toHaveCount(0);
-        await expect(saveButton).toBeEnabled();
+        await expect(staticValuesError).toHaveCount(0);
+        await saveButton.click();
+        await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(1);
     });
 
     test('selecting a static list locks the List toggle on', async ({ mount, page }) => {
@@ -367,6 +390,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-name').fill('environment');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
+        await pickSanMapping(page);
 
         // Free input (default) does not offer the List checkbox at all.
         await expect(page.locator('#ra-attr-list')).toHaveCount(0);
@@ -491,8 +515,10 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Duplicate');
 
+        await page.getByRole('button', { name: 'Save', exact: true }).click();
         await expect(page.getByTestId('request-attribute-authoring-attribute-name-duplicate')).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeDisabled();
+        // Still the single pre-existing row: the duplicate was not stored.
+        await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(1);
     });
 
     test('removes an authored attribute', async ({ mount }) => {
@@ -554,6 +580,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-name').fill('env');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
+        await pickSanMapping(page);
         await page.locator('#ra-attr-default-value').click();
         await page.locator('#ra-attr-default-value').fill('prod');
         await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
@@ -582,15 +609,17 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-name').fill('env');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
+        // Mapped definitions are restricted to String/Text, so the switch under test is String → Text.
+        await pickSanMapping(page);
         await page.locator('#ra-attr-default-value').click();
         await page.locator('#ra-attr-default-value').fill('prod');
 
         await page.getByTestId('select-ra-attr-content-type-trigger').click();
-        await page.getByRole('option', { name: 'Integer', exact: true }).click();
+        await page.getByRole('option', { name: 'Text', exact: true }).click();
         await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
 
-        // The default entered under String must not survive the type switch and serialise as a
-        // wrong-typed (NaN) content entry.
+        // The default entered under the old type must not survive the switch and serialise as a
+        // wrong-typed content entry.
         await expect(page.getByTestId('value-json')).not.toContainText('"defaultValue"');
     });
 
@@ -602,10 +631,105 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-name').fill('env');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
+        await pickSanMapping(page);
         await page.locator('#ra-attr-readonly').check();
+        // Read Only locks the field to its default, so a default is mandatory for it.
+        await page.locator('#ra-attr-default-value').click();
+        await page.locator('#ra-attr-default-value').fill('prod');
         await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
 
         await expect(page.getByTestId('value-json')).toContainText('"readOnly":true');
+    });
+
+    test('Read Only without a default value is rejected inline', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('env');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+        await pickSanMapping(page);
+
+        await page.locator('#ra-attr-readonly').check();
+
+        const saveButton = page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true });
+        await saveButton.click();
+        await expect(page.getByTestId('request-attribute-authoring-attribute-readonly-error')).toContainText('default value');
+        await expect(page.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(0);
+
+        await page.locator('#ra-attr-default-value').click();
+        await page.locator('#ra-attr-default-value').fill('prod');
+        await expect(page.getByTestId('request-attribute-authoring-attribute-readonly-error')).toHaveCount(0);
+        await saveButton.click();
+        await expect(page.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(1);
+    });
+
+    test('errors stay hidden until Save is pressed, and an invalid Save stores nothing', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+
+        // A just-opened dialog must not greet the user with errors — only the required markers...
+        await expect(page.getByTestId('request-attribute-authoring-attribute-name-error')).toHaveCount(0);
+        await expect(page.getByTestId('request-attribute-authoring-attribute-mapping-error')).toHaveCount(0);
+
+        // ...and typing must not either: the reveal is tied to the Save attempt, nothing else.
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('env');
+        await expect(page.getByTestId('request-attribute-authoring-attribute-mapping-error')).toHaveCount(0);
+
+        const saveButton = page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true });
+        await saveButton.click();
+
+        await expect(page.getByTestId('request-attribute-authoring-attribute-label-error')).toContainText('Label is required');
+        await expect(page.getByTestId('request-attribute-authoring-attribute-mapping-error')).toContainText('mapping target is required');
+        await expect(page.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(0);
+
+        // Fixing a field clears its message without another Save.
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+        await expect(page.getByTestId('request-attribute-authoring-attribute-label-error')).toHaveCount(0);
+        await expect(page.getByTestId('request-attribute-authoring-attribute-mapping-error')).toBeVisible();
+
+        await pickSanMapping(page);
+        await saveButton.click();
+        await expect(page.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(1);
+    });
+
+    test('a stored definition that breaks the rules is flagged in the list', async ({ mount, page }) => {
+        // A set authored before these rules: unmapped, so Core would reject it on the next save.
+        const initialValue = {
+            ...emptyAuthoringForm(),
+            attributes: [{ ...emptyAuthoredAttribute(), name: 'legacy', label: 'Legacy' }],
+        };
+        await mount(<RequestAttributeAuthoringEditorHarness initialValue={initialValue} />);
+
+        await expect(page.getByTestId('request-attribute-authoring-attribute-row-invalid')).toContainText('mapping target is required');
+
+        // The Edit dialog itself still waits for a Save attempt before turning red.
+        await page.getByTestId('request-attribute-authoring-attribute-edit').click();
+        await expect(page.getByTestId('request-attribute-authoring-attribute-mapping-error')).toHaveCount(0);
+        await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
+        await expect(page.getByTestId('request-attribute-authoring-attribute-mapping-error')).toBeVisible();
+    });
+
+    test('picking a mapping target narrows the content type to String/Text and coerces an incompatible one', async ({ mount, page }) => {
+        await mount(<RequestAttributeAuthoringEditorHarness />);
+
+        await page.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.getByTestId('select-ra-attr-content-type-trigger').click();
+        await page.getByRole('option', { name: 'Integer', exact: true }).click();
+
+        await pickSanMapping(page);
+
+        // Integer cannot be mapped, so the selection falls back to String...
+        await expect(page.getByTestId('select-ra-attr-content-type-trigger')).toContainText('String');
+        // ...and the dropdown no longer offers anything but String/Text.
+        await page.getByTestId('select-ra-attr-content-type-trigger').click();
+        await expect(page.getByRole('option', { name: 'Text', exact: true })).toBeVisible();
+        await expect(page.getByRole('option', { name: 'Integer', exact: true })).toHaveCount(0);
+        await expect(page.getByRole('option', { name: 'Boolean', exact: true })).toHaveCount(0);
     });
 
     test('Free input value source shows Read Only and hides List/Multi select', async ({ mount, page }) => {
@@ -639,6 +763,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-name').fill('env');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
+        await pickSanMapping(page);
         await page.locator('#ra-attr-readonly').check();
 
         await page.getByTestId('select-ra-attr-value-source-trigger').click();
@@ -662,6 +787,7 @@ test.describe('RequestAttributeAuthoringEditor', () => {
         await page.locator('#ra-attr-name').fill('env');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
+        await pickSanMapping(page);
 
         // Static list forces List on and shows the checkbox...
         await page.getByTestId('select-ra-attr-value-source-trigger').click();

--- a/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
+++ b/src/components/RequestAttributes/RequestAttributeAuthoringEditor.tsx
@@ -24,10 +24,12 @@ import type { OidSelectOption } from 'utils/oid';
 import {
     emptyAuthoredAttribute,
     emptyValueSourceBinding,
-    hasDuplicateStaticValues,
-    isAuthoredAttributeValid,
+    isContentTypeAllowedForMapping,
     isStaticListSupportedForContentType,
     isValueSourceBindingValid,
+    MAPPED_CONTENT_TYPES,
+    validateAuthoredAttribute,
+    type AuthoredAttributeErrors,
     type AuthoredAttributeFormValues,
     type RequestAttributeAuthoringFormValues,
     type ValueSourceBindingFormValues,
@@ -55,6 +57,8 @@ const CONTENT_TYPE_OPTIONS = Object.values(AttributeContentType).map((v) => ({
     value: v,
     label: v.charAt(0).toUpperCase() + v.slice(1),
 }));
+
+const MAPPED_CONTENT_TYPE_OPTIONS = CONTENT_TYPE_OPTIONS.filter((o) => MAPPED_CONTENT_TYPES.includes(o.value));
 
 const FIELD_TYPE_LABELS: Record<FieldType, string> = {
     [FieldType.Rdn]: 'RDN (subject)',
@@ -123,6 +127,15 @@ function resolveOidValue(options: OidSelectOption[], current?: string): string |
 function withCurrentValue(options: OidSelectOption[], resolved?: string): OidSelectOption[] {
     if (!resolved || options.some((o) => o.value === resolved)) return options;
     return [...options, { value: resolved, label: `${resolved} (not registered)` }];
+}
+
+function FieldError({ testId, message }: Readonly<{ testId: string; message?: string }>) {
+    if (!message) return null;
+    return (
+        <p className="text-sm text-red-600" data-testid={testId}>
+            {message}
+        </p>
+    );
 }
 
 type OidMappingSelectProps = Readonly<{
@@ -231,7 +244,10 @@ export default function RequestAttributeAuthoringEditor({
     extensionOptionsLoaded = true,
     dataTestId = 'request-attribute-authoring',
 }: Props) {
-    const [attrDraft, setAttrDraft] = useState<{ index: number | null; data: AuthoredAttributeFormValues } | null>(null);
+    // `submitted` gates the error messages: the dialog stays clean until Save is pressed.
+    const [attrDraft, setAttrDraft] = useState<{ index: number | null; data: AuthoredAttributeFormValues; submitted: boolean } | null>(
+        null,
+    );
     const [bindingDraft, setBindingDraft] = useState<{ index: number | null; data: ValueSourceBindingFormValues } | null>(null);
 
     const patch = useCallback((next: Partial<RequestAttributeAuthoringFormValues>) => onChange({ ...value, ...next }), [onChange, value]);
@@ -265,8 +281,22 @@ export default function RequestAttributeAuthoringEditor({
     // -- Authored attributes ---------------------------------------------------
     const removeAttribute = (index: number) => patch({ attributes: value.attributes.filter((_, i) => i !== index) });
 
+    // A name must be unique within the set (excluding the row being edited).
+    const attrNameDuplicate =
+        !!attrDraft &&
+        !!attrDraft.data.name.trim() &&
+        value.attributes.some((a, i) => i !== attrDraft.index && a.name.trim() === attrDraft.data.name.trim());
+    const allAttrErrors: AuthoredAttributeErrors = attrDraft ? validateAuthoredAttribute(attrDraft.data) : {};
+    const attrValid = !!attrDraft && Object.keys(allAttrErrors).length === 0 && !attrNameDuplicate;
+    const attrErrors: AuthoredAttributeErrors = attrDraft?.submitted ? allAttrErrors : {};
+    const nameDuplicateVisible = attrNameDuplicate && !!attrDraft?.submitted;
+
     const saveAttribute = () => {
         if (!attrDraft) return;
+        if (!attrValid) {
+            setAttrDraft({ ...attrDraft, submitted: true });
+            return;
+        }
         const next = [...value.attributes];
         if (attrDraft.index === null) {
             next.push(attrDraft.data);
@@ -296,6 +326,8 @@ export default function RequestAttributeAuthoringEditor({
         }
     };
 
+    const firstError = (attr: AuthoredAttributeFormValues) => Object.values(validateAuthoredAttribute(attr))[0];
+
     const renderAttributeList = () => (
         <div className="space-y-2" data-testid={`${dataTestId}-attributes`}>
             <p className="text-sm font-medium text-gray-700">Authored attributes</p>
@@ -305,49 +337,61 @@ export default function RequestAttributeAuthoringEditor({
                 </p>
             ) : (
                 <ul className="space-y-1">
-                    {value.attributes.map((attr, index) => (
-                        <li
-                            key={attr.uuid ?? `${attr.name}-${index}`}
-                            className="flex items-center justify-between gap-2 rounded-md border border-gray-200 px-3 py-2 text-sm"
-                            data-testid={`${dataTestId}-attribute-row`}
-                        >
-                            <span className="truncate">
-                                <span className="font-medium">{attr.label || attr.name || '(unnamed)'}</span>
-                                <span className="text-gray-500">
-                                    {' · '}
-                                    {attr.contentType}
-                                    {attr.required ? ' · required' : ''} {mappingSummary(attr)}
-                                    {attr.valueSourceType !== ValueSourceType.None ? ` · ${valueSourceLabel(attr.valueSourceType)}` : ''}
+                    {value.attributes.map((attr, index) => {
+                        // Definitions stored before these rules can violate them — flag them without
+                        // making the user open every row.
+                        const rowError = firstError(attr);
+                        return (
+                            <li
+                                key={attr.uuid ?? `${attr.name}-${index}`}
+                                className="flex items-center justify-between gap-2 rounded-md border border-gray-200 px-3 py-2 text-sm"
+                                data-testid={`${dataTestId}-attribute-row`}
+                            >
+                                <span className="truncate">
+                                    <span className="font-medium">{attr.label || attr.name || '(unnamed)'}</span>
+                                    <span className="text-gray-500">
+                                        {' · '}
+                                        {attr.contentType}
+                                        {attr.required ? ' · required' : ''} {mappingSummary(attr)}
+                                        {attr.valueSourceType !== ValueSourceType.None
+                                            ? ` · ${valueSourceLabel(attr.valueSourceType)}`
+                                            : ''}
+                                    </span>
+                                    {rowError && (
+                                        <span className="block text-red-600" data-testid={`${dataTestId}-attribute-row-invalid`}>
+                                            {rowError}
+                                        </span>
+                                    )}
                                 </span>
-                            </span>
-                            <span className="flex shrink-0 gap-2">
-                                <Button
-                                    variant="outline"
-                                    onClick={() => setAttrDraft({ index, data: { ...attr } })}
-                                    disabled={disabled}
-                                    type="button"
-                                    data-testid={`${dataTestId}-attribute-edit`}
-                                >
-                                    Edit
-                                </Button>
-                                <Button
-                                    variant="outline"
-                                    color="danger"
-                                    onClick={() => removeAttribute(index)}
-                                    disabled={disabled}
-                                    type="button"
-                                    data-testid={`${dataTestId}-attribute-remove`}
-                                >
-                                    Remove
-                                </Button>
-                            </span>
-                        </li>
-                    ))}
+                                <span className="flex shrink-0 gap-2">
+                                    <Button
+                                        variant="outline"
+                                        onClick={() => setAttrDraft({ index, data: { ...attr }, submitted: false })}
+                                        disabled={disabled}
+                                        type="button"
+                                        data-testid={`${dataTestId}-attribute-edit`}
+                                    >
+                                        Edit
+                                    </Button>
+                                    <Button
+                                        variant="outline"
+                                        color="danger"
+                                        onClick={() => removeAttribute(index)}
+                                        disabled={disabled}
+                                        type="button"
+                                        data-testid={`${dataTestId}-attribute-remove`}
+                                    >
+                                        Remove
+                                    </Button>
+                                </span>
+                            </li>
+                        );
+                    })}
                 </ul>
             )}
             <Button
                 variant="outline"
-                onClick={() => setAttrDraft({ index: null, data: emptyAuthoredAttribute() })}
+                onClick={() => setAttrDraft({ index: null, data: emptyAuthoredAttribute(), submitted: false })}
                 disabled={disabled}
                 type="button"
                 data-testid={`${dataTestId}-attribute-add`}
@@ -357,17 +401,19 @@ export default function RequestAttributeAuthoringEditor({
         </div>
     );
 
-    // A name must be unique within the set (excluding the row being edited).
-    const attrNameDuplicate =
-        !!attrDraft &&
-        !!attrDraft.data.name.trim() &&
-        value.attributes.some((a, i) => i !== attrDraft.index && a.name.trim() === attrDraft.data.name.trim());
-    const attrValid = !!attrDraft && isAuthoredAttributeValid(attrDraft.data) && !attrNameDuplicate;
-
     const renderAttributeDialog = () => {
         if (!attrDraft) return null;
         const d = attrDraft.data;
         const set = (p: Partial<AuthoredAttributeFormValues>) => setAttrDraft({ ...attrDraft, data: { ...d, ...p } });
+        // Drop the static list and the default so a value typed under the old type can never serialise
+        // into `content`, and fall back to free input when the new type has no scalar editor.
+        const setContentType = (contentType: AttributeContentType) =>
+            set({
+                contentType,
+                staticValues: [],
+                defaultValue: undefined,
+                valueSourceType: isStaticListSupportedForContentType(contentType) ? d.valueSourceType : ValueSourceType.None,
+            });
         return (
             <div className="space-y-3 text-left" data-testid={`${dataTestId}-attribute-form`}>
                 <TextInput
@@ -379,10 +425,12 @@ export default function RequestAttributeAuthoringEditor({
                     value={d.name}
                     onChange={(v) => set({ name: v })}
                 />
-                {attrNameDuplicate && (
+                {nameDuplicateVisible ? (
                     <p className="text-sm text-red-600" data-testid={`${dataTestId}-attribute-name-duplicate`}>
                         An attribute with this name already exists in the set.
                     </p>
+                ) : (
+                    <FieldError testId={`${dataTestId}-attribute-name-error`} message={attrErrors.name} />
                 )}
                 <TextInput
                     id="ra-attr-label"
@@ -392,6 +440,7 @@ export default function RequestAttributeAuthoringEditor({
                     value={d.label}
                     onChange={(v) => set({ label: v })}
                 />
+                <FieldError testId={`${dataTestId}-attribute-label-error`} message={attrErrors.label} />
                 <TextInput
                     id="ra-attr-description"
                     label="Description"
@@ -402,51 +451,55 @@ export default function RequestAttributeAuthoringEditor({
                 <Select
                     id="ra-attr-content-type"
                     label="Content type"
-                    labelTooltip="The data type of the value the requester provides."
+                    labelTooltip="The data type of the value the requester provides. A mapped attribute is written into the certificate as text, so only String and Text are offered once a mapping target is set."
                     value={d.contentType}
-                    onChange={(v) => {
-                        const contentType = v as AttributeContentType;
-                        // Static list is only authorable for scalar content types; drop back to free
-                        // input if the new type can't carry one, so we never render a missing editor.
-                        const keepStaticList = isStaticListSupportedForContentType(contentType);
-                        // Drop both the static list and any free-input default — a value entered under
-                        // the old type would otherwise survive and serialise as a wrong-typed content entry.
-                        set({
-                            contentType,
-                            staticValues: [],
-                            defaultValue: undefined,
-                            valueSourceType: keepStaticList ? d.valueSourceType : ValueSourceType.None,
-                        });
-                    }}
-                    options={CONTENT_TYPE_OPTIONS}
+                    onChange={(v) => setContentType(v as AttributeContentType)}
+                    options={d.mappingFieldType ? MAPPED_CONTENT_TYPE_OPTIONS : CONTENT_TYPE_OPTIONS}
                 />
+                <FieldError testId={`${dataTestId}-attribute-content-type-error`} message={attrErrors.contentType} />
                 <Select
                     id="ra-attr-mapping"
                     label="Mapping target"
-                    labelTooltip="Where this attribute's value is placed in the issued certificate: an RDN (subject) component, a Subject Alternative Name, or a certificate extension. Leave it unmapped if the connector or workflow consumes the value directly."
+                    required
+                    labelTooltip="Where this attribute's value is placed in the issued certificate: an RDN (subject) component, a Subject Alternative Name, or a certificate extension."
                     value={d.mappingFieldType ?? ''}
-                    onChange={(v) =>
-                        set({ mappingFieldType: (v as FieldType) || undefined, mappingObjectType: ObjectType.X509Certificate })
-                    }
+                    onChange={(v) => {
+                        const mappingFieldType = (v as FieldType) || undefined;
+                        // Otherwise the dialog would show a content type its own dropdown no longer offers.
+                        if (mappingFieldType && !isContentTypeAllowedForMapping(d.contentType)) {
+                            set({
+                                mappingFieldType,
+                                mappingObjectType: ObjectType.X509Certificate,
+                                contentType: AttributeContentType.String,
+                                staticValues: [],
+                                defaultValue: undefined,
+                            });
+                            return;
+                        }
+                        set({ mappingFieldType, mappingObjectType: ObjectType.X509Certificate });
+                    }}
                     options={MAPPING_OPTIONS}
-                    isClearable
-                    placeholder="Not mapped"
+                    placeholder="Select mapping target"
                 />
+                <FieldError testId={`${dataTestId}-attribute-mapping-error`} message={attrErrors.mappingFieldType} />
                 {d.mappingFieldType === FieldType.Rdn && (
-                    <OidMappingSelect
-                        id="ra-attr-rdn"
-                        label="RDN"
-                        placeholder="Select an RDN"
-                        testIdPrefix={`${dataTestId}-rdn`}
-                        emptyHint="No RDNs are available. Register one under Settings → Custom OIDs."
-                        errorHint="Failed to load RDNs."
-                        options={rdnOptions}
-                        optionsError={rdnOptionsError}
-                        optionsLoaded={rdnOptionsLoaded}
-                        value={d.mappingRdnCode}
-                        onChange={(v) => set({ mappingRdnCode: v })}
-                        disabled={disabled}
-                    />
+                    <>
+                        <OidMappingSelect
+                            id="ra-attr-rdn"
+                            label="RDN"
+                            placeholder="Select an RDN"
+                            testIdPrefix={`${dataTestId}-rdn`}
+                            emptyHint="No RDNs are available. Register one under Settings → Custom OIDs."
+                            errorHint="Failed to load RDNs."
+                            options={rdnOptions}
+                            optionsError={rdnOptionsError}
+                            optionsLoaded={rdnOptionsLoaded}
+                            value={d.mappingRdnCode}
+                            onChange={(v) => set({ mappingRdnCode: v })}
+                            disabled={disabled}
+                        />
+                        <FieldError testId={`${dataTestId}-attribute-rdn-error`} message={attrErrors.mappingRdnCode} />
+                    </>
                 )}
                 {d.mappingFieldType === FieldType.San && (
                     <>
@@ -459,6 +512,7 @@ export default function RequestAttributeAuthoringEditor({
                             options={GENERAL_NAME_TYPE_OPTIONS}
                             placeholder="Select SAN type"
                         />
+                        <FieldError testId={`${dataTestId}-attribute-san-error`} message={attrErrors.mappingGeneralNameType} />
                         {d.mappingGeneralNameType === GeneralNameType.OtherName && (
                             <>
                                 <TextInput
@@ -468,6 +522,10 @@ export default function RequestAttributeAuthoringEditor({
                                     value={d.mappingOtherNameOid ?? ''}
                                     onChange={(v) => set({ mappingOtherNameOid: v })}
                                 />
+                                <FieldError
+                                    testId={`${dataTestId}-attribute-othername-oid-error`}
+                                    message={attrErrors.mappingOtherNameOid}
+                                />
                                 <Select
                                     id="ra-attr-othername-encoding"
                                     label="otherName value encoding"
@@ -476,6 +534,10 @@ export default function RequestAttributeAuthoringEditor({
                                     onChange={(v) => set({ mappingOtherNameEncoding: (v as ExtensionValueEncoding) || undefined })}
                                     options={ENCODING_OPTIONS}
                                     placeholder="Select encoding"
+                                />
+                                <FieldError
+                                    testId={`${dataTestId}-attribute-othername-encoding-error`}
+                                    message={attrErrors.mappingOtherNameEncoding}
                                 />
                             </>
                         )}
@@ -497,6 +559,7 @@ export default function RequestAttributeAuthoringEditor({
                             onChange={(v) => set({ mappingExtensionOid: v })}
                             disabled={disabled}
                         />
+                        <FieldError testId={`${dataTestId}-attribute-extension-error`} message={attrErrors.mappingExtensionOid} />
                         <Checkbox
                             id="ra-attr-critical-overridable"
                             checked={d.mappingCriticalOverridable ?? false}
@@ -566,6 +629,8 @@ export default function RequestAttributeAuthoringEditor({
                             />
                         )}
                     </Container>
+                    <FieldError testId={`${dataTestId}-attribute-readonly-error`} message={attrErrors.readOnly} />
+                    <FieldError testId={`${dataTestId}-attribute-multiselect-error`} message={attrErrors.multiSelect} />
                 </div>
                 {d.valueSourceType === ValueSourceType.StaticList && renderStaticValues(d, set)}
                 {d.valueSourceType === ValueSourceType.None && renderFreeInputDefault(d, set)}
@@ -616,16 +681,7 @@ export default function RequestAttributeAuthoringEditor({
                         </Button>
                     </div>
                 ))}
-                {d.staticValues.length === 0 && (
-                    <p className="text-sm text-gray-400" data-testid={`${dataTestId}-static-values-empty`}>
-                        Add at least one value for the static list.
-                    </p>
-                )}
-                {hasDuplicateStaticValues(d.staticValues) && (
-                    <p className="text-sm text-red-600" data-testid={`${dataTestId}-static-values-duplicate`}>
-                        Static list values must be unique.
-                    </p>
-                )}
+                <FieldError testId={`${dataTestId}-static-values-error`} message={attrErrors.staticValues} />
                 <Button
                     variant="transparent"
                     className="text-blue-600"
@@ -648,7 +704,10 @@ export default function RequestAttributeAuthoringEditor({
         if (!config) return null;
         return (
             <div className="space-y-2" data-testid={`${dataTestId}-default-value-block`}>
-                <Label labelTooltip="Optional. Pre-fills the field on the request form; the requester can change it unless Read Only is set.">
+                <Label
+                    required={d.readOnly}
+                    labelTooltip="Pre-fills the field on the request form; the requester can change it unless Read Only is set. Required when Read Only is set, optional otherwise."
+                >
                     Default value
                 </Label>
                 <AddCustomValueInput
@@ -661,6 +720,7 @@ export default function RequestAttributeAuthoringEditor({
                     readOnly={disabled}
                     placeholder="Enter default value"
                 />
+                <FieldError testId={`${dataTestId}-default-value-error`} message={attrErrors.defaultValue} />
             </div>
         );
     };
@@ -808,8 +868,8 @@ export default function RequestAttributeAuthoringEditor({
                 caption={attrDraft?.index === null ? 'Add request attribute' : 'Edit request attribute'}
                 body={renderAttributeDialog()}
                 buttons={[
-                    { key: 'cancel', color: 'secondary', variant: 'outline', body: 'Cancel', onClick: () => setAttrDraft(null) },
-                    { key: 'save', color: 'primary', body: 'Save', disabled: !attrValid, onClick: saveAttribute },
+                    { key: 'cancel', color: 'primary', variant: 'outline', body: 'Cancel', onClick: () => setAttrDraft(null) },
+                    { key: 'save', color: 'primary', body: 'Save', onClick: saveAttribute },
                 ]}
             />
 
@@ -820,7 +880,7 @@ export default function RequestAttributeAuthoringEditor({
                 caption={bindingDraft?.index === null ? 'Add value-source binding' : 'Edit value-source binding'}
                 body={renderBindingDialog()}
                 buttons={[
-                    { key: 'cancel', color: 'secondary', variant: 'outline', body: 'Cancel', onClick: () => setBindingDraft(null) },
+                    { key: 'cancel', color: 'primary', variant: 'outline', body: 'Cancel', onClick: () => setBindingDraft(null) },
                     { key: 'save', color: 'primary', body: 'Save', disabled: !bindingValid, onClick: saveBinding },
                 ]}
             />

--- a/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.spec.tsx
+++ b/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.spec.tsx
@@ -27,6 +27,11 @@ test.describe('RequestAttributesSettings (platform default set)', () => {
         await page.locator('#ra-attr-name').fill('environment');
         await page.locator('#ra-attr-label').click();
         await page.locator('#ra-attr-label').fill('Environment');
+        // A definition must carry a mapping target; SAN/dNSName needs no OID options wired into the store.
+        await page.getByTestId('select-ra-attr-mapping-trigger').click();
+        await page.getByRole('option', { name: 'Subject Alternative Name' }).click();
+        await page.getByTestId('select-ra-attr-general-name-type-trigger').click();
+        await page.getByRole('option', { name: 'dNSName' }).click();
         await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
 
         // The attribute is added to the list...
@@ -35,6 +40,31 @@ test.describe('RequestAttributesSettings (platform default set)', () => {
         // true (CT runs no epics to resolve it), which disables the editor. No second Save exists.
         await expect(component.getByTestId('request-attribute-authoring-attribute-add')).toBeDisabled();
         await expect(page.getByRole('button', { name: 'Save', exact: true })).toHaveCount(0);
+    });
+
+    test('a rejected save rolls the list back to the persisted set instead of leaving the attribute behind', async ({ mount, page }) => {
+        const component = await mount(<RequestAttributesSettingsWithStore />);
+
+        await component.getByTestId('request-attribute-authoring-attribute-add').click();
+        await page.locator('#ra-attr-name').click();
+        await page.locator('#ra-attr-name').fill('environment');
+        await page.locator('#ra-attr-label').click();
+        await page.locator('#ra-attr-label').fill('Environment');
+        await page.getByTestId('select-ra-attr-mapping-trigger').click();
+        await page.getByRole('option', { name: 'Subject Alternative Name' }).click();
+        await page.getByTestId('select-ra-attr-general-name-type-trigger').click();
+        await page.getByRole('option', { name: 'dNSName' }).click();
+        await page.getByRole('dialog').getByRole('button', { name: 'Save', exact: true }).click();
+
+        // Optimistically listed while the save is in flight...
+        await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(1);
+
+        await page.getByTestId('simulate-rejection').click();
+
+        // ...and gone again once the backend rejects it: nothing was persisted, so nothing may be listed.
+        await expect(component.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(0);
+        await expect(component.getByTestId('request-attribute-authoring-attributes-empty')).toBeVisible();
+        await expect(page.getByTestId('request-attributes-update-error')).toContainText('Attribute definition is invalid');
     });
 
     test('reflects the preloaded strict validation flag', async ({ mount, page }) => {

--- a/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.tsx
+++ b/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettings.tsx
@@ -6,6 +6,7 @@ import Widget from 'components/Widget';
 import { actions, selectors } from 'ducks/raProfileRequestAttributes';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useRunOnFailedFinish } from 'utils/common-hooks';
 import {
     buildPlatformDefaultUpdateDto,
     emptyAuthoringForm,
@@ -24,6 +25,8 @@ export default function RequestAttributesSettings() {
     const defaultSet = useSelector(selectors.defaultSet);
     const isFetching = useSelector(selectors.isFetchingDefaultSet);
     const isUpdating = useSelector(selectors.isUpdatingDefaultSet);
+    const updateSucceeded = useSelector(selectors.updateDefaultSetSucceeded);
+    const updateError = useSelector(selectors.updateDefaultSetError);
     const { rdnOptions, extensionOptions, rdnOptionsError, extensionOptionsError, rdnOptionsLoaded, extensionOptionsLoaded } =
         useOidMappingOptions();
 
@@ -34,18 +37,28 @@ export default function RequestAttributesSettings() {
         dispatch(actions.getPlatformDefaultRequestAttributes());
     }, [dispatch]);
 
+    const formFromDefaultSet = useCallback(
+        (): RequestAttributeAuthoringFormValues => ({
+            ...emptyAuthoringForm(),
+            attributes: parsePlatformDefaultDto(defaultSet),
+            externalCsrValidationStrict: defaultSet?.externalCsrValidationStrict,
+        }),
+        [defaultSet],
+    );
+
     // Seed the form once, on the undefined → defined transition of the fetched set. Re-seeding on
     // every `defaultSet` reference change would clobber in-progress edits when a late fetch resolves.
     useEffect(() => {
         if (defaultSet !== undefined && !loaded) {
-            setForm({
-                ...emptyAuthoringForm(),
-                attributes: parsePlatformDefaultDto(defaultSet),
-                externalCsrValidationStrict: defaultSet?.externalCsrValidationStrict,
-            });
+            setForm(formFromDefaultSet());
             setLoaded(true);
         }
-    }, [defaultSet, loaded]);
+    }, [defaultSet, loaded, formFromDefaultSet]);
+
+    // A rejected save persisted nothing, so drop the optimistic edit: `defaultSet` is only replaced on
+    // success, which makes it the authoritative rollback target.
+    const revertToPersisted = useCallback(() => setForm(formFromDefaultSet()), [formFromDefaultSet]);
+    useRunOnFailedFinish(isUpdating, updateSucceeded, revertToPersisted);
 
     // Persist on every editor mutation (add / edit / remove) so the attribute dialog's own Save is the
     // only click a user needs — there is no separate form-level Save to confirm the change again.
@@ -103,6 +116,15 @@ export default function RequestAttributesSettings() {
                     The platform default request-attribute set is the terminal fallback used when an RA Profile does not define its own set.
                     Changes are saved automatically.
                 </p>
+                {updateError && (
+                    <div
+                        className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-800/10 dark:text-red-500"
+                        data-testid="request-attributes-update-error"
+                        role="alert"
+                    >
+                        {`The change was rejected and has not been saved: ${updateError}`}
+                    </div>
+                )}
                 <div className="space-y-2">
                     <Label className="!text-base">Request validation</Label>
                     <ExternalCsrValidationRadio

--- a/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettingsWithStore.tsx
+++ b/src/components/_pages/platform-settings/request-attributes/RequestAttributesSettingsWithStore.tsx
@@ -24,6 +24,20 @@ export default function RequestAttributesSettingsWithStore({
         <Provider store={store}>
             <MemoryRouter initialEntries={['/platformsettings/request-attributes']}>
                 <RequestAttributesSettings />
+                {/* Stand-in for the epic's rejection path (CT runs no epics): flips the pending flag
+                    back with no success, which is what the editor rolls back on. */}
+                <button
+                    type="button"
+                    data-testid="simulate-rejection"
+                    onClick={() =>
+                        store.dispatch({
+                            type: 'raProfileRequestAttributes/updatePlatformDefaultRequestAttributesFailure',
+                            payload: { error: 'Attribute definition is invalid' },
+                        })
+                    }
+                >
+                    simulate rejection
+                </button>
             </MemoryRouter>
         </Provider>
     );

--- a/src/components/_pages/ra-profiles/RaProfileRequestAttributesWidget.spec.tsx
+++ b/src/components/_pages/ra-profiles/RaProfileRequestAttributesWidget.spec.tsx
@@ -48,8 +48,38 @@ test('saving in the dialog adds the request attribute to the list immediately', 
     await page.locator('#ra-attr-name').fill('commonName');
     await page.locator('#ra-attr-label').click();
     await page.locator('#ra-attr-label').fill('Common Name');
+    // A definition must carry a mapping target; SAN/dNSName needs no OID options wired into the store.
+    await page.getByTestId('select-ra-attr-mapping-trigger').click();
+    await page.getByRole('option', { name: 'Subject Alternative Name' }).click();
+    await page.getByTestId('select-ra-attr-general-name-type-trigger').click();
+    await page.getByRole('option', { name: 'dNSName' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click();
 
     await expect(page.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(1);
     await expect(page.getByRole('button', { name: 'Save' })).toHaveCount(0);
+});
+
+test('a rejected save rolls the list back to the persisted set instead of leaving the attribute behind', async ({ mount, page }) => {
+    await mount(<RaProfileRequestAttributesWidgetWithStore />);
+
+    await page.getByTestId('request-attribute-authoring-attribute-add').click();
+    await page.locator('#ra-attr-name').click();
+    await page.locator('#ra-attr-name').fill('commonName');
+    await page.locator('#ra-attr-label').click();
+    await page.locator('#ra-attr-label').fill('Common Name');
+    await page.getByTestId('select-ra-attr-mapping-trigger').click();
+    await page.getByRole('option', { name: 'Subject Alternative Name' }).click();
+    await page.getByTestId('select-ra-attr-general-name-type-trigger').click();
+    await page.getByRole('option', { name: 'dNSName' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click();
+
+    // Optimistically listed while the save is in flight...
+    await expect(page.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(1);
+
+    await page.getByTestId('simulate-rejection').click();
+
+    // ...and gone again once the backend rejects it: nothing was persisted, so nothing may be listed.
+    await expect(page.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(0);
+    await expect(page.getByTestId('request-attributes-platform-default-note')).toBeVisible();
+    await expect(page.getByTestId('request-attributes-update-error')).toContainText('Attribute definition is invalid');
 });

--- a/src/components/_pages/ra-profiles/RaProfileRequestAttributesWidget.tsx
+++ b/src/components/_pages/ra-profiles/RaProfileRequestAttributesWidget.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { RaProfileCertificateRequestAttributesDto } from 'types/openapi';
 import { isGroupAttributeModel } from 'types/attributes';
-import { useRunOnSuccessfulFinish } from 'utils/common-hooks';
+import { useRunOnFailedFinish, useRunOnSuccessfulFinish } from 'utils/common-hooks';
 import {
     buildRaProfileRequestAttributesUpdateDto,
     gateMergeModeAndBindings,
@@ -40,6 +40,7 @@ export default function RaProfileRequestAttributesWidget({
 
     const isUpdating = useSelector(requestAttributesSelectors.isUpdatingRaProfileSet);
     const updateSucceeded = useSelector(requestAttributesSelectors.updateRaProfileSetSucceeded);
+    const updateError = useSelector(requestAttributesSelectors.updateRaProfileSetError);
 
     const [form, setForm] = useState<RequestAttributeAuthoringFormValues>(() =>
         gateMergeModeAndBindings(parseRaProfileRequestAttributesDto(certificateRequestAttributes)),
@@ -92,8 +93,25 @@ export default function RaProfileRequestAttributesWidget({
     }, [onSaved]);
     useRunOnSuccessfulFinish(isUpdating, updateSucceeded, clearDirtyAndRefetch);
 
+    // A rejected save persisted nothing, so drop the optimistic edit: the props still hold the last set
+    // Core accepted, and clearing `dirty` unblocks the re-seed effect.
+    const revertToPersisted = useCallback(() => {
+        setForm(gateMergeModeAndBindings(parseRaProfileRequestAttributesDto(certificateRequestAttributes)));
+        setDirty(false);
+    }, [certificateRequestAttributes]);
+    useRunOnFailedFinish(isUpdating, updateSucceeded, revertToPersisted);
+
     return (
         <div className="space-y-4" data-testid="ra-profile-request-attributes-widget">
+            {updateError && (
+                <div
+                    className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-800/10 dark:text-red-500"
+                    data-testid="request-attributes-update-error"
+                    role="alert"
+                >
+                    {`The change was rejected and has not been saved: ${updateError}`}
+                </div>
+            )}
             {showPlatformDefaultNote && (
                 <p className="text-sm text-gray-500" data-testid="request-attributes-platform-default-note">
                     No request attributes are defined for this RA profile. The set of request attributes defined in platform settings will

--- a/src/components/_pages/ra-profiles/RaProfileRequestAttributesWidgetWithStore.tsx
+++ b/src/components/_pages/ra-profiles/RaProfileRequestAttributesWidgetWithStore.tsx
@@ -15,6 +15,20 @@ export default function RaProfileRequestAttributesWidgetWithStore({
                 raProfileUuid="ra-1"
                 certificateRequestAttributes={certificateRequestAttributes}
             />
+            {/* Stand-in for the epic's rejection path (CT runs no epics): flips the pending flag back
+                with no success, which is what the editor rolls back on. */}
+            <button
+                type="button"
+                data-testid="simulate-rejection"
+                onClick={() =>
+                    store.dispatch({
+                        type: 'raProfileRequestAttributes/updateRaProfileRequestAttributesFailure',
+                        payload: { error: 'Attribute definition is invalid' },
+                    })
+                }
+            >
+                simulate rejection
+            </button>
         </Provider>
     );
 }

--- a/src/components/_pages/ra-profiles/form/RaProfileForm.spec.tsx
+++ b/src/components/_pages/ra-profiles/form/RaProfileForm.spec.tsx
@@ -34,6 +34,11 @@ async function authorAttribute(page: Page, name: string, label: string): Promise
     await page.locator('#ra-attr-name').fill(name);
     await page.locator('#ra-attr-label').click();
     await page.locator('#ra-attr-label').fill(label);
+    // A definition must carry a mapping target; SAN/dNSName needs no OID options wired into the store.
+    await page.getByTestId('select-ra-attr-mapping-trigger').click();
+    await page.getByRole('option', { name: 'Subject Alternative Name' }).click();
+    await page.getByTestId('select-ra-attr-general-name-type-trigger').click();
+    await page.getByRole('option', { name: 'dNSName' }).click();
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(page.getByTestId('request-attribute-authoring-attribute-row')).toHaveCount(1);
 }

--- a/src/ducks/raProfileRequestAttributes.spec.ts
+++ b/src/ducks/raProfileRequestAttributes.spec.ts
@@ -76,4 +76,31 @@ describe('raProfileRequestAttributes slice', () => {
         expect(next.isUpdatingRaProfileSet).toBe(false);
         expect(next.updateRaProfileSetSucceeded).toBe(false);
     });
+
+    // The editors read the rejection message to roll back and explain why, so it must survive the
+    // failure and be cleared by the next attempt (otherwise a stale banner outlives the error).
+    test('the RA-profile rejection message is stored and cleared on the next attempt', () => {
+        const failed = reducer(initialState, actions.updateRaProfileRequestAttributesFailure({ error: 'boom' }));
+        expect(failed.updateRaProfileSetError).toBe('boom');
+
+        const retrying = reducer(
+            failed,
+            actions.updateRaProfileRequestAttributes({ authorityUuid: 'a', raProfileUuid: 'r', data: { requestAttributes: [] } }),
+        );
+        expect(retrying.updateRaProfileSetError).toBeUndefined();
+
+        const succeeded = reducer(failed, actions.updateRaProfileRequestAttributesSuccess({ set: undefined }));
+        expect(succeeded.updateRaProfileSetError).toBeUndefined();
+    });
+
+    test('the platform-default rejection message is stored and cleared on the next attempt', () => {
+        const failed = reducer(initialState, actions.updatePlatformDefaultRequestAttributesFailure({ error: 'boom' }));
+        expect(failed.updateDefaultSetError).toBe('boom');
+
+        const retrying = reducer(failed, actions.updatePlatformDefaultRequestAttributes({ data: { requestAttributes: [] } }));
+        expect(retrying.updateDefaultSetError).toBeUndefined();
+
+        const succeeded = reducer(failed, actions.updatePlatformDefaultRequestAttributesSuccess({ requestAttributes: [] }));
+        expect(succeeded.updateDefaultSetError).toBeUndefined();
+    });
 });

--- a/src/ducks/raProfileRequestAttributes.ts
+++ b/src/ducks/raProfileRequestAttributes.ts
@@ -11,12 +11,15 @@ export type State = {
     raProfileSet?: RaProfileCertificateRequestAttributesDto;
     isUpdatingRaProfileSet: boolean;
     updateRaProfileSetSucceeded: boolean;
+    /** Rejection message of the last update; the editor shows it and rolls back to the persisted set. */
+    updateRaProfileSetError?: string;
 
     // Platform default set (/platform CertificateSettings.requestAttributes)
     defaultSet?: CertificateRequestAttributesSettingsDto;
     isFetchingDefaultSet: boolean;
     isUpdatingDefaultSet: boolean;
     updateDefaultSetSucceeded: boolean;
+    updateDefaultSetError?: string;
 };
 
 export const initialState: State = {
@@ -41,17 +44,20 @@ export const slice = createSlice({
         ) => {
             state.isUpdatingRaProfileSet = true;
             state.updateRaProfileSetSucceeded = false;
+            state.updateRaProfileSetError = undefined;
         },
 
         updateRaProfileRequestAttributesSuccess: (state, action: PayloadAction<{ set?: RaProfileCertificateRequestAttributesDto }>) => {
             state.isUpdatingRaProfileSet = false;
             state.updateRaProfileSetSucceeded = true;
+            state.updateRaProfileSetError = undefined;
             state.raProfileSet = action.payload.set;
         },
 
         updateRaProfileRequestAttributesFailure: (state, action: PayloadAction<{ error: string | undefined }>) => {
             state.isUpdatingRaProfileSet = false;
             state.updateRaProfileSetSucceeded = false;
+            state.updateRaProfileSetError = action.payload.error;
         },
 
         getPlatformDefaultRequestAttributes: (state, action: PayloadAction<void>) => {
@@ -70,17 +76,20 @@ export const slice = createSlice({
         updatePlatformDefaultRequestAttributes: (state, action: PayloadAction<{ data: CertificateRequestAttributesSettingsUpdateDto }>) => {
             state.isUpdatingDefaultSet = true;
             state.updateDefaultSetSucceeded = false;
+            state.updateDefaultSetError = undefined;
         },
 
         updatePlatformDefaultRequestAttributesSuccess: (state, action: PayloadAction<CertificateRequestAttributesSettingsDto>) => {
             state.isUpdatingDefaultSet = false;
             state.updateDefaultSetSucceeded = true;
+            state.updateDefaultSetError = undefined;
             state.defaultSet = action.payload;
         },
 
         updatePlatformDefaultRequestAttributesFailure: (state, action: PayloadAction<{ error: string | undefined }>) => {
             state.isUpdatingDefaultSet = false;
             state.updateDefaultSetSucceeded = false;
+            state.updateDefaultSetError = action.payload.error;
         },
     },
 });
@@ -90,21 +99,25 @@ const state = (reduxStore: { [slice.name]?: State }): State => reduxStore?.[slic
 const raProfileSet = createSelector(state, (state: State) => state.raProfileSet);
 const isUpdatingRaProfileSet = createSelector(state, (state: State) => state.isUpdatingRaProfileSet);
 const updateRaProfileSetSucceeded = createSelector(state, (state: State) => state.updateRaProfileSetSucceeded);
+const updateRaProfileSetError = createSelector(state, (state: State) => state.updateRaProfileSetError);
 
 const defaultSet = createSelector(state, (state: State) => state.defaultSet);
 const isFetchingDefaultSet = createSelector(state, (state: State) => state.isFetchingDefaultSet);
 const isUpdatingDefaultSet = createSelector(state, (state: State) => state.isUpdatingDefaultSet);
 const updateDefaultSetSucceeded = createSelector(state, (state: State) => state.updateDefaultSetSucceeded);
+const updateDefaultSetError = createSelector(state, (state: State) => state.updateDefaultSetError);
 
 export const selectors = {
     state,
     raProfileSet,
     isUpdatingRaProfileSet,
     updateRaProfileSetSucceeded,
+    updateRaProfileSetError,
     defaultSet,
     isFetchingDefaultSet,
     isUpdatingDefaultSet,
     updateDefaultSetSucceeded,
+    updateDefaultSetError,
 };
 
 export const actions = slice.actions;

--- a/src/ducks/test-reducers.ts
+++ b/src/ducks/test-reducers.ts
@@ -688,7 +688,7 @@ function raProfileRequestAttributesTestReducer(
     // Mirror the real slice's pending flag so CT can observe that a save was dispatched. CT runs no
     // epics, so the flag stays true — enough to assert the auto-save fired and disabled the editor.
     if (action.type === 'raProfileRequestAttributes/updatePlatformDefaultRequestAttributes') {
-        return { ...current, isUpdatingDefaultSet: true, updateDefaultSetError: undefined };
+        return { ...current, isUpdatingDefaultSet: true, updateDefaultSetSucceeded: false, updateDefaultSetError: undefined };
     }
     if (action.type === 'raProfileRequestAttributes/updateRaProfileRequestAttributes') {
         return { ...current, isUpdatingRaProfileSet: true, updateRaProfileSetSucceeded: false, updateRaProfileSetError: undefined };

--- a/src/ducks/test-reducers.ts
+++ b/src/ducks/test-reducers.ts
@@ -664,10 +664,12 @@ type RaProfileRequestAttributesTestState = {
     raProfileSet?: any;
     isUpdatingRaProfileSet: boolean;
     updateRaProfileSetSucceeded: boolean;
+    updateRaProfileSetError?: string;
     defaultSet?: any;
     isFetchingDefaultSet: boolean;
     isUpdatingDefaultSet: boolean;
     updateDefaultSetSucceeded: boolean;
+    updateDefaultSetError?: string;
 };
 
 const raProfileRequestAttributesTestInitialState: RaProfileRequestAttributesTestState = {
@@ -686,10 +688,23 @@ function raProfileRequestAttributesTestReducer(
     // Mirror the real slice's pending flag so CT can observe that a save was dispatched. CT runs no
     // epics, so the flag stays true — enough to assert the auto-save fired and disabled the editor.
     if (action.type === 'raProfileRequestAttributes/updatePlatformDefaultRequestAttributes') {
-        return { ...current, isUpdatingDefaultSet: true };
+        return { ...current, isUpdatingDefaultSet: true, updateDefaultSetError: undefined };
     }
     if (action.type === 'raProfileRequestAttributes/updateRaProfileRequestAttributes') {
-        return { ...current, isUpdatingRaProfileSet: true, updateRaProfileSetSucceeded: false };
+        return { ...current, isUpdatingRaProfileSet: true, updateRaProfileSetSucceeded: false, updateRaProfileSetError: undefined };
+    }
+    // Failure transitions too, so CT can drive a backend rejection and observe the rollback.
+    const failure = action as { type: string; payload?: { error?: string } };
+    if (failure.type === 'raProfileRequestAttributes/updatePlatformDefaultRequestAttributesFailure') {
+        return { ...current, isUpdatingDefaultSet: false, updateDefaultSetSucceeded: false, updateDefaultSetError: failure.payload?.error };
+    }
+    if (failure.type === 'raProfileRequestAttributes/updateRaProfileRequestAttributesFailure') {
+        return {
+            ...current,
+            isUpdatingRaProfileSet: false,
+            updateRaProfileSetSucceeded: false,
+            updateRaProfileSetError: failure.payload?.error,
+        };
     }
     return current;
 }

--- a/src/utils/requestAttributeAuthoring.spec.ts
+++ b/src/utils/requestAttributeAuthoring.spec.ts
@@ -417,6 +417,13 @@ describe('requestAttributeAuthoring', () => {
             expect(validateAuthoredAttribute({ ...mappedAttr(), label: '' }).label).toBeTruthy();
         });
 
+        // The attribute list shows Object.values(errors)[0] as the row's marker, so identity errors must
+        // keep coming first however the rule checks are split up internally.
+        test('reports the missing name before the missing mapping', () => {
+            const errors = validateAuthoredAttribute({ ...baseAttr(), name: '', label: '' });
+            expect(Object.keys(errors)).toEqual(['name', 'label', 'mappingFieldType']);
+        });
+
         test('a mapping target is required', () => {
             expect(validateAuthoredAttribute(baseAttr()).mappingFieldType).toBeTruthy();
         });

--- a/src/utils/requestAttributeAuthoring.spec.ts
+++ b/src/utils/requestAttributeAuthoring.spec.ts
@@ -24,10 +24,11 @@ import {
     emptyValueSourceBinding,
     gateMergeModeAndBindings,
     hasAuthoredRequestAttributes,
-    isAuthoredAttributeMappingValid,
-    isAuthoredAttributeValid,
+    isContentTypeAllowedForMapping,
     isStaticListSupportedForContentType,
     isValueSourceBindingValid,
+    isValueValidForContentType,
+    validateAuthoredAttribute,
     parseAuthoredAttributeDto,
     parsePlatformDefaultDto,
     parseRaProfileRequestAttributesDto,
@@ -348,85 +349,160 @@ describe('requestAttributeAuthoring', () => {
         });
     });
 
-    describe('isAuthoredAttributeMappingValid / isAuthoredAttributeValid', () => {
-        test('unmapped attribute is valid', () => {
-            expect(isAuthoredAttributeMappingValid(baseAttr())).toBe(true);
+    describe('isValueValidForContentType', () => {
+        test('blank is always accepted — required-ness is a separate rule', () => {
+            expect(isValueValidForContentType('', AttributeContentType.Integer)).toBe(true);
+            expect(isValueValidForContentType('   ', AttributeContentType.Date)).toBe(true);
+        });
+
+        test('integer accepts whole numbers only', () => {
+            expect(isValueValidForContentType('42', AttributeContentType.Integer)).toBe(true);
+            expect(isValueValidForContentType('-7', AttributeContentType.Integer)).toBe(true);
+            expect(isValueValidForContentType(42, AttributeContentType.Integer)).toBe(true);
+            expect(isValueValidForContentType('4.2', AttributeContentType.Integer)).toBe(false);
+            expect(isValueValidForContentType('abc', AttributeContentType.Integer)).toBe(false);
+            expect(isValueValidForContentType(4.2, AttributeContentType.Integer)).toBe(false);
+        });
+
+        test('float accepts decimals and rejects non-numerics', () => {
+            expect(isValueValidForContentType('4.2', AttributeContentType.Float)).toBe(true);
+            expect(isValueValidForContentType('-1e3', AttributeContentType.Float)).toBe(true);
+            expect(isValueValidForContentType('abc', AttributeContentType.Float)).toBe(false);
+        });
+
+        test('boolean accepts only booleans and their literal spellings', () => {
+            expect(isValueValidForContentType(true, AttributeContentType.Boolean)).toBe(true);
+            expect(isValueValidForContentType('false', AttributeContentType.Boolean)).toBe(true);
+            expect(isValueValidForContentType('yes', AttributeContentType.Boolean)).toBe(false);
+        });
+
+        test('date / time / datetime are format-checked', () => {
+            expect(isValueValidForContentType('2026-07-29', AttributeContentType.Date)).toBe(true);
+            expect(isValueValidForContentType('29/07/2026', AttributeContentType.Date)).toBe(false);
+            expect(isValueValidForContentType('14:30', AttributeContentType.Time)).toBe(true);
+            expect(isValueValidForContentType('2 pm', AttributeContentType.Time)).toBe(false);
+            expect(isValueValidForContentType('2026-07-29T14:30:00Z', AttributeContentType.Datetime)).toBe(true);
+            expect(isValueValidForContentType('not a date', AttributeContentType.Datetime)).toBe(false);
+        });
+
+        test('string and text accept anything', () => {
+            expect(isValueValidForContentType('whatever', AttributeContentType.String)).toBe(true);
+            expect(isValueValidForContentType('whatever', AttributeContentType.Text)).toBe(true);
+        });
+    });
+
+    describe('validateAuthoredAttribute', () => {
+        const mappedAttr = (): AuthoredAttributeFormValues => ({
+            ...baseAttr(),
+            mappingFieldType: FieldType.Rdn,
+            mappingRdnCode: '2.5.4.3',
+        });
+
+        test('a mapped String attribute with name and label is valid', () => {
+            expect(validateAuthoredAttribute(mappedAttr())).toEqual({});
+        });
+
+        test('name and label are required', () => {
+            expect(validateAuthoredAttribute({ ...mappedAttr(), name: '  ' }).name).toBeTruthy();
+            expect(validateAuthoredAttribute({ ...mappedAttr(), label: '' }).label).toBeTruthy();
+        });
+
+        test('a mapping target is required', () => {
+            expect(validateAuthoredAttribute(baseAttr()).mappingFieldType).toBeTruthy();
         });
 
         test('RDN requires a code', () => {
-            expect(isAuthoredAttributeMappingValid({ ...baseAttr(), mappingFieldType: FieldType.Rdn })).toBe(false);
-            expect(isAuthoredAttributeMappingValid({ ...baseAttr(), mappingFieldType: FieldType.Rdn, mappingRdnCode: 'CN' })).toBe(true);
+            expect(validateAuthoredAttribute({ ...mappedAttr(), mappingRdnCode: '' }).mappingRdnCode).toBeTruthy();
+            expect(validateAuthoredAttribute(mappedAttr()).mappingRdnCode).toBeUndefined();
         });
 
         test('SAN requires a generalNameType, and OTHER_NAME requires oid + encoding', () => {
-            expect(isAuthoredAttributeMappingValid({ ...baseAttr(), mappingFieldType: FieldType.San })).toBe(false);
+            const san = { ...mappedAttr(), mappingFieldType: FieldType.San, mappingRdnCode: '' };
+            expect(validateAuthoredAttribute(san).mappingGeneralNameType).toBeTruthy();
+            expect(validateAuthoredAttribute({ ...san, mappingGeneralNameType: GeneralNameType.Dns })).toEqual({});
+
+            const otherName = { ...san, mappingGeneralNameType: GeneralNameType.OtherName, mappingOtherNameOid: '1.2.3' };
+            expect(validateAuthoredAttribute(otherName).mappingOtherNameEncoding).toBeTruthy();
+            expect(validateAuthoredAttribute({ ...otherName, mappingOtherNameEncoding: ExtensionValueEncoding.Utf8String })).toEqual({});
             expect(
-                isAuthoredAttributeMappingValid({
-                    ...baseAttr(),
-                    mappingFieldType: FieldType.San,
-                    mappingGeneralNameType: GeneralNameType.Dns,
-                }),
-            ).toBe(true);
-            expect(
-                isAuthoredAttributeMappingValid({
-                    ...baseAttr(),
-                    mappingFieldType: FieldType.San,
-                    mappingGeneralNameType: GeneralNameType.OtherName,
-                    mappingOtherNameOid: '1.2.3',
-                }),
-            ).toBe(false);
-            expect(
-                isAuthoredAttributeMappingValid({
-                    ...baseAttr(),
-                    mappingFieldType: FieldType.San,
-                    mappingGeneralNameType: GeneralNameType.OtherName,
-                    mappingOtherNameOid: '1.2.3',
+                validateAuthoredAttribute({
+                    ...otherName,
+                    mappingOtherNameOid: '',
                     mappingOtherNameEncoding: ExtensionValueEncoding.Utf8String,
-                }),
-            ).toBe(true);
+                }).mappingOtherNameOid,
+            ).toBeTruthy();
         });
 
         test('EXTENSION requires an OID', () => {
-            expect(isAuthoredAttributeMappingValid({ ...baseAttr(), mappingFieldType: FieldType.Extension })).toBe(false);
+            const ext = { ...mappedAttr(), mappingFieldType: FieldType.Extension, mappingRdnCode: '' };
+            expect(validateAuthoredAttribute(ext).mappingExtensionOid).toBeTruthy();
+            expect(validateAuthoredAttribute({ ...ext, mappingExtensionOid: '2.5.29.17' })).toEqual({});
+        });
+
+        test('a mapped attribute is restricted to String or Text', () => {
+            expect(isContentTypeAllowedForMapping(AttributeContentType.String)).toBe(true);
+            expect(isContentTypeAllowedForMapping(AttributeContentType.Text)).toBe(true);
+            expect(isContentTypeAllowedForMapping(AttributeContentType.Integer)).toBe(false);
+
+            expect(validateAuthoredAttribute({ ...mappedAttr(), contentType: AttributeContentType.Text }).contentType).toBeUndefined();
+            expect(validateAuthoredAttribute({ ...mappedAttr(), contentType: AttributeContentType.Integer }).contentType).toBeTruthy();
+        });
+
+        test('the content-type restriction only applies to mapped attributes', () => {
+            const errors = validateAuthoredAttribute({ ...baseAttr(), contentType: AttributeContentType.Integer });
+            expect(errors.contentType).toBeUndefined();
+            expect(errors.mappingFieldType).toBeTruthy();
+        });
+
+        test('Read Only requires a non-blank default value', () => {
+            expect(validateAuthoredAttribute({ ...mappedAttr(), readOnly: true }).readOnly).toBeTruthy();
+            expect(validateAuthoredAttribute({ ...mappedAttr(), readOnly: true, defaultValue: '   ' }).readOnly).toBeTruthy();
+            expect(validateAuthoredAttribute({ ...mappedAttr(), readOnly: true, defaultValue: 'acme.example.com' })).toEqual({});
+        });
+
+        test('Read Only cannot be combined with a list', () => {
+            expect(validateAuthoredAttribute({ ...mappedAttr(), readOnly: true, defaultValue: 'x', list: true }).readOnly).toBeTruthy();
+            // A static list is a list even when the toggle itself is off.
             expect(
-                isAuthoredAttributeMappingValid({ ...baseAttr(), mappingFieldType: FieldType.Extension, mappingExtensionOid: '2.5.29.17' }),
-            ).toBe(true);
-        });
-
-        test('isAuthoredAttributeValid also requires name and label', () => {
-            expect(isAuthoredAttributeValid({ ...baseAttr(), name: '', label: 'X' })).toBe(false);
-            expect(isAuthoredAttributeValid({ ...baseAttr(), name: 'x', label: '' })).toBe(false);
-            expect(isAuthoredAttributeValid(baseAttr())).toBe(true);
-        });
-
-        test('STATIC_LIST requires at least one value', () => {
-            expect(isAuthoredAttributeValid({ ...baseAttr(), valueSourceType: ValueSourceType.StaticList, staticValues: [] })).toBe(false);
-            expect(isAuthoredAttributeValid({ ...baseAttr(), valueSourceType: ValueSourceType.StaticList, staticValues: ['prod'] })).toBe(
-                true,
-            );
-        });
-
-        test('STATIC_LIST rejects blank string values', () => {
-            expect(isAuthoredAttributeValid({ ...baseAttr(), valueSourceType: ValueSourceType.StaticList, staticValues: ['  '] })).toBe(
-                false,
-            );
-        });
-
-        test('STATIC_LIST rejects duplicate values', () => {
-            expect(
-                isAuthoredAttributeValid({
-                    ...baseAttr(),
+                validateAuthoredAttribute({
+                    ...mappedAttr(),
+                    readOnly: true,
+                    defaultValue: 'x',
                     valueSourceType: ValueSourceType.StaticList,
-                    staticValues: ['prod', 'prod'],
-                }),
-            ).toBe(false);
+                    staticValues: ['prod'],
+                }).readOnly,
+            ).toBeTruthy();
+        });
+
+        test('Multi select requires a list', () => {
+            expect(validateAuthoredAttribute({ ...mappedAttr(), multiSelect: true }).multiSelect).toBeTruthy();
+            expect(validateAuthoredAttribute({ ...mappedAttr(), multiSelect: true, list: true })).toEqual({});
+        });
+
+        test('a default value must conform to the declared content type', () => {
+            const unmappedInteger = { ...baseAttr(), contentType: AttributeContentType.Integer };
+            expect(validateAuthoredAttribute({ ...unmappedInteger, defaultValue: '12' }).defaultValue).toBeUndefined();
+            expect(validateAuthoredAttribute({ ...unmappedInteger, defaultValue: 'twelve' }).defaultValue).toBeTruthy();
+        });
+
+        test('STATIC_LIST requires at least one non-blank, unique, well-typed value', () => {
+            const staticList = (staticValues: (string | number | boolean)[]) => ({
+                ...mappedAttr(),
+                valueSourceType: ValueSourceType.StaticList,
+                staticValues,
+            });
+            expect(validateAuthoredAttribute(staticList([])).staticValues).toBeTruthy();
+            expect(validateAuthoredAttribute(staticList(['  '])).staticValues).toBeTruthy();
+            expect(validateAuthoredAttribute(staticList(['prod', 'prod'])).staticValues).toBeTruthy();
+            expect(validateAuthoredAttribute(staticList(['prod', 'staging']))).toEqual({});
             expect(
-                isAuthoredAttributeValid({
+                validateAuthoredAttribute({
                     ...baseAttr(),
+                    contentType: AttributeContentType.Integer,
                     valueSourceType: ValueSourceType.StaticList,
-                    staticValues: ['prod', 'staging'],
-                }),
-            ).toBe(true);
+                    staticValues: ['1', 'two'],
+                }).staticValues,
+            ).toBeTruthy();
         });
     });
 

--- a/src/utils/requestAttributeAuthoring.spec.ts
+++ b/src/utils/requestAttributeAuthoring.spec.ts
@@ -370,10 +370,20 @@ describe('requestAttributeAuthoring', () => {
             expect(isValueValidForContentType('abc', AttributeContentType.Float)).toBe(false);
         });
 
-        test('boolean accepts only booleans and their literal spellings', () => {
+        test('boolean accepts only booleans and their literal spellings, in any case', () => {
             expect(isValueValidForContentType(true, AttributeContentType.Boolean)).toBe(true);
             expect(isValueValidForContentType('false', AttributeContentType.Boolean)).toBe(true);
             expect(isValueValidForContentType('yes', AttributeContentType.Boolean)).toBe(false);
+
+            // Persisting lowercases before comparing, so validation must not be stricter than that.
+            expect(isValueValidForContentType('TRUE', AttributeContentType.Boolean)).toBe(true);
+            const dto = buildAuthoredAttributeDto({
+                ...baseAttr(),
+                contentType: AttributeContentType.Boolean,
+                valueSourceType: ValueSourceType.StaticList,
+                staticValues: ['TRUE'],
+            });
+            expect(dto.content).toEqual([{ data: true, contentType: AttributeContentType.Boolean }]);
         });
 
         test('date / time / datetime are format-checked', () => {

--- a/src/utils/requestAttributeAuthoring.ts
+++ b/src/utils/requestAttributeAuthoring.ts
@@ -405,7 +405,7 @@ export function hasDuplicateStaticValues(values: (string | number | boolean)[]):
     return false;
 }
 
-const BOOLEAN_LITERALS = ['true', 'false'];
+const BOOLEAN_LITERALS = new Set(['true', 'false']);
 
 /** Blank counts as "no value" (left to the required-ness rules); otherwise guards `normalizeStaticContentValue`, which turns `"abc"` into `0`. */
 export function isValueValidForContentType(value: string | number | boolean, contentType: AttributeContentType): boolean {
@@ -417,10 +417,10 @@ export function isValueValidForContentType(value: string | number | boolean, con
         case AttributeContentType.Integer:
             return typeof raw === 'number' ? Number.isInteger(raw) : /^[+-]?\d+$/.test(String(raw));
         case AttributeContentType.Float:
-            return typeof raw === 'number' ? Number.isFinite(raw) : /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(String(raw));
+            return typeof raw === 'number' ? Number.isFinite(raw) : /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/.test(String(raw));
         case AttributeContentType.Boolean:
             // Case-insensitive to match normalizeStaticContentValue, which lowercases before comparing.
-            return typeof raw === 'boolean' || BOOLEAN_LITERALS.includes(String(raw).toLowerCase());
+            return typeof raw === 'boolean' || BOOLEAN_LITERALS.has(String(raw).toLowerCase());
         case AttributeContentType.Date:
             return /^\d{4}-\d{2}-\d{2}$/.test(String(raw)) && !Number.isNaN(Date.parse(`${raw}T00:00:00`));
         case AttributeContentType.Time:
@@ -449,49 +449,51 @@ export interface AuthoredAttributeErrors {
     staticValues?: string;
 }
 
-/** The rules Core enforces on a definition, applied client-side so the dialog can flag them per field. */
-export function validateAuthoredAttribute(form: AuthoredAttributeFormValues): AuthoredAttributeErrors {
+function validateSanMapping(form: AuthoredAttributeFormValues): AuthoredAttributeErrors {
+    if (!form.mappingGeneralNameType) {
+        return { mappingGeneralNameType: 'Select the SAN type this attribute maps to.' };
+    }
+    if (form.mappingGeneralNameType !== GeneralNameType.OtherName) {
+        return {};
+    }
     const errors: AuthoredAttributeErrors = {};
-
-    if (!form.name.trim()) {
-        errors.name = 'Name is required.';
+    if (!form.mappingOtherNameOid?.trim()) {
+        errors.mappingOtherNameOid = 'An otherName OID is required.';
     }
-    if (!form.label.trim()) {
-        errors.label = 'Label is required.';
+    if (!form.mappingOtherNameEncoding) {
+        errors.mappingOtherNameEncoding = 'An otherName value encoding is required.';
     }
+    return errors;
+}
 
-    if (form.mappingFieldType) {
-        if (!isContentTypeAllowedForMapping(form.contentType)) {
-            errors.contentType = 'A mapped request attribute must use content type String or Text.';
-        }
-        switch (form.mappingFieldType) {
-            case FieldType.Rdn:
-                if (!form.mappingRdnCode?.trim()) {
-                    errors.mappingRdnCode = 'Select the RDN this attribute maps to.';
-                }
-                break;
-            case FieldType.San:
-                if (!form.mappingGeneralNameType) {
-                    errors.mappingGeneralNameType = 'Select the SAN type this attribute maps to.';
-                } else if (form.mappingGeneralNameType === GeneralNameType.OtherName) {
-                    if (!form.mappingOtherNameOid?.trim()) {
-                        errors.mappingOtherNameOid = 'An otherName OID is required.';
-                    }
-                    if (!form.mappingOtherNameEncoding) {
-                        errors.mappingOtherNameEncoding = 'An otherName value encoding is required.';
-                    }
-                }
-                break;
-            case FieldType.Extension:
-                if (!form.mappingExtensionOid?.trim()) {
-                    errors.mappingExtensionOid = 'Select the certificate extension this attribute maps to.';
-                }
-                break;
-        }
-    } else {
-        errors.mappingFieldType = 'A mapping target is required — pick where this attribute lands in the certificate.';
+function validateMapping(form: AuthoredAttributeFormValues): AuthoredAttributeErrors {
+    if (!form.mappingFieldType) {
+        return { mappingFieldType: 'A mapping target is required — pick where this attribute lands in the certificate.' };
     }
+    const errors: AuthoredAttributeErrors = {};
+    if (!isContentTypeAllowedForMapping(form.contentType)) {
+        errors.contentType = 'A mapped request attribute must use content type String or Text.';
+    }
+    switch (form.mappingFieldType) {
+        case FieldType.Rdn:
+            if (!form.mappingRdnCode?.trim()) {
+                errors.mappingRdnCode = 'Select the RDN this attribute maps to.';
+            }
+            break;
+        case FieldType.San:
+            Object.assign(errors, validateSanMapping(form));
+            break;
+        case FieldType.Extension:
+            if (!form.mappingExtensionOid?.trim()) {
+                errors.mappingExtensionOid = 'Select the certificate extension this attribute maps to.';
+            }
+            break;
+    }
+    return errors;
+}
 
+function validateProperties(form: AuthoredAttributeFormValues): AuthoredAttributeErrors {
+    const errors: AuthoredAttributeErrors = {};
     const isList = form.list || form.valueSourceType === ValueSourceType.StaticList;
     if (form.readOnly) {
         if (isList) {
@@ -503,30 +505,59 @@ export function validateAuthoredAttribute(form: AuthoredAttributeFormValues): Au
     if (form.multiSelect && !isList) {
         errors.multiSelect = 'Multi select requires a list.';
     }
-
-    const { defaultValue } = form;
-    if (
-        form.valueSourceType === ValueSourceType.None &&
-        defaultValue !== undefined &&
-        hasFreeInputDefault(form) &&
-        !isValueValidForContentType(defaultValue, form.contentType)
-    ) {
-        errors.defaultValue = `The default value is not a valid ${form.contentType} value.`;
-    }
-
-    if (form.valueSourceType === ValueSourceType.StaticList) {
-        if (form.staticValues.length === 0) {
-            errors.staticValues = 'Add at least one value for the static list.';
-        } else if (form.staticValues.some((v) => typeof v === 'string' && v.trim() === '')) {
-            errors.staticValues = 'Static list values cannot be blank.';
-        } else if (hasDuplicateStaticValues(form.staticValues)) {
-            errors.staticValues = 'Static list values must be unique.';
-        } else if (form.staticValues.some((v) => !isValueValidForContentType(v, form.contentType))) {
-            errors.staticValues = `Every static list value must be a valid ${form.contentType} value.`;
-        }
-    }
-
     return errors;
+}
+
+function validateDefaultValue(form: AuthoredAttributeFormValues): AuthoredAttributeErrors {
+    const { defaultValue } = form;
+    if (form.valueSourceType !== ValueSourceType.None || defaultValue === undefined || !hasFreeInputDefault(form)) {
+        return {};
+    }
+    if (isValueValidForContentType(defaultValue, form.contentType)) {
+        return {};
+    }
+    return { defaultValue: `The default value is not a valid ${form.contentType} value.` };
+}
+
+function validateStaticList(form: AuthoredAttributeFormValues): AuthoredAttributeErrors {
+    if (form.valueSourceType !== ValueSourceType.StaticList) {
+        return {};
+    }
+    const { staticValues, contentType } = form;
+    if (staticValues.length === 0) {
+        return { staticValues: 'Add at least one value for the static list.' };
+    }
+    if (staticValues.some((v) => typeof v === 'string' && v.trim() === '')) {
+        return { staticValues: 'Static list values cannot be blank.' };
+    }
+    if (hasDuplicateStaticValues(staticValues)) {
+        return { staticValues: 'Static list values must be unique.' };
+    }
+    if (staticValues.some((v) => !isValueValidForContentType(v, contentType))) {
+        return { staticValues: `Every static list value must be a valid ${contentType} value.` };
+    }
+    return {};
+}
+
+/**
+ * The rules Core enforces on a definition, applied client-side so the dialog can flag them per field.
+ * Spread order fixes the key order, which the attribute list relies on to show the first message.
+ */
+export function validateAuthoredAttribute(form: AuthoredAttributeFormValues): AuthoredAttributeErrors {
+    const identity: AuthoredAttributeErrors = {};
+    if (!form.name.trim()) {
+        identity.name = 'Name is required.';
+    }
+    if (!form.label.trim()) {
+        identity.label = 'Label is required.';
+    }
+    return {
+        ...identity,
+        ...validateMapping(form),
+        ...validateProperties(form),
+        ...validateDefaultValue(form),
+        ...validateStaticList(form),
+    };
 }
 
 export function isValueSourceBindingValid(form: ValueSourceBindingFormValues): boolean {

--- a/src/utils/requestAttributeAuthoring.ts
+++ b/src/utils/requestAttributeAuthoring.ts
@@ -405,6 +405,8 @@ export function hasDuplicateStaticValues(values: (string | number | boolean)[]):
     return false;
 }
 
+const BOOLEAN_LITERALS = ['true', 'false'];
+
 /** Blank counts as "no value" (left to the required-ness rules); otherwise guards `normalizeStaticContentValue`, which turns `"abc"` into `0`. */
 export function isValueValidForContentType(value: string | number | boolean, contentType: AttributeContentType): boolean {
     if (typeof value === 'string' && value.trim() === '') {
@@ -417,7 +419,8 @@ export function isValueValidForContentType(value: string | number | boolean, con
         case AttributeContentType.Float:
             return typeof raw === 'number' ? Number.isFinite(raw) : /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(String(raw));
         case AttributeContentType.Boolean:
-            return typeof raw === 'boolean' || raw === 'true' || raw === 'false';
+            // Case-insensitive to match normalizeStaticContentValue, which lowercases before comparing.
+            return typeof raw === 'boolean' || BOOLEAN_LITERALS.includes(String(raw).toLowerCase());
         case AttributeContentType.Date:
             return /^\d{4}-\d{2}-\d{2}$/.test(String(raw)) && !Number.isNaN(Date.parse(`${raw}T00:00:00`));
         case AttributeContentType.Time:

--- a/src/utils/requestAttributeAuthoring.ts
+++ b/src/utils/requestAttributeAuthoring.ts
@@ -137,6 +137,13 @@ export function isStaticListSupportedForContentType(contentType: AttributeConten
     return STATIC_LIST_CONTENT_TYPES.includes(contentType);
 }
 
+/** Core renders a mapped request attribute into its X.509 field as text, so only these can be mapped. */
+export const MAPPED_CONTENT_TYPES: readonly AttributeContentType[] = [AttributeContentType.String, AttributeContentType.Text];
+
+export function isContentTypeAllowedForMapping(contentType: AttributeContentType): boolean {
+    return MAPPED_CONTENT_TYPES.includes(contentType);
+}
+
 function generateUuid(): string {
     // crypto.randomUUID is available in all supported browsers and the test env; using it
     // (never Math.random) keeps the generated identifier cryptographically sound.
@@ -380,29 +387,6 @@ export function parseAuthoredAttributeDto(dto: BaseAttributeDto): AuthoredAttrib
     };
 }
 
-/**
- * A mapped attribute must carry its target identifier: RDN code, SAN general-name-type
- * (+ otherName OID/encoding when OTHER_NAME), or extension OID. Unmapped attributes are valid.
- */
-export function isAuthoredAttributeMappingValid(form: AuthoredAttributeFormValues): boolean {
-    switch (form.mappingFieldType) {
-        case FieldType.Rdn:
-            return !!form.mappingRdnCode?.trim();
-        case FieldType.San:
-            if (!form.mappingGeneralNameType) {
-                return false;
-            }
-            if (form.mappingGeneralNameType === GeneralNameType.OtherName) {
-                return !!form.mappingOtherNameOid?.trim() && !!form.mappingOtherNameEncoding;
-            }
-            return true;
-        case FieldType.Extension:
-            return !!form.mappingExtensionOid?.trim();
-        default:
-            return true;
-    }
-}
-
 /** Normalize a static value for equality comparison — strings compared trimmed, others by value. */
 function normalizeStaticValue(v: string | number | boolean): string {
     return typeof v === 'string' ? v.trim() : String(v);
@@ -421,23 +405,125 @@ export function hasDuplicateStaticValues(values: (string | number | boolean)[]):
     return false;
 }
 
-/**
- * A STATIC_LIST source needs at least one option, no option may be a blank string, and the
- * options must be unique.
- */
-export function isStaticListValid(form: AuthoredAttributeFormValues): boolean {
-    if (form.valueSourceType !== ValueSourceType.StaticList) {
+/** Blank counts as "no value" (left to the required-ness rules); otherwise guards `normalizeStaticContentValue`, which turns `"abc"` into `0`. */
+export function isValueValidForContentType(value: string | number | boolean, contentType: AttributeContentType): boolean {
+    if (typeof value === 'string' && value.trim() === '') {
         return true;
     }
-    return (
-        form.staticValues.length > 0 &&
-        form.staticValues.every((v) => typeof v !== 'string' || v.trim() !== '') &&
-        !hasDuplicateStaticValues(form.staticValues)
-    );
+    const raw = typeof value === 'string' ? value.trim() : value;
+    switch (contentType) {
+        case AttributeContentType.Integer:
+            return typeof raw === 'number' ? Number.isInteger(raw) : /^[+-]?\d+$/.test(String(raw));
+        case AttributeContentType.Float:
+            return typeof raw === 'number' ? Number.isFinite(raw) : /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(String(raw));
+        case AttributeContentType.Boolean:
+            return typeof raw === 'boolean' || raw === 'true' || raw === 'false';
+        case AttributeContentType.Date:
+            return /^\d{4}-\d{2}-\d{2}$/.test(String(raw)) && !Number.isNaN(Date.parse(`${raw}T00:00:00`));
+        case AttributeContentType.Time:
+            return /^\d{2}:\d{2}(:\d{2})?$/.test(String(raw));
+        case AttributeContentType.Datetime:
+            return !Number.isNaN(Date.parse(String(raw)));
+        default:
+            return true;
+    }
 }
 
-export function isAuthoredAttributeValid(form: AuthoredAttributeFormValues): boolean {
-    return !!form.name.trim() && !!form.label.trim() && isAuthoredAttributeMappingValid(form) && isStaticListValid(form);
+/** Empty object means the definition is valid. */
+export interface AuthoredAttributeErrors {
+    name?: string;
+    label?: string;
+    contentType?: string;
+    mappingFieldType?: string;
+    mappingRdnCode?: string;
+    mappingGeneralNameType?: string;
+    mappingOtherNameOid?: string;
+    mappingOtherNameEncoding?: string;
+    mappingExtensionOid?: string;
+    readOnly?: string;
+    multiSelect?: string;
+    defaultValue?: string;
+    staticValues?: string;
+}
+
+/** The rules Core enforces on a definition, applied client-side so the dialog can flag them per field. */
+export function validateAuthoredAttribute(form: AuthoredAttributeFormValues): AuthoredAttributeErrors {
+    const errors: AuthoredAttributeErrors = {};
+
+    if (!form.name.trim()) {
+        errors.name = 'Name is required.';
+    }
+    if (!form.label.trim()) {
+        errors.label = 'Label is required.';
+    }
+
+    if (form.mappingFieldType) {
+        if (!isContentTypeAllowedForMapping(form.contentType)) {
+            errors.contentType = 'A mapped request attribute must use content type String or Text.';
+        }
+        switch (form.mappingFieldType) {
+            case FieldType.Rdn:
+                if (!form.mappingRdnCode?.trim()) {
+                    errors.mappingRdnCode = 'Select the RDN this attribute maps to.';
+                }
+                break;
+            case FieldType.San:
+                if (!form.mappingGeneralNameType) {
+                    errors.mappingGeneralNameType = 'Select the SAN type this attribute maps to.';
+                } else if (form.mappingGeneralNameType === GeneralNameType.OtherName) {
+                    if (!form.mappingOtherNameOid?.trim()) {
+                        errors.mappingOtherNameOid = 'An otherName OID is required.';
+                    }
+                    if (!form.mappingOtherNameEncoding) {
+                        errors.mappingOtherNameEncoding = 'An otherName value encoding is required.';
+                    }
+                }
+                break;
+            case FieldType.Extension:
+                if (!form.mappingExtensionOid?.trim()) {
+                    errors.mappingExtensionOid = 'Select the certificate extension this attribute maps to.';
+                }
+                break;
+        }
+    } else {
+        errors.mappingFieldType = 'A mapping target is required — pick where this attribute lands in the certificate.';
+    }
+
+    const isList = form.list || form.valueSourceType === ValueSourceType.StaticList;
+    if (form.readOnly) {
+        if (isList) {
+            errors.readOnly = 'Read Only cannot be combined with a list.';
+        } else if (!hasFreeInputDefault(form)) {
+            errors.readOnly = 'Read Only requires a default value — the requester cannot supply one.';
+        }
+    }
+    if (form.multiSelect && !isList) {
+        errors.multiSelect = 'Multi select requires a list.';
+    }
+
+    const { defaultValue } = form;
+    if (
+        form.valueSourceType === ValueSourceType.None &&
+        defaultValue !== undefined &&
+        hasFreeInputDefault(form) &&
+        !isValueValidForContentType(defaultValue, form.contentType)
+    ) {
+        errors.defaultValue = `The default value is not a valid ${form.contentType} value.`;
+    }
+
+    if (form.valueSourceType === ValueSourceType.StaticList) {
+        if (form.staticValues.length === 0) {
+            errors.staticValues = 'Add at least one value for the static list.';
+        } else if (form.staticValues.some((v) => typeof v === 'string' && v.trim() === '')) {
+            errors.staticValues = 'Static list values cannot be blank.';
+        } else if (hasDuplicateStaticValues(form.staticValues)) {
+            errors.staticValues = 'Static list values must be unique.';
+        } else if (form.staticValues.some((v) => !isValueValidForContentType(v, form.contentType))) {
+            errors.staticValues = `Every static list value must be a valid ${form.contentType} value.`;
+        }
+    }
+
+    return errors;
 }
 
 export function isValueSourceBindingValid(form: ValueSourceBindingFormValues): boolean {


### PR DESCRIPTION
Fixes #1919 