### PR TITLE
Toggle the internal notification switch through its visible track in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "test:vitest:ui": "vitest --ui",
         "test:vitest:watch": "vitest",
         "test:vitest:cov": "vitest run --coverage",
-        "test:playwright": "playwright test -c playwright-ct.config.ts",
+        "test:playwright": "rm -rf playwright/.cache && playwright test -c playwright-ct.config.ts",
         "test:chromium": "playwright test -c playwright-ct.config.ts --project=chromium && node scripts/clean-lcov.js",
         "test:firefox": "playwright test -c playwright-ct.config.ts --project=firefox",
         "test:webkit": "playwright test -c playwright-ct.config.ts --project=webkit",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "test:vitest:ui": "vitest --ui",
         "test:vitest:watch": "vitest",
         "test:vitest:cov": "vitest run --coverage",
-        "test:playwright": "rm -rf playwright/.cache && playwright test -c playwright-ct.config.ts",
+        "test:playwright": "node -e \"require('fs').rmSync('playwright/.cache',{recursive:true,force:true})\" && playwright test -c playwright-ct.config.ts",
         "test:chromium": "playwright test -c playwright-ct.config.ts --project=chromium && node scripts/clean-lcov.js",
         "test:firefox": "playwright test -c playwright-ct.config.ts --project=firefox",
         "test:webkit": "playwright test -c playwright-ct.config.ts --project=webkit",

--- a/src/components/_pages/notifications/notification-profiles/form/index.spec.tsx
+++ b/src/components/_pages/notifications/notification-profiles/form/index.spec.tsx
@@ -44,7 +44,7 @@ test.describe('NotificationProfileForm - Object recipient type', () => {
         await page.getByTestId('select-recipientType-trigger').click();
         await page.getByRole('option', { name: 'User', exact: true }).click();
         const switchEl = page.locator('#internalNotification');
-        await page.getByTestId('switch-internalNotification').locator('label[for="internalNotification"]').last().click();
+        await page.locator('label:has(#internalNotification)').click();
         await expect(switchEl).toBeChecked();
 
         // Switch to Object — must be off and disabled

--- a/src/components/_pages/notifications/notification-profiles/form/index.spec.tsx
+++ b/src/components/_pages/notifications/notification-profiles/form/index.spec.tsx
@@ -39,11 +39,12 @@ test.describe('NotificationProfileForm - Object recipient type', () => {
     test('Object resets internal notifications to off', async ({ mount, page }) => {
         await mount(<NotificationProfileFormTestWrapper />);
 
-        // Enable internal notifications via the visually hidden checkbox (sr-only).
+        // Enable internal notifications through the visible switch track: the input itself is
+        // visually hidden (sr-only), and force-clicking it does not toggle on Firefox and WebKit.
         await page.getByTestId('select-recipientType-trigger').click();
         await page.getByRole('option', { name: 'User', exact: true }).click();
         const switchEl = page.locator('#internalNotification');
-        await switchEl.check({ force: true });
+        await page.getByTestId('switch-internalNotification').locator('label[for="internalNotification"]').last().click();
         await expect(switchEl).toBeChecked();
 
         // Switch to Object — must be off and disabled


### PR DESCRIPTION
Fixes a browser-specific component test failure: the notification profile form's internal-notification switch input is visually hidden (`sr-only`), and force-clicking it does not change its state on Firefox and WebKit, so `Object resets internal notifications to off` failed on those browsers. The test now clicks the visible label track like a user would.

Also clears the Playwright cache before component test runs — a stale `playwright/.cache` can reference modules from other branches and break the whole suite at build time.